### PR TITLE
MS SQL adapter uses ParseDate (which was removed from Ruby 1.9)

### DIFF
--- a/lib/arjdbc/mssql/adapter.rb
+++ b/lib/arjdbc/mssql/adapter.rb
@@ -143,15 +143,7 @@ module ::ArJdbc
 
       def cast_to_time(value)
         return value if value.is_a?(Time)
-        time_array = ParseDate.parsedate(value)
-        return nil if !time_array.any?
-        time_array[0] ||= 2000
-        time_array[1] ||= 1
-        time_array[2] ||= 1
-        return Time.send(ActiveRecord::Base.default_timezone, *time_array) rescue nil
-
-        # Try DateTime instead - the date may be outside the time period support by Time.
-        DateTime.new(*time_array[0..5]) rescue nil
+        DateTime.parse(value).to_time rescue nil
       end
 
       def cast_to_date(value)


### PR DESCRIPTION
When running JRuby in 1.9 mode, the MS SQL adapter will ultimately return nil (but a NameError uninitialized constant for ParseDate will be thrown) for any date related columns.

My change uses Ruby's DateTime.parse(...).to_time to return a Time object. This change works for me locally running SQL Server 2008.  I'll be the first to admit I'm new to Ruby, so any feedback that you can provide would be great.  I'm hoping this will at least get a conversation started to add support for JRuby's 1.9 mode.

As a side note, I believe this issue also affects the DB2 adapter, which was mentioned briefly in this issue:  https://github.com/jruby/activerecord-jdbc-adapter/pull/70

Thanks!

Bill
