### PR TITLE
Enhance the 'change_column' in H2 adapter to support additional options(:null, :default)

### DIFF
--- a/test/h2_change_column_test.rb
+++ b/test/h2_change_column_test.rb
@@ -1,0 +1,68 @@
+require 'jdbc_common'
+require 'db/h2'
+
+class H2ChangeColumnTest < Test::Unit::TestCase
+
+  class Person < ActiveRecord::Base; end
+
+  class CreatePeopleTable < ActiveRecord::Migration
+    def self.up
+      create_table :people do |t|
+        t.integer :phone
+      end
+    end
+
+    def self.down
+      drop_table :people
+    end
+  end
+
+  def setup
+    CreatePeopleTable.up
+  end
+
+  def teardown
+    CreatePeopleTable.down
+  end
+
+  def test_should_change_column_type
+    ActiveRecord::Migration.change_column :people, :phone, :string
+    Person.reset_column_information
+
+    p = Person.create!(:phone => 'ABC')
+    assert_equal 'ABC', p.phone
+  end
+
+  def test_sets_defaults_on_column
+    ActiveRecord::Migration.change_column :people, :phone, :string, :default => '123456'
+    Person.reset_column_information
+
+    p = Person.create!
+    assert_equal '123456', p.phone
+  end
+
+  def test_should_change_column_default_value
+    ActiveRecord::Migration.add_column    :people, :email, :string, :default => 'foo@example.com'
+    ActiveRecord::Migration.change_column :people, :email, :string, :default => 'bar@example.com'
+    Person.reset_column_information
+
+    p = Person.create!
+    assert_equal 'bar@example.com', p.email
+  end
+
+  def test_should_set_non_null_restriction
+    ActiveRecord::Migration.change_column :people, :phone, :string, :null => false
+    Person.reset_column_information
+    assert_raises(ActiveRecord::StatementInvalid) { Person.create! }
+  end
+
+  def test_should_set_null_restriction_with_default
+    p = Person.create!
+    ActiveRecord::Migration.change_column :people, :phone, :string, :null => true, :default => '123456'
+    Person.reset_column_information
+
+    assert_nil p.reload.phone
+    assert_equal '123456', Person.create!.phone
+  end
+end
+


### PR DESCRIPTION
I know I was given commit access to the repo a while ago, but I thought I'd run this through a few people just to make sure I'm not doing something crazy :)

This patch adds support to the H2 adapter to be able to handle additional options when performing 'ALTER TABLE ALTER COLUMN' type stuff to make it more compliant with rails.
