### PR TITLE
Added bigint serial support + some testcases for native type mapping (postgres only)

### DIFF
--- a/lib/arjdbc/postgresql/adapter.rb
+++ b/lib/arjdbc/postgresql/adapter.rb
@@ -41,7 +41,7 @@ module ::ArJdbc
       end
 
       def simplified_type(field_type)
-        return :integer if field_type =~ /^serial/i
+        return :integer if field_type =~ /^(big|)serial/i
         return :string if field_type =~ /\[\]$/i || field_type =~ /^interval/i
         return :string if field_type =~ /^(?:point|lseg|box|"?path"?|polygon|circle)/i
         return :datetime if field_type =~ /^timestamp/i

--- a/test/postgres_native_type_mapping_test.rb
+++ b/test/postgres_native_type_mapping_test.rb
@@ -1,0 +1,84 @@
+require 'jdbc_common'
+require 'db/postgres'
+
+class CreateNativeTypeMappingTestSchema < ActiveRecord::Migration
+  def self.up
+    execute "DROP SEQUENCE IF EXISTS seq_pk_customers"
+    execute "CREATE SEQUENCE seq_pk_customers"
+    execute %q{
+      CREATE TABLE customers (
+          bigint_serial_should_be_integer bigint default nextval('seq_pk_customers'),
+          integer_serial_should_be_integer integer default nextval('seq_pk_customers'),
+          varchar_should_be_string varchar(2),
+          timestamp_should_be_datetime timestamp,
+          bytea_should_be_binary bytea,
+          double_precision_should_be_float double precision,
+          real_should_be_float real,
+          bool_should_be_boolean bool,
+          interval_should_be_string interval,
+          bigint_should_be_integer bigint
+      )}
+  end
+
+  def self.down
+    execute "DROP TABLE customers"
+    execute "DROP SEQUENCE IF EXISTS seq_pk_customers"
+  end
+end
+
+class Customer < ActiveRecord::Base
+end
+
+class PostgresNativeTypeMappingTest < Test::Unit::TestCase
+  def setup
+    CreateNativeTypeMappingTestSchema.up
+  end
+
+  def teardown
+    CreateNativeTypeMappingTestSchema.down
+  end
+
+  def column_type(column_name)
+    Customer.columns.detect { |c| c.name == column_name }.type
+  end
+
+  def test_bigint_serial_should_be_mapped_to_integer
+    assert_equal :integer, column_type("bigint_serial_should_be_integer")
+  end
+
+  def test_integer_serial_should_be_mapped_to_integer
+    assert_equal :integer, column_type("integer_serial_should_be_integer")
+  end
+
+  def test_varchar_should_be_mapped_to_string
+    assert_equal :string, column_type("varchar_should_be_string")
+  end
+
+  def test_timestamp_should_be_mapped_to_datetime
+    assert_equal :datetime, column_type("timestamp_should_be_datetime")
+  end
+
+  def test_bytea_should_be_mapped_to_binary
+    assert_equal :binary, column_type("bytea_should_be_binary")
+  end
+
+  def test_double_precision_should_be_mapped_to_float
+    assert_equal :float, column_type("double_precision_should_be_float")
+  end
+
+  def test_real_should_be_mapped_to_float
+    assert_equal :float, column_type("real_should_be_float")
+  end
+
+  def test_bool_should_be_mapped_to_boolean
+    assert_equal :boolean, column_type("bool_should_be_boolean")
+  end
+
+  def test_interval_should_be_mapped_to_string
+    assert_equal :string, column_type("interval_should_be_string")
+  end
+
+  def test_bigint_should_be_mapped_to_integer
+    assert_equal :integer, column_type("bigint_should_be_integer")
+  end
+end


### PR DESCRIPTION
Columns created with "bigint default nextval('seq_foo')" weren't recognized by the simplified_type(field_type) method in the postgres adapter.

This patch fixed that behavior and includes some more test cases covering the native type conversion.
