### PR TITLE
URLs in README and gemspecs are out-of-date

### DIFF
--- a/activerecord-jdbc-adapter.gemspec
+++ b/activerecord-jdbc-adapter.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.authors     = ["Nick Sieger, Ola Bini and JRuby contributors"]
   s.email       = %q{nick@nicksieger.com, ola.bini@gmail.com}
-  s.homepage = %q{http://jruby-extras.rubyforge.org/activerecord-jdbc-adapter}
+  s.homepage = %q{https://github.com/jruby/activerecord-jdbc-adapter}
   s.summary = %q{JDBC adapter for ActiveRecord, for use within JRuby on Rails.}
   s.description = %q{activerecord-jdbc-adapter is a database adapter for Rails\' ActiveRecord
 component that can be used with JRuby[http://www.jruby.org/]. It allows use of

--- a/activerecord-jdbcderby-adapter/README.txt
+++ b/activerecord-jdbcderby-adapter/README.txt
@@ -1,6 +1,6 @@
 = activerecord-jdbcderby-adapter
 
-* http://jruby-extras.rubyforge.org/activerecord-jdbc-adapter/
+* https://github.com/jruby/activerecord-jdbc-adapter/
 
 == DESCRIPTION:
 

--- a/activerecord-jdbcderby-adapter/activerecord-jdbcderby-adapter.gemspec
+++ b/activerecord-jdbcderby-adapter/activerecord-jdbcderby-adapter.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
     "LICENSE.txt",
     "lib/active_record/connection_adapters/jdbcderby_adapter.rb"
   ]
-  s.homepage = %q{http://jruby-extras.rubyforge.org/ActiveRecord-JDBC}
+  s.homepage = %q{https://github.com/jruby/activerecord-jdbc-adapter}
   s.require_paths = ["lib"]
   s.rubyforge_project = %q{jruby-extras}
   s.summary = %q{Derby JDBC adapter for JRuby on Rails.}

--- a/activerecord-jdbch2-adapter/README.txt
+++ b/activerecord-jdbch2-adapter/README.txt
@@ -1,6 +1,6 @@
 = activerecord-jdbch2-adapter
 
-* http://jruby-extras.rubyforge.org/activerecord-jdbc-adapter/
+* https://github.com/jruby/activerecord-jdbc-adapter/
 
 == DESCRIPTION:
 

--- a/activerecord-jdbch2-adapter/activerecord-jdbch2-adapter.gemspec
+++ b/activerecord-jdbch2-adapter/activerecord-jdbch2-adapter.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
     "LICENSE.txt",
     "lib/active_record/connection_adapters/jdbch2_adapter.rb"
   ]
-  s.homepage = %q{http://jruby-extras.rubyforge.org/ActiveRecord-JDBC}
+  s.homepage = %q{https://github.com/jruby/activerecord-jdbc-adapter}
   s.require_paths = ["lib"]
   s.rubyforge_project = %q{jruby-extras}
   s.summary = %q{H2 JDBC adapter for JRuby on Rails.}

--- a/activerecord-jdbchsqldb-adapter/README.txt
+++ b/activerecord-jdbchsqldb-adapter/README.txt
@@ -1,6 +1,6 @@
 = activerecord-jdbchsqldb-adapter
 
-* http://jruby-extras.rubyforge.org/activerecord-jdbc-adapter/
+* https://github.com/jruby/activerecord-jdbc-adapter/
 
 == DESCRIPTION:
 

--- a/activerecord-jdbchsqldb-adapter/activerecord-jdbchsqldb-adapter.gemspec
+++ b/activerecord-jdbchsqldb-adapter/activerecord-jdbchsqldb-adapter.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
     "LICENSE.txt",
     "lib/active_record/connection_adapters/jdbchsqldb_adapter.rb"
   ]
-  s.homepage = %q{http://jruby-extras.rubyforge.org/ActiveRecord-JDBC}
+  s.homepage = %q{https://github.com/jruby/activerecord-jdbc-adapter}
   s.require_paths = ["lib"]
   s.rubyforge_project = %q{jruby-extras}
   s.summary = %q{HSQLDB JDBC adapter for JRuby on Rails.}

--- a/activerecord-jdbcmssql-adapter/README.txt
+++ b/activerecord-jdbcmssql-adapter/README.txt
@@ -1,6 +1,6 @@
 = activerecord-jdbcmssql-adapter
 
-* http://jruby-extras.rubyforge.org/activerecord-jdbc-adapter/
+* https://github.com/jruby/activerecord-jdbc-adapter/
 
 == DESCRIPTION:
 

--- a/activerecord-jdbcmssql-adapter/activerecord-jdbcmssql-adapter.gemspec
+++ b/activerecord-jdbcmssql-adapter/activerecord-jdbcmssql-adapter.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
     "LICENSE.txt",
     "lib/active_record/connection_adapters/jdbcmssql_adapter.rb"
   ]
-  s.homepage = %q{http://jruby-extras.rubyforge.org/ActiveRecord-JDBC}
+  s.homepage = %q{https://github.com/jruby/activerecord-jdbc-adapter}
   s.require_paths = ["lib"]
   s.rubyforge_project = %q{jruby-extras}
   s.summary = %q{MS_SQL JDBC adapter for JRuby on Rails.}

--- a/activerecord-jdbcmysql-adapter/README.txt
+++ b/activerecord-jdbcmysql-adapter/README.txt
@@ -1,6 +1,6 @@
 = activerecord-jdbcmysql-adapter
 
-* http://jruby-extras.rubyforge.org/activerecord-jdbc-adapter/
+* https://github.com/jruby/activerecord-jdbc-adapter/
 
 == DESCRIPTION:
 

--- a/activerecord-jdbcmysql-adapter/activerecord-jdbcmysql-adapter.gemspec
+++ b/activerecord-jdbcmysql-adapter/activerecord-jdbcmysql-adapter.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
     "LICENSE.txt",
     "lib/active_record/connection_adapters/jdbcmysql_adapter.rb"
   ]
-  s.homepage = %q{http://jruby-extras.rubyforge.org/ActiveRecord-JDBC}
+  s.homepage = %q{https://github.com/jruby/activerecord-jdbc-adapter}
   s.require_paths = ["lib"]
   s.rubyforge_project = %q{jruby-extras}
   s.summary = %q{MySQL JDBC adapter for JRuby on Rails.}

--- a/activerecord-jdbcpostgresql-adapter/README.txt
+++ b/activerecord-jdbcpostgresql-adapter/README.txt
@@ -1,6 +1,6 @@
 = activerecord-jdbcpostgresql-adapter
 
-* http://jruby-extras.rubyforge.org/activerecord-jdbc-adapter/
+* https://github.com/jruby/activerecord-jdbc-adapter/
 
 == DESCRIPTION:
 

--- a/activerecord-jdbcpostgresql-adapter/activerecord-jdbcpostgresql-adapter.gemspec
+++ b/activerecord-jdbcpostgresql-adapter/activerecord-jdbcpostgresql-adapter.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
     "LICENSE.txt",
     "lib/active_record/connection_adapters/jdbcpostgresql_adapter.rb"
   ]
-  s.homepage = %q{http://jruby-extras.rubyforge.org/ActiveRecord-JDBC}
+  s.homepage = %q{https://github.com/jruby/activerecord-jdbc-adapter}
   s.require_paths = ["lib"]
   s.rubyforge_project = %q{jruby-extras}
   s.summary = %q{Postgres JDBC adapter for JRuby on Rails.}

--- a/activerecord-jdbcsqlite3-adapter/README.txt
+++ b/activerecord-jdbcsqlite3-adapter/README.txt
@@ -1,6 +1,6 @@
 = activerecord-jdbcsqlite3-adapter
 
-* http://jruby-extras.rubyforge.org/activerecord-jdbc-adapter/
+* https://github.com/jruby/activerecord-jdbc-adapter/
 
 == DESCRIPTION:
 

--- a/activerecord-jdbcsqlite3-adapter/activerecord-jdbcsqlite3-adapter.gemspec
+++ b/activerecord-jdbcsqlite3-adapter/activerecord-jdbcsqlite3-adapter.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
     "LICENSE.txt",
     "lib/active_record/connection_adapters/jdbcsqlite3_adapter.rb"
   ]
-  s.homepage = %q{http://jruby-extras.rubyforge.org/ActiveRecord-JDBC}
+  s.homepage = %q{https://github.com/jruby/activerecord-jdbc-adapter}
   s.require_paths = ["lib"]
   s.rubyforge_project = %q{jruby-extras}
   s.summary = %q{Sqlite3 JDBC adapter for JRuby on Rails.}

--- a/jdbc-derby/README.txt
+++ b/jdbc-derby/README.txt
@@ -1,6 +1,6 @@
 = jdbc-derby
 
-* http://jruby-extras.rubyforge.org/activerecord-jdbc-adapter/
+* https://github.com/jruby/activerecord-jdbc-adapter/
 
 == DESCRIPTION:
 

--- a/jdbc-derby/jdbc-derby.gemspec
+++ b/jdbc-derby/jdbc-derby.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
     "Rakefile", "README.txt", "LICENSE.txt",
     *Dir["lib/**/*"].to_a
   ]
-  s.homepage = %q{http://jruby-extras.rubyforge.org/ActiveRecord-JDBC}
+  s.homepage = %q{https://github.com/jruby/activerecord-jdbc-adapter}
   s.rdoc_options = ["--main", "README.txt"]
   s.require_paths = ["lib"]
   s.rubyforge_project = %q{jruby-extras}

--- a/jdbc-h2/README.txt
+++ b/jdbc-h2/README.txt
@@ -1,6 +1,6 @@
 = jdbc-h2
 
-* http://jruby-extras.rubyforge.org/activerecord-jdbc-adapter/
+* https://github.com/jruby/activerecord-jdbc-adapter/
 
 == DESCRIPTION:
 

--- a/jdbc-h2/jdbc-h2.gemspec
+++ b/jdbc-h2/jdbc-h2.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
     "Rakefile", "README.txt", "LICENSE.txt",
     *Dir["lib/**/*"].to_a
   ]
-  s.homepage = %q{http://jruby-extras.rubyforge.org/ActiveRecord-JDBC}
+  s.homepage = %q{https://github.com/jruby/activerecord-jdbc-adapter}
   s.rdoc_options = ["--main", "README.txt"]
   s.require_paths = ["lib"]
   s.rubyforge_project = %q{jruby-extras}

--- a/jdbc-hsqldb/README.txt
+++ b/jdbc-hsqldb/README.txt
@@ -1,6 +1,6 @@
 = jdbc-hsqldb
 
-* http://jruby-extras.rubyforge.org/activerecord-jdbc-adapter/
+* https://github.com/jruby/activerecord-jdbc-adapter/
 
 == DESCRIPTION:
 

--- a/jdbc-hsqldb/jdbc-hsqldb.gemspec
+++ b/jdbc-hsqldb/jdbc-hsqldb.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
     "Rakefile", "README.txt", "LICENSE.txt",
     *Dir["lib/**/*"].to_a
   ]
-  s.homepage = %q{http://jruby-extras.rubyforge.org/ActiveRecord-JDBC}
+  s.homepage = %q{https://github.com/jruby/activerecord-jdbc-adapter}
   s.rdoc_options = ["--main", "README.txt"]
   s.require_paths = ["lib"]
   s.rubyforge_project = %q{jruby-extras}

--- a/jdbc-jtds/README.txt
+++ b/jdbc-jtds/README.txt
@@ -1,6 +1,6 @@
 = jdbc-jtds
 
-* http://jruby-extras.rubyforge.org/activerecord-jdbc-adapter/
+* https://github.com/jruby/activerecord-jdbc-adapter/
 
 == DESCRIPTION:
 

--- a/jdbc-jtds/jdbc-jtds.gemspec
+++ b/jdbc-jtds/jdbc-jtds.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
     *Dir["lib/**/*"].to_a
   ]
 
-  s.homepage = %q{http://jruby-extras.rubyforge.org/ActiveRecord-JDBC}
+  s.homepage = %q{https://github.com/jruby/activerecord-jdbc-adapter}
   s.rdoc_options = ["--main", "README.txt"]
   s.require_paths = ["lib"]
   s.rubyforge_project = %q{jruby-extras}

--- a/jdbc-mysql/README.txt
+++ b/jdbc-mysql/README.txt
@@ -1,6 +1,6 @@
 = jdbc-mysql
 
-* http://jruby-extras.rubyforge.org/activerecord-jdbc-adapter/
+* https://github.com/jruby/activerecord-jdbc-adapter/
 
 == DESCRIPTION:
 

--- a/jdbc-mysql/jdbc-mysql.gemspec
+++ b/jdbc-mysql/jdbc-mysql.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
     "Rakefile", "README.txt", "LICENSE.txt",
     *Dir["lib/**/*"].to_a
   ]
-  s.homepage = %q{http://jruby-extras.rubyforge.org/ActiveRecord-JDBC}
+  s.homepage = %q{https://github.com/jruby/activerecord-jdbc-adapter}
   s.rdoc_options = ["--main", "README.txt"]
   s.require_paths = ["lib"]
   s.rubyforge_project = %q{jruby-extras}

--- a/jdbc-postgres/README.txt
+++ b/jdbc-postgres/README.txt
@@ -1,6 +1,6 @@
 = jdbc-postgres
 
-* http://jruby-extras.rubyforge.org/activerecord-jdbc-adapter/
+* https://github.com/jruby/activerecord-jdbc-adapter/
 
 == DESCRIPTION:
 

--- a/jdbc-postgres/jdbc-postgres.gemspec
+++ b/jdbc-postgres/jdbc-postgres.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
     *Dir["lib/**/*"].to_a
   ]
 
-  s.homepage = %q{http://jruby-extras.rubyforge.org/ActiveRecord-JDBC}
+  s.homepage = %q{https://github.com/jruby/activerecord-jdbc-adapter}
   s.rdoc_options = ["--main", "README.txt"]
   s.require_paths = ["lib"]
   s.rubyforge_project = %q{jruby-extras}

--- a/jdbc-sqlite3/README.txt
+++ b/jdbc-sqlite3/README.txt
@@ -1,6 +1,6 @@
 = jdbc-sqlite3
 
-* http://jruby-extras.rubyforge.org/activerecord-jdbc-adapter/
+* https://github.com/jruby/activerecord-jdbc-adapter/
 
 == DESCRIPTION:
 

--- a/jdbc-sqlite3/jdbc-sqlite3.gemspec
+++ b/jdbc-sqlite3/jdbc-sqlite3.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
     *Dir["lib/**/*"].to_a
   ]
 
-  s.homepage = %q{http://jruby-extras.rubyforge.org/ActiveRecord-JDBC}
+  s.homepage = %q{https://github.com/jruby/activerecord-jdbc-adapter}
   s.rdoc_options = ["--main", "README.txt"]
   s.require_paths = ["lib"]
   s.rubyforge_project = %q{jruby-extras}


### PR DESCRIPTION
This changes all urls from jruby-extras.rubyforge.net to point to github.
