### PR TITLE
fixing the double ORDER BY

### DIFF
--- a/lib/arjdbc/mssql/limit_helpers.rb
+++ b/lib/arjdbc/mssql/limit_helpers.rb
@@ -31,10 +31,13 @@ module ::ArJdbc
               rest = rest_of_query[/FROM/i=~ rest_of_query.. -1]
               #need the table name for avoiding amiguity
               table_name = LimitHelpers.get_table_name(sql)
-              primary_key = order[/(\w*id\w*)/i]
+              primary_key = order[/(\w*id\w*)/i] || "id"
               #I am not sure this will cover all bases.  but all the tests pass
-              new_order = "ORDER BY #{order}, #{table_name}.#{primary_key}" if order.index("#{table_name}.#{primary_key}").nil?
-              new_order ||= order
+              if order[/ORDER/].nil?
+                new_order = "ORDER BY #{order}, #{table_name}.#{primary_key}" if order.index("#{table_name}.#{primary_key}").nil?
+              else
+                new_order ||= order
+              end
 
               if (rest_of_query.match(/WHERE/).nil?)
                 new_sql = "#{select} TOP #{limit} #{rest_of_query} WHERE #{table_name}.#{primary_key} NOT IN (#{select} TOP #{offset} #{table_name}.#{primary_key} #{rest} #{new_order}) #{order} "


### PR DESCRIPTION
Without this check on `order` the resulting SQL query contains two times ORDER BY:

``` ruby
User.limit(20)
```

``` sql
ActiveRecord::JDBCError: Incorrect syntax near the keyword 'ORDER'.: SELECT TOP 20   [db_USER].* FROM [db_USER] WHERE [db_USER].id NOT IN (SELECT TOP 0 [db_USER].id FROM [db_USER] ORDER BY ORDER BY Account, [db_USER].id) ORDER BY Account
```

and I've fixed the search of the `primary_key` too
