### PR TITLE
Better handle schema dump for mysql year and enum columns

### DIFF
--- a/lib/arjdbc/mysql/adapter.rb
+++ b/lib/arjdbc/mysql/adapter.rb
@@ -42,6 +42,7 @@ module ::ArJdbc
         case field_type
         when /tinyint\(1\)|bit/i then :boolean
         when /enum/i             then :string
+        when /year/i             then :integer
         else
           super
         end
@@ -60,6 +61,7 @@ module ::ArJdbc
           else
             nil # we could return 65535 here, but we leave it undecorated by default
           end
+        when /^enum/i;     255
         when /^bigint/i;    8
         when /^int/i;       4
         when /^mediumint/i; 3


### PR DESCRIPTION
A few minor tweaks to better handle mysql year and enum columns during schema dump

year - treat as int (currently says unknown)

enum - default size to 255 (currently gives it 0 size)

Not sure how this code is maintained in relation to the core Rails mysql adapter - very similar code - but FWIW I have submitted the same patch there too. ( https://github.com/rails/rails/pull/3079 )

But as I am mainly using jruby now, this is more useful to me :)

Thanks.
Chris
