### PR TITLE
Invalid schema.rb generation, appending limit to MySQL date columns

### DIFF
--- a/lib/arjdbc/mysql/adapter.rb
+++ b/lib/arjdbc/mysql/adapter.rb
@@ -58,7 +58,7 @@ module ::ArJdbc
         when /^mediumint/i; 3
         when /^smallint/i;  2
         when /^tinyint/i;   1
-        when /^(datetime|timestamp)/
+        when /^(datetime|timestamp|date)/
           nil
         else
           super


### PR DESCRIPTION
Added 'date' column to existing 'datetime' and 'timestamp' entries in a case statement that returns column limit. Existing implementation was returning all 'date' columns as having :limit => 10, leading to incorrect SQL when trying to re-build a test database from schema.rb.

For example, the following migration:

```
 create_table :payments do |t|
   t.date :duedate
 end
```

Would generate the following schema.rb entry after being executed:

```
create_table "payments", :force => true do |t|
  t.date     "duedate", :limit => 10
end
```

And end up throwing the following error each time 

```
ActiveRecord::JDBCError: You have an error in your SQL syntax; check the manual that corresponds to your  MySQL server version for the right syntax to use near '(10)' at line 1: CREATE TABLE `payments` (`id` int(11) DEFAULT NULL auto_increment PRIMARY KEY, `duedate` date(10)) ENGINE=InnoDB CHARACTER SET `utf8`
```
