### PR TITLE
I have fixed some bugs for oracle inserts under rails 3.1

### DIFF
--- a/lib/arjdbc/oracle/adapter.rb
+++ b/lib/arjdbc/oracle/adapter.rb
@@ -183,7 +183,6 @@ module ::ArJdbc
 		id_col[1] = id_value if id_col
         log(sql.to_sql, name) do
 		  execute sql, name, binds
-          #@connection.execute_id_insert(sql.to_sql,id_value)
         end
       end
       id_value


### PR DESCRIPTION
The oracle code to fetch a sequence value and then insert was horribly broken under rails 3.1. I have a fix, please consider it and integrate if appropriate.
