### PR TITLE
postgres doesn't support a limit for bytea columns

### DIFF
--- a/lib/arjdbc/postgresql/adapter.rb
+++ b/lib/arjdbc/postgresql/adapter.rb
@@ -30,7 +30,7 @@ module ::ArJdbc
         case sql_type
         when /^bigint/i;    8
         when /^smallint/i;  2
-        when /^(bool|text|date|time)/i; nil # ACTIVERECORD_JDBC-135,139
+        when /^(bool|text|date|time|bytea)/i; nil # ACTIVERECORD_JDBC-135,139
         else super
         end
       end


### PR DESCRIPTION
postgres explodes when trying to create a binary column because we are adding a limit

tests pass (on windows):

C:\Users\tambellini\Desktop\repos\activerecord-jdbc-adapter>rake test_postgres
(in C:/Users/tambellini/Desktop/repos/activerecord-jdbc-adapter)
C:/jruby-1.6.1/bin/jruby.exe -I"lib;drivers/postgres/lib;adapters/postgresql/lib;test" -rjdbc/postgres "C:/jruby-1.6.1/lib/ruby/gems/1.8/gems/rake-0.8.7/lib/rake/rake_test_loader.rb" "test/postgres_db_create_test.rb" "test/postgres_drop_db_test.rb" "test/postgres_mixed_case_test.rb" "test/postgres_nonseq_pkey_test.rb"
"test/postgres_reserved_test.rb" "test/postgres_schema_search_path_test.rb" "test/postgres_simple_test.rb" "test/postgres_table_alias_length_test.rb"
Using activerecord version 3.0.7
Specify version with AR_VERSION=={version} or RUBYLIB={path}
Loaded suite C:/jruby-1.6.1/lib/ruby/gems/1.8/gems/rake-0.8.7/lib/rake/rake_test_loader
Started
.......................................................
Finished in 30.458 seconds.

55 tests, 80 assertions, 0 failures, 0 errors
