### PR TITLE
db:test:clone_structure restores to the wrong database with PostgreSQL

### DIFF
--- a/lib/arjdbc/jdbc/jdbc.rake
+++ b/lib/arjdbc/jdbc/jdbc.rake
@@ -54,8 +54,12 @@ namespace :db do
     if config['adapter'] =~ /postgresql/i
       config = config.dup
       if config['url']
-        db = config['url'][/\/([^\/]*)$/, 1]
-        config['url'][/\/([^\/]*)$/, 1] = 'postgres' if db
+        url = config['url'].dup
+        db = url[/\/([^\/]*)$/, 1]
+        if db
+          url[/\/([^\/]*)$/, 1] = 'postgres'
+          config['url'] = url
+        end
       else
         db = config['database']
         config['database'] = 'postgres'


### PR DESCRIPTION
db:test:clone_structure invokes db:test:purge, which in turn calls find_database_name.
On PostgreSQL this switches the connection to the 'postgres' database, but it has the unwanted side effect of also changing the 'url' config parameter.

That happens because even though config was dup'ed, replacing the database name in-place with config['url'][]= changes the value stored in the hash, which is shared.
