### PR TITLE
Fix for adapter adding limits to date fields.

### DIFF
--- a/lib/arjdbc/mysql/adapter.rb
+++ b/lib/arjdbc/mysql/adapter.rb
@@ -58,7 +58,7 @@ module ::ArJdbc
         when /^mediumint/i; 3
         when /^smallint/i;  2
         when /^tinyint/i;   1
-        when /^(datetime|timestamp)/
+        when /^(datetime|date|timestamp)/
           nil
         else
           super

--- a/test/mysql_info_test.rb
+++ b/test/mysql_info_test.rb
@@ -12,6 +12,7 @@ class DBSetup < ActiveRecord::Migration
 
     create_table :cars, :primary_key => 'legacy_id' do |t|
       t.string :name
+      t.date :production_started_on
     end
 
     create_table :cats, :id => false do |t|
@@ -79,6 +80,13 @@ class MysqlInfoTest < Test::Unit::TestCase
     ActiveRecord::SchemaDumper::dump(@connection, strio)
     dump = strio.string
     dump.grep(/datetime/).each {|line| assert line !~ /limit/ }
+  end
+  
+  def test_schema_dump_should_not_have_limits_on_date
+    strio = StringIO.new
+    ActiveRecord::SchemaDumper::dump(@connection, strio)
+    dump = strio.string
+    dump.grep(/date/).each {|line| assert line !~ /limit/ }
   end
 
   def test_should_include_limit


### PR DESCRIPTION
Currently v1.0.2 is adding limits to dates e.g.

t.date     "abstract_deadline",      :limit => 10

This results in an sql error when the schema is passed into the database. It should be

t.date     "abstract_deadline"
