### PR TITLE
Fix for a bug when using JNDI with DB2 hosted in Tomcat

### DIFF
--- a/lib/arjdbc/db2/adapter.rb
+++ b/lib/arjdbc/db2/adapter.rb
@@ -5,6 +5,10 @@ module ArJdbc
         lambda { |cfg, column| column.extend(::ArJdbc::DB2::Column) } ]
     end
 
+    def self.jdbc_connection_class
+      ::ActiveRecord::ConnectionAdapters::DB2JdbcConnection
+    end
+
     module Column
       def type_cast(value)
         return nil if value.nil? || value =~ /^\s*null\s*$/i

--- a/src/java/arjdbc/db2/DB2RubyJdbcConnection.java
+++ b/src/java/arjdbc/db2/DB2RubyJdbcConnection.java
@@ -1,0 +1,62 @@
+/*
+ **** BEGIN LICENSE BLOCK *****
+ * Copyright (c) 2006-2010 Nick Sieger <nick@nicksieger.com>
+ * Copyright (c) 2006-2007 Ola Bini <ola.bini@gmail.com>
+ * Copyright (c) 2008-2009 Thomas E Enebo <enebo@acm.org>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ ***** END LICENSE BLOCK *****/
+package arjdbc.db2;
+
+import org.jruby.Ruby;
+import org.jruby.RubyClass;
+import org.jruby.runtime.ObjectAllocator;
+import org.jruby.runtime.builtin.IRubyObject;
+
+import arjdbc.jdbc.RubyJdbcConnection;
+
+/**
+ *
+ * @author mikestone
+ */
+public class DB2RubyJdbcConnection extends RubyJdbcConnection {
+    protected DB2RubyJdbcConnection(Ruby runtime, RubyClass metaClass) {
+        super(runtime, metaClass);
+    }
+
+    @Override
+    protected boolean databaseSupportsSchemas() {
+        return true;
+    }
+
+    public static RubyClass createDB2JdbcConnectionClass(Ruby runtime, RubyClass jdbcConnection) {
+        RubyClass clazz = RubyJdbcConnection.getConnectionAdapters(runtime).defineClassUnder("DB2JdbcConnection",
+                jdbcConnection, DB2_JDBCCONNECTION_ALLOCATOR);
+        clazz.defineAnnotatedMethods(DB2RubyJdbcConnection.class);
+
+        return clazz;
+    }
+
+    private static ObjectAllocator DB2_JDBCCONNECTION_ALLOCATOR = new ObjectAllocator() {
+        public IRubyObject allocate(Ruby runtime, RubyClass klass) {
+            return new DB2RubyJdbcConnection(runtime, klass);
+        }
+    };
+}

--- a/src/java/arjdbc/jdbc/AdapterJavaService.java
+++ b/src/java/arjdbc/jdbc/AdapterJavaService.java
@@ -28,6 +28,7 @@ package arjdbc.jdbc;
 
 import java.io.IOException;
 
+import arjdbc.db2.DB2RubyJdbcConnection;
 import arjdbc.derby.DerbyModule;
 import arjdbc.h2.H2RubyJdbcConnection;
 import arjdbc.informix.InformixRubyJdbcConnection;
@@ -57,6 +58,7 @@ public class AdapterJavaService implements BasicLibraryService {
         Sqlite3RubyJdbcConnection.createSqlite3JdbcConnectionClass(runtime, jdbcConnection);
         H2RubyJdbcConnection.createH2JdbcConnectionClass(runtime, jdbcConnection);
         MySQLRubyJdbcConnection.createMySQLJdbcConnectionClass(runtime, jdbcConnection);
+        DB2RubyJdbcConnection.createDB2JdbcConnectionClass(runtime, jdbcConnection);
         RubyModule arJdbc = runtime.getOrCreateModule("ArJdbc");
         rubyApi = JavaEmbedUtils.newObjectAdapter();
         MySQLModule.load(arJdbc);

--- a/src/java/arjdbc/jdbc/RubyJdbcConnection.java
+++ b/src/java/arjdbc/jdbc/RubyJdbcConnection.java
@@ -132,7 +132,6 @@ public class RubyJdbcConnection extends RubyObject {
 
                     DatabaseMetaData metadata = c.getMetaData();
                     String clzName = metadata.getClass().getName().toLowerCase();
-                    boolean isDB2 = clzName.indexOf("db2") != -1 || clzName.indexOf("as400") != -1;
 
                     String catalog = c.getCatalog();
                     if( name_parts.length == 2 ) {
@@ -150,7 +149,7 @@ public class RubyJdbcConnection extends RubyObject {
                     if (schemaName != null) schemaName = caseConvertIdentifierForJdbc(metadata, schemaName);
                     table_name = caseConvertIdentifierForJdbc(metadata, table_name);
 
-                    if (schemaName != null && !isDB2 && !databaseSupportsSchemas()) { catalog = schemaName; }
+                    if (schemaName != null && !databaseSupportsSchemas()) { catalog = schemaName; }
 
                     String[] tableTypes = new String[]{"TABLE","VIEW","SYNONYM"};
                     RubyArray matchingTables = (RubyArray) tableLookupBlock(context.getRuntime(),


### PR DESCRIPTION
I created a new rails project hosted with Tomcat using JNDI to connect to our DB2 database.  Since it is a brand new project, I used rails 3 with the latest stable JRuby 1.5 release and the latest activerecord-jdbc-adapter gem, 1.1.1.

I ran into a problem when trying to access the database.  Whenever I would try to access one of my models, I would get an exception stating the table didn't exist (I was setting the table name via set_table_name "myschema.mytable").  After delving into the problem, it turned out to be a problem in the activerecord-jdbc-adapter gem, specifically in RubyJdbcConnection, in the columns_internal method.  The local boolean isDB2 was turning up false because the DatabaseMetaData instance was actually wrapped by Tomcat to be an instance of org.apache.commons.dbcp.DelegatingDatabaseMetaData.

I created a local monkeypatch that basically does exactly what I did in this pull request but in Ruby instead.  It fixed the bug, and seemed to be the right way to fix the problem, so I wrote this fix and tested it out in my project, and it seems to work just fine.
