### PR TITLE
Fixing module scope on exceptions classes in the postgres module

### DIFF
--- a/lib/arjdbc/postgresql/adapter.rb
+++ b/lib/arjdbc/postgresql/adapter.rb
@@ -557,9 +557,9 @@ module ::ArJdbc
     def translate_exception(exception, message)
       case exception.message
       when /duplicate key value violates unique constraint/
-        RecordNotUnique.new(message, exception)
+        ::ActiveRecord::RecordNotUnique.new(message, exception)
       when /violates foreign key constraint/
-        InvalidForeignKey.new(message, exception)
+        ::ActiveRecord::InvalidForeignKey.new(message, exception)
       else
         super
       end


### PR DESCRIPTION
RecordNotUnique and InvalidForeignKey live in the ActiveRecord module
