### PR TITLE
Naive attempt to support ARel 2.2

### DIFF
--- a/lib/arjdbc/jdbc/adapter.rb
+++ b/lib/arjdbc/jdbc/adapter.rb
@@ -176,7 +176,8 @@ module ActiveRecord
         @connection.disconnect!
       end
 
-      def substitute_binds(sql, binds = [])
+      def substitute_binds(manager, binds = [])
+        sql = extract_sql(manager)
         if binds.empty?
           sql
         else
@@ -316,7 +317,16 @@ module ActiveRecord
         puts e.backtrace if $DEBUG || ENV['DEBUG']
         super
       end
-      protected :translate_exception
+
+      def extract_sql(obj)
+        if obj.respond_to? :to_sql
+          obj.send :to_sql
+        else
+          obj
+        end
+      end
+
+      protected :translate_exception, :extract_sql
     end
   end
 end

--- a/lib/arjdbc/mysql/adapter.rb
+++ b/lib/arjdbc/mysql/adapter.rb
@@ -414,6 +414,10 @@ module ActiveRecord::ConnectionAdapters
       configure_connection
     end
 
+    def self.visitor_for(pool) # :nodoc:
+      ::Arel::Visitors::MySQL.new(pool)
+    end
+
     def adapter_spec(config)
       # return nil to avoid extending ArJdbc::MySQL, which we've already done
     end


### PR DESCRIPTION
The most important change works for all adapters: ARel now passes a
TreeManager instead of the parsed SQL to adapters; This was handled by
calling #to_sql on the manager (if the object actually responds to that)
deep inside #substitute_binds, which should cover all types of
statements.

Also, the global Arel::Visitors::VISITORS is deprecated, and instead
each adapter should respond to :visitor_for returning an appropriate
visitor. The MySQL adapter was changed to do that, but other adapters
are still using the deprecated API. It should be easy to change this in
other adapters, but I'll leave that to people more familiar with the respective
databases.
