### PR TITLE
Sqlite3 Float Data Type

### DIFF
--- a/lib/arjdbc/sqlite3/adapter.rb
+++ b/lib/arjdbc/sqlite3/adapter.rb
@@ -108,7 +108,7 @@ module ::ArJdbc
       tp[:primary_key] = "integer primary key autoincrement not null"
       tp[:string] = { :name => "varchar", :limit => 255 }
       tp[:text] = { :name => "text" }
-      tp[:float] = { :name => "decimal" }
+      tp[:float] = { :name => "float" }
       tp[:decimal] = { :name => "decimal" }
       tp[:datetime] = { :name => "datetime" }
       tp[:timestamp] = { :name => "datetime" }


### PR DESCRIPTION
Sqlite3 supports the float data type:

http://www.sqlite.org/datatype3.html

Also, xmlrpc library only supports float data type (not BigDecimal which is what decimal gets cast to):

https://github.com/ruby/ruby/blob/trunk/lib/xmlrpc/create.rb#L210

So without this commit you cannot use sqlite3 with floats with the xmlrpc library.
