### PR TITLE
Added Basic z/OS support.

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -84,6 +84,21 @@ URL. Example:
       adapter: jdbc
       jndi: jdbc/mysqldb
 
+   If you're really old school you might want to use ARJDBC with a DB2 on z/OS.
+
+    development:
+      adapter: jdbc
+      encoding: unicode
+      url: jdbc:db2j:net://mightyzoshost:446/RAILS_DBT1
+      driver: com.ibm.db2.jcc.DB2Driver
+      schema: DB2XB12
+      database: RAILS_DB1
+      tablespace: TSDE911
+      lob_tablespaces:
+        first_table: TSDE912
+      username: scott
+      password: lion
+
 === Standalone, with ActiveRecord
 
 1. Install the gem with JRuby:


### PR DESCRIPTION
Hey Guys,
finally. I made it to get through politics and integrated the necessary patches with (hopefully you agree) minimum impact on the existing codebase.

I would be very happy if this get's merged into the main tree. If it's necessary to to anything before that happens I'm here to assist. As the Project comes to an end (and I'm just an external consultant) I might leave that client and might not have a chance to test under this circumstances (DB2 on z/OS) again.

Kind regards from Bavaria,

Rubén Parés-Selders

P.S.: 

If I run this in JRuby in 1.9 mode I get an error when I try to update an entity..maybe I'm doing something wrong so I didn't engage here but just wanted to let you know (We're more or less fine running 1.8 mode now):

NameError in

uninitialized constant ArJdbc::DB2::Column::ParseDate

Rails.root: C:/Repositories/apollo
Application Trace | Framework Trace | Full Trace

vendor/gems/jruby/1.9/gems/activerecord-jdbc-adapter-1.1.2/lib/arjdbc/db2/adapter.rb:72:in `cast_to_time'
vendor/gems/jruby/1.9/gems/activerecord-jdbc-adapter-1.1.2/lib/arjdbc/db2/adapter.rb:66:in`cast_to_date_or_time'
vendor/gems/jruby/1.9/gems/activerecord-jdbc-adapter-1.1.2/lib/arjdbc/db2/adapter.rb:42:in `type_cast'
vendor/gems/jruby/1.9/gems/activerecord-3.0.9/lib/active_record/attribute_methods/read.rb:114:in`_read_attribute'
vendor/gems/jruby/1.9/gems/activerecord-3.0.9/lib/active_record/attribute_methods/time_zone_conversion.rb:33:in `_created_at'
vendor/gems/jruby/1.9/gems/activerecord-3.0.9/lib/active_record/attribute_methods/read.rb:99:in`send'
vendor/gems/jruby/1.9/gems/activerecord-3.0.9/lib/active_record/attribute_methods/read.rb:99:in `read_attribute'
vendor/gems/jruby/1.9/gems/activerecord-3.0.9/lib/active_record/base.rb:1574:in`attributes'
vendor/gems/jruby/1.9/gems/activerecord-3.0.9/lib/active_record/base.rb:1574:in `each'
vendor/gems/jruby/1.9/gems/activerecord-3.0.9/lib/active_record/base.rb:1574:in`attributes'
vendor/gems/jruby/1.9/gems/activerecord-3.0.9/lib/active_record/attribute_methods/dirty.rb:68:in `update'
vendor/gems/jruby/1.9/gems/activerecord-3.0.9/lib/active_record/timestamp.rb:60:in`update'
vendor/gems/jruby/1.9/gems/activerecord-3.0.9/lib/active_record/callbacks.rb:281:in `update'
vendor/gems/jruby/1.9/gems/activesupport-3.0.9/lib/active_support/callbacks.rb:429:in`_run_update_callbacks'
vendor/gems/jruby/1.9/gems/activerecord-3.0.9/lib/active_record/callbacks.rb:281:in `update'
vendor/gems/jruby/1.9/gems/activerecord-3.0.9/lib/active_record/persistence.rb:250:in`create_or_update'
vendor/gems/jruby/1.9/gems/activerecord-3.0.9/lib/active_record/callbacks.rb:273:in `create_or_update'
vendor/gems/jruby/1.9/gems/activesupport-3.0.9/lib/active_support/callbacks.rb:429:in`_run_save_callbacks'
vendor/gems/jruby/1.9/gems/activerecord-3.0.9/lib/active_record/callbacks.rb:273:in `create_or_update'
vendor/gems/jruby/1.9/gems/activerecord-3.0.9/lib/active_record/persistence.rb:40:in`save'
vendor/gems/jruby/1.9/gems/activerecord-3.0.9/lib/active_record/validations.rb:43:in `save'
vendor/gems/jruby/1.9/gems/activerecord-3.0.9/lib/active_record/attribute_methods/dirty.rb:21:in`save'
vendor/gems/jruby/1.9/gems/activerecord-3.0.9/lib/active_record/transactions.rb:240:in `save'
vendor/gems/jruby/1.9/gems/activerecord-3.0.9/lib/active_record/transactions.rb:292:in`with_transaction_returning_status'
vendor/gems/jruby/1.9/gems/activerecord-3.0.9/lib/active_record/connection_adapters/abstract/database_statements.rb:139:in `transaction'
vendor/gems/jruby/1.9/gems/activerecord-3.0.9/lib/active_record/transactions.rb:207:in`transaction'
vendor/gems/jruby/1.9/gems/activerecord-3.0.9/lib/active_record/transactions.rb:290:in `with_transaction_returning_status'
vendor/gems/jruby/1.9/gems/activerecord-3.0.9/lib/active_record/transactions.rb:240:in`save'
vendor/gems/jruby/1.9/gems/activerecord-3.0.9/lib/active_record/transactions.rb:251:in `rollback_active_record_state!'
vendor/gems/jruby/1.9/gems/activerecord-3.0.9/lib/active_record/transactions.rb:239:in`save'
vendor/gems/jruby/1.9/gems/activerecord-3.0.9/lib/active_record/persistence.rb:132:in `update_attributes'
vendor/gems/jruby/1.9/gems/activerecord-3.0.9/lib/active_record/transactions.rb:292:in`with_transaction_returning_status'
vendor/gems/jruby/1.9/gems/activerecord-3.0.9/lib/active_record/connection_adapters/abstract/database_statements.rb:139:in `transaction'
vendor/gems/jruby/1.9/gems/activerecord-3.0.9/lib/active_record/transactions.rb:207:in`transaction'
vendor/gems/jruby/1.9/gems/activerecord-3.0.9/lib/active_record/transactions.rb:290:in `with_transaction_returning_status'
vendor/gems/jruby/1.9/gems/activerecord-3.0.9/lib/active_record/persistence.rb:130:in`update_attributes'
vendor/gems/jruby/1.9/gems/actionpack-3.0.9/lib/action_controller/metal/mime_responds.rb:264:in `call'
vendor/gems/jruby/1.9/gems/actionpack-3.0.9/lib/action_controller/metal/mime_responds.rb:264:in`retrieve_response_from_mimes'
vendor/gems/jruby/1.9/gems/actionpack-3.0.9/lib/action_controller/metal/mime_responds.rb:191:in `respond_to'
vendor/gems/jruby/1.9/gems/actionpack-3.0.9/lib/action_controller/metal/implicit_render.rb:4:in`send'
vendor/gems/jruby/1.9/gems/actionpack-3.0.9/lib/action_controller/metal/implicit_render.rb:4:in `send_action'
vendor/gems/jruby/1.9/gems/actionpack-3.0.9/lib/abstract_controller/base.rb:150:in`process_action'
vendor/gems/jruby/1.9/gems/actionpack-3.0.9/lib/action_controller/metal/rendering.rb:11:in `process_action'
vendor/gems/jruby/1.9/gems/actionpack-3.0.9/lib/abstract_controller/callbacks.rb:18:in`process_action'
vendor/gems/jruby/1.9/gems/activesupport-3.0.9/lib/active_support/callbacks.rb:444:in `_run__2078183425__process_action__944252406__callbacks'
vendor/gems/jruby/1.9/gems/activesupport-3.0.9/lib/active_support/callbacks.rb:425:in`send'
vendor/gems/jruby/1.9/gems/activesupport-3.0.9/lib/active_support/callbacks.rb:425:in `_run_process_action_callbacks'
vendor/gems/jruby/1.9/gems/activesupport-3.0.9/lib/active_support/callbacks.rb:94:in`send'
vendor/gems/jruby/1.9/gems/activesupport-3.0.9/lib/active_support/callbacks.rb:94:in `run_callbacks'
vendor/gems/jruby/1.9/gems/actionpack-3.0.9/lib/abstract_controller/callbacks.rb:17:in`process_action'
vendor/gems/jruby/1.9/gems/actionpack-3.0.9/lib/action_controller/metal/instrumentation.rb:30:in `process_action'
vendor/gems/jruby/1.9/gems/activesupport-3.0.9/lib/active_support/notifications.rb:52:in`instrument'
vendor/gems/jruby/1.9/gems/activesupport-3.0.9/lib/active_support/notifications/instrumenter.rb:21:in `instrument'
vendor/gems/jruby/1.9/gems/activesupport-3.0.9/lib/active_support/notifications.rb:52:in`instrument'
vendor/gems/jruby/1.9/gems/actionpack-3.0.9/lib/action_controller/metal/instrumentation.rb:29:in `process_action'
vendor/gems/jruby/1.9/gems/actionpack-3.0.9/lib/action_controller/metal/rescue.rb:17:in`process_action'
vendor/gems/jruby/1.9/gems/actionpack-3.0.9/lib/abstract_controller/base.rb:119:in `process'
vendor/gems/jruby/1.9/gems/actionpack-3.0.9/lib/abstract_controller/rendering.rb:41:in`process'
vendor/gems/jruby/1.9/gems/actionpack-3.0.9/lib/action_controller/metal.rb:138:in `dispatch'
vendor/gems/jruby/1.9/gems/actionpack-3.0.9/lib/action_controller/metal/rack_delegation.rb:14:in`dispatch'
vendor/gems/jruby/1.9/gems/actionpack-3.0.9/lib/action_controller/metal.rb:178:in `action'
vendor/gems/jruby/1.9/gems/actionpack-3.0.9/lib/action_dispatch/routing/route_set.rb:62:in`call'
vendor/gems/jruby/1.9/gems/actionpack-3.0.9/lib/action_dispatch/routing/route_set.rb:62:in `dispatch'
vendor/gems/jruby/1.9/gems/actionpack-3.0.9/lib/action_dispatch/routing/route_set.rb:27:in`call'
vendor/gems/jruby/1.9/gems/rack-mount-0.6.14/lib/rack/mount/route_set.rb:148:in `call'
vendor/gems/jruby/1.9/gems/rack-mount-0.6.14/lib/rack/mount/code_generation.rb:111:in`recognize'
vendor/gems/jruby/1.9/gems/rack-mount-0.6.14/lib/rack/mount/code_generation.rb:101:in `optimized_each'
vendor/gems/jruby/1.9/gems/rack-mount-0.6.14/lib/rack/mount/code_generation.rb:110:in`recognize'
vendor/gems/jruby/1.9/gems/rack-mount-0.6.14/lib/rack/mount/route_set.rb:139:in `call'
vendor/gems/jruby/1.9/gems/actionpack-3.0.9/lib/action_dispatch/routing/route_set.rb:493:in`call'
vendor/gems/jruby/1.9/gems/actionpack-3.0.9/lib/action_dispatch/middleware/best_standards_support.rb:17:in `call'
vendor/gems/jruby/1.9/gems/actionpack-3.0.9/lib/action_dispatch/middleware/head.rb:14:in`call'
vendor/gems/jruby/1.9/gems/rack-1.2.2/lib/rack/methodoverride.rb:24:in `call'
vendor/gems/jruby/1.9/gems/actionpack-3.0.9/lib/action_dispatch/middleware/params_parser.rb:21:in`call'
vendor/gems/jruby/1.9/gems/actionpack-3.0.9/lib/action_dispatch/middleware/flash.rb:182:in `call'
vendor/gems/jruby/1.9/gems/actionpack-3.0.9/lib/action_dispatch/middleware/session/abstract_store.rb:149:in`call'
vendor/gems/jruby/1.9/gems/actionpack-3.0.9/lib/action_dispatch/middleware/cookies.rb:302:in `call'
vendor/gems/jruby/1.9/gems/activerecord-3.0.9/lib/active_record/query_cache.rb:32:in`call'
vendor/gems/jruby/1.9/gems/activerecord-3.0.9/lib/active_record/connection_adapters/abstract/query_cache.rb:28:in `cache'
vendor/gems/jruby/1.9/gems/activerecord-3.0.9/lib/active_record/query_cache.rb:12:in`cache'
vendor/gems/jruby/1.9/gems/activerecord-3.0.9/lib/active_record/query_cache.rb:31:in `call'
vendor/gems/jruby/1.9/gems/activerecord-3.0.9/lib/active_record/connection_adapters/abstract/connection_pool.rb:354:in`call'
vendor/gems/jruby/1.9/gems/actionpack-3.0.9/lib/action_dispatch/middleware/callbacks.rb:46:in `call'
vendor/gems/jruby/1.9/gems/activesupport-3.0.9/lib/active_support/callbacks.rb:431:in`_run_call_callbacks'
vendor/gems/jruby/1.9/gems/actionpack-3.0.9/lib/action_dispatch/middleware/callbacks.rb:44:in `call'
vendor/gems/jruby/1.9/gems/rack-1.2.2/lib/rack/sendfile.rb:107:in`call'
vendor/gems/jruby/1.9/gems/actionpack-3.0.9/lib/action_dispatch/middleware/remote_ip.rb:48:in `call'
vendor/gems/jruby/1.9/gems/actionpack-3.0.9/lib/action_dispatch/middleware/show_exceptions.rb:47:in`call'
vendor/gems/jruby/1.9/gems/railties-3.0.9/lib/rails/rack/logger.rb:13:in `call'
vendor/gems/jruby/1.9/gems/rack-1.2.2/lib/rack/runtime.rb:17:in`call'
vendor/gems/jruby/1.9/gems/activesupport-3.0.9/lib/active_support/cache/strategy/local_cache.rb:90:in `call'
vendor/gems/jruby/1.9/gems/rack-1.2.2/lib/rack/lock.rb:11:in`call'
vendor/gems/jruby/1.9/gems/rack-1.2.2/lib/rack/lock.rb:11:in `call'
vendor/gems/jruby/1.9/gems/actionpack-3.0.9/lib/action_dispatch/middleware/static.rb:30:in`call'
vendor/gems/jruby/1.9/gems/railties-3.0.9/lib/rails/application.rb:168:in `call'
vendor/gems/jruby/1.9/gems/railties-3.0.9/lib/rails/application.rb:77:in`send'
vendor/gems/jruby/1.9/gems/railties-3.0.9/lib/rails/application.rb:77:in `method_missing'
vendor/gems/jruby/1.9/gems/railties-3.0.9/lib/rails/rack/log_tailer.rb:14:in`call'
vendor/gems/jruby/1.9/gems/rack-1.2.2/lib/rack/content_length.rb:13:in `call'
vendor/gems/jruby/1.9/gems/rack-1.2.2/lib/rack/handler/webrick.rb:52:in`service'
C:/Programme/h7daecy/jruby-1.6.2/lib/ruby/1.9/webrick/httpserver.rb:111:in `service'
C:/Programme/h7daecy/jruby-1.6.2/lib/ruby/1.9/webrick/httpserver.rb:70:in`run'
C:/Programme/h7daecy/jruby-1.6.2/lib/ruby/1.9/webrick/server.rb:183:in `start_thread'

Request

Parameters:

{"utf8"=>"\xE2\x9C\x93",
 "_method"=>"put",
 "authenticity_token"=>"sK8Sl3Fz1mF6UK7k5Z99F26ywKUNZPyevEBzUB6eE1Y=",
 "document"=>{"name"=>"1",
 "inhalt"=>"1"},
 "commit"=>"Update Document",
 "id"=>"1"}
