### PR TITLE
H2 rake methods

### DIFF
--- a/lib/arjdbc/hsqldb/adapter.rb
+++ b/lib/arjdbc/hsqldb/adapter.rb
@@ -167,5 +167,19 @@ module ::ArJdbc
     def remove_index(table_name, options = {})
       execute "DROP INDEX #{quote_column_name(index_name(table_name, options))}"
     end
+
+    def recreate_database(name)
+      drop_database(name)
+    end
+    
+    # do nothing since database gets created upon connection. However
+    # this method gets called by rails db rake tasks so now we're
+    # avoiding method_missing error
+    def create_database(name)
+    end
+
+    def drop_database(name)
+      execute("DROP ALL OBJECTS")
+    end    
   end
 end


### PR DESCRIPTION
Current h2/hsql adapter blows up when running Rails rake tasks like:

rake:db:create
rake:db:drop
...etc

This branch adds appropriate methods to the hsql/h2 adapter (similar to the postgres adapter).
