### PR TITLE
Fix no integer no limit test

### DIFF
--- a/test/postgres_simple_test.rb
+++ b/test/postgres_simple_test.rb
@@ -73,7 +73,7 @@ class PostgresSchemaDumperTest < Test::Unit::TestCase
   def test_schema_dump_integer_with_no_limit_should_have_no_limit
     lines = @dump.grep(/sample_integer_no_limit/)
     assert !lines.empty?
-    lines.each {|line| assert line !~ / limit/ }
+    lines.each {|line| assert line !~ /:limit/ }
   end
 
   def test_schema_dump_integer_with_limit_2_should_have_limit_2


### PR DESCRIPTION
My test for postgres integers with no limit would always pass.
