### PR TITLE
Fix LIMIT/OFFSET

### DIFF
--- a/lib/arel/visitors/firebird.rb
+++ b/lib/arel/visitors/firebird.rb
@@ -4,12 +4,19 @@ module Arel
   module Visitors
     class Firebird < Arel::Visitors::ToSql
       def visit_Arel_Nodes_SelectStatement o
-        [
+        lim_off = [
+          ("FIRST #{visit(o.limit.expr)}" if o.limit),
+          ("SKIP #{visit(o.offset.expr)}" if o.offset)
+        ].compact.join(' ').strip
+
+        sql = [
          o.cores.map { |x| visit_Arel_Nodes_SelectCore x }.join,
          ("ORDER BY #{o.orders.map { |x| visit x }.join(', ')}" unless o.orders.empty?),
-         ("ROWS #{limit_for(o.limit)} " if o.limit),
-         ("TO #{o.offset} " if o.offset),
         ].compact.join ' '
+
+        sql.sub!(/\A(\s*SELECT\s)/i, '\&' + lim_off + ' ') unless lim_off.empty?
+
+        sql
       end
 
     end


### PR DESCRIPTION
Firebird LIMIT/OFFSET equivalents are FIRST/SKIP. ROWS/TO has other meaning
so now the code  Post.limit(5).offset(20).count will return 5 as expected.
