### PR TITLE
Fix for running tests on activerecord 2.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source "http://rubygems.org"
 # This may wreak havoc on the lockfile, but we need a way to test
 # different AR versions
 gem 'activerecord', ENV['AR_VERSION']
+gem 'rails', ENV['AR_VERSION']
 
 gem 'rake'
 

--- a/test/abstract_db_create.rb
+++ b/test/abstract_db_create.rb
@@ -83,7 +83,7 @@ module AbstractDbCreate
     ar_version = $LOADED_FEATURES.grep(%r{active_record/version}).first
     ar_lib_path = $LOAD_PATH.detect {|p| p if File.exist?File.join(p, ar_version)}
     ar_lib_path = ar_lib_path.sub(%r{activerecord/lib}, 'railties/lib') # edge rails
-    rails_lib_path = ar_lib_path.sub(/activerecord-([^\/]+)/, 'rails-\1') # gem rails
+    rails_lib_path = ar_lib_path.sub(/activerecord-([\d\.]+)/, 'rails-\1') # gem rails
     load "#{rails_lib_path}/tasks/databases.rake"
   end
 


### PR DESCRIPTION
Out of the box the tests will not run to test against activerecord 2.x.

1) Gemfile update to put in rails
2) fix regex for path munging to find databases.rake
