### PR TITLE
Improve performance by avoiding "TypeError: can't dup Fixnum" exceptions.

### DIFF
--- a/lib/arjdbc/jdbc/connection.rb
+++ b/lib/arjdbc/jdbc/connection.rb
@@ -107,7 +107,11 @@ module ActiveRecord
         types = {}
         @native_types.each_pair do |k, v|
           types[k] = v.inject({}) do |memo, kv|
-            memo[kv.first] = begin kv.last.dup rescue kv.last end
+            memo[kv.first] = if kv.last.is_a? Numeric
+                               kv.last
+                             else
+                               begin kv.last.dup rescue kv.last end
+                             end
             memo
           end
         end


### PR DESCRIPTION
While chasing excess exceptions in our Rails application, I used the JRuby options:
-Xlog.exceptions=true -Xlog.backtraces=true -Xlog.callers=true

I see many exceptions like this:

Backtrace generated:
TypeError: can't dup Fixnum
                      dup at org/jruby/RubyKernel.java:1784
         dup_native_types at /home/adams/.rvm/gems/jruby-head@cxo/gems/activerecord-jdbc-adapter-1.2.1/lib/arjdbc/jdbc/connection.rb:110
                     each at org/jruby/RubyHash.java:1181
                   inject at org/jruby/RubyEnumerable.java:807
         dup_native_types at /home/adams/.rvm/gems/jruby-head@cxo/gems/activerecord-jdbc-adapter-1.2.1/lib/arjdbc/jdbc/connection.rb:109
                each_pair at org/jruby/RubyHash.java:1211
         dup_native_types at /home/adams/.rvm/gems/jruby-head@cxo/gems/activerecord-jdbc-adapter-1.2.1/lib/arjdbc/jdbc/connection.rb:108
                 adapter= at /home/adams/.rvm/gems/jruby-head@cxo/gems/activerecord-jdbc-adapter-1.2.1/lib/arjdbc/jdbc/connection.rb:99
               initialize at /home/adams/.rvm/gems/jruby-head@cxo/gems/activerecord-jdbc-adapter-1.2.1/lib/arjdbc/jdbc/adapter.rb:39
          jdbc_connection at /home/adams/.rvm/gems/jruby-head@cxo/gems/activerecord-jdbc-adapter-1.2.1/lib/arjdbc/jdbc/connection_methods.rb:6
    postgresql_connection at /home/adams/.rvm/gems/jruby-head@cxo/gems/activerecord-jdbc-adapter-1.2.1/lib/arjdbc/postgresql/connection_methods.rb:15
