### PR TITLE
Fix for rake db:create

### DIFF
--- a/lib/arjdbc/jdbc/jdbc.rake
+++ b/lib/arjdbc/jdbc/jdbc.rake
@@ -74,7 +74,7 @@ namespace :db do
       ActiveRecord::Base.connection
     rescue
       begin
-        if url = config['url'] && url =~ /^(.*(?<!\/)\/)(?=\w)/
+        if url = config['url'] and url =~ /^(.*(?<!\/)\/)(?=\w)/
           url = $1
         end
 


### PR DESCRIPTION
rake db:create fails (at least when using the url + driver class method described in the README), complaining about the url and/or driver class missing.

This commit fixes that.
