### PR TITLE
Respect postgres integer sizes

### DIFF
--- a/lib/arjdbc/postgresql/adapter.rb
+++ b/lib/arjdbc/postgresql/adapter.rb
@@ -28,8 +28,12 @@ module ::ArJdbc
 
       def extract_limit(sql_type)
         case sql_type
-        when /^bigint/i;    8
+        when /^int2/i;      2
         when /^smallint/i;  2
+        when /^int4/i;      nil
+        when /^integer/i;   nil
+        when /^int8/i;      8
+        when /^bigint/i;    8
         when /^(bool|text|date|time|bytea)/i; nil # ACTIVERECORD_JDBC-135,139
         else super
         end

--- a/test/models/data_types.rb
+++ b/test/models/data_types.rb
@@ -12,6 +12,9 @@ class DbTypeMigration < ActiveRecord::Migration
       t.column :sample_boolean, :boolean
       t.column :sample_string, :string, :default => ''
       t.column :sample_integer, :integer, :limit => 5
+      t.column :sample_integer_with_limit_2, :integer, :limit => 2
+      t.column :sample_integer_with_limit_8, :integer, :limit => 8
+      t.column :sample_integer_no_limit, :integer
       t.column :sample_text, :text
     end
   end

--- a/test/postgres_simple_test.rb
+++ b/test/postgres_simple_test.rb
@@ -69,4 +69,22 @@ class PostgresSchemaDumperTest < Test::Unit::TestCase
     assert !lines.empty?
     lines.each {|line| assert line !~ /limit/ }
   end
+
+  def test_schema_dump_integer_with_no_limit_should_have_no_limit
+    lines = @dump.grep(/sample_integer_no_limit/)
+    assert !lines.empty?
+    lines.each {|line| assert line !~ / limit/ }
+  end
+
+  def test_schema_dump_integer_with_limit_2_should_have_limit_2
+    lines = @dump.grep(/sample_integer_with_limit_2/)
+    assert !lines.empty?
+    lines.each {|line| assert line =~ /limit => 2/ }
+  end
+
+  def test_schema_dump_integer_with_limit_8_should_have_limit_8
+    lines = @dump.grep(/sample_integer_with_limit_8/)
+    assert !lines.empty?
+    lines.each {|line| assert line =~ /limit => 8/ }
+  end
 end


### PR DESCRIPTION
Postgres has smallints (int2), integers (int4), and bigints (int8). This commit makes default integer have no limit, smallints (in2) have limit 2, and bigints (int8) have limit 8.
