### PR TITLE
We rely on these exceptions being tossed in TorqueBox when a database doe

### DIFF
--- a/lib/arjdbc/mysql/adapter.rb
+++ b/lib/arjdbc/mysql/adapter.rb
@@ -138,24 +138,6 @@ module ::ArJdbc
         "0"
     end
 
-    def begin_db_transaction #:nodoc:
-      @connection.begin
-    rescue Exception
-      # Transactions aren't supported
-    end
-
-    def commit_db_transaction #:nodoc:
-      @connection.commit
-    rescue Exception
-      # Transactions aren't supported
-    end
-
-    def rollback_db_transaction #:nodoc:
-      @connection.rollback
-    rescue Exception
-      # Transactions aren't supported
-    end
-
     def supports_savepoints? #:nodoc:
       true
     end


### PR DESCRIPTION
We rely on these exceptions being tossed in TorqueBox when a database doesn't support transactions. Eating them causes us problems. One could argue that it might lead to surprising results if errors occur in the callbacks around a save. Since InnoDB supports transactions, and it's the default engine starting with MySQL 5.5, I propose we toss exceptions when tx's aren't supported.
