### PR TITLE
distinct api change in rails 3.1

### DIFF
--- a/lib/arjdbc/postgresql/adapter.rb
+++ b/lib/arjdbc/postgresql/adapter.rb
@@ -405,19 +405,16 @@ module ::ArJdbc
     # requires that the ORDER BY include the distinct column.
     #
     #   distinct("posts.id", "posts.created_at desc")
-    def distinct(columns, order_by)
-      return "DISTINCT #{columns}" if order_by.blank?
+    def distinct(columns, orders)
+      return "DISTINCT #{columns}" if orders.empty?
 
-      # construct a clean list of column names from the ORDER BY clause, removing
-      # any asc/desc modifiers
-      order_columns = order_by.split(',').collect { |s| s.split.first }
-      order_columns.delete_if(&:blank?)
+      # Construct a clean list of column names from the ORDER BY clause, removing
+      # any ASC/DESC modifiers
+      order_columns = orders.collect { |s| s.gsub(/\s+(ASC|DESC)\s*/i, '') }
+      order_columns.delete_if { |c| c.blank? }
       order_columns = order_columns.zip((0...order_columns.size).to_a).map { |s,i| "#{s} AS alias_#{i}" }
 
-      # return a DISTINCT ON() clause that's distinct on the columns we want but includes
-      # all the required columns for the ORDER BY to work properly
-      sql = "DISTINCT ON (#{columns}) #{columns}, "
-      sql << order_columns * ', '
+      "DISTINCT #{columns}, #{order_columns * ', '}"
     end
 
     # ORDER BY clause for the passed order option.


### PR DESCRIPTION
the distinct method in rails 3.1 has changed the second parameters from order_by(string) to orders(array) and update implementation a bit
