### PR TITLE
Fix Support for Ar 3.2.1

### DIFF
--- a/lib/arjdbc/db2/adapter.rb
+++ b/lib/arjdbc/db2/adapter.rb
@@ -8,7 +8,11 @@ module ArJdbc
               lobfields = self.class.columns.select { |c| c.sql_type =~ /blob|clob/i }
               lobfields.each do |c|
                 value = self[c.name]
-                value = value.to_yaml if unserializable_attribute?(c.name, c)
+                if respond_to?(:unserializable_attribute?)
+                  value = value.to_yaml if unserializable_attribute?(c.name, c)
+                else
+                  value = value.to_yaml if value.is_a?(Hash)
+                end
                 next if value.nil?
                 connection.write_large_object(c.type == :binary, c.name, self.class.table_name, self.class.primary_key, quote_value(id), value)
               end

--- a/lib/arjdbc/firebird/adapter.rb
+++ b/lib/arjdbc/firebird/adapter.rb
@@ -7,7 +7,11 @@ module ::ArJdbc
           def after_save_with_firebird_blob
             self.class.columns.select { |c| c.sql_type =~ /blob/i }.each do |c|
               value = self[c.name]
-              value = value.to_yaml if unserializable_attribute?(c.name, c)
+              if respond_to?(:unserializable_attribute?)
+                value = value.to_yaml if unserializable_attribute?(c.name, c)
+              else
+                value = value.to_yaml if value.is_a?(Hash)
+              end
               next if value.nil?
               connection.write_large_object(c.type == :binary, c.name, self.class.table_name, self.class.primary_key, quote_value(id), value)
             end

--- a/lib/arjdbc/informix/adapter.rb
+++ b/lib/arjdbc/informix/adapter.rb
@@ -8,7 +8,11 @@ module ::ActiveRecord
         self.class.columns.each do |c|
           if [:text, :binary].include? c.type
             value = self[c.name]
-            value = value.to_yaml if unserializable_attribute?(c.name, c)
+            if respond_to?(:unserializable_attribute?)
+              value = value.to_yaml if unserializable_attribute?(c.name, c)
+            else
+              value = value.to_yaml if value.is_a?(Hash)
+            end
 
             unless value.nil? || (value == '')
               connection.write_large_object(c.type == :binary,

--- a/lib/arjdbc/oracle/adapter.rb
+++ b/lib/arjdbc/oracle/adapter.rb
@@ -10,7 +10,11 @@ module ::ArJdbc
           def after_save_with_oracle_lob
             self.class.columns.select { |c| c.sql_type =~ /LOB\(|LOB$/i }.each do |c|
               value = self[c.name]
-              value = value.to_yaml if unserializable_attribute?(c.name, c)
+              if respond_to?(:unserializable_attribute?)
+                value = value.to_yaml if unserializable_attribute?(c.name, c)
+              else
+                value = value.to_yaml if value.is_a?(Hash)
+              end
               next if value.nil?  || (value == '')
 
               connection.write_large_object(c.type == :binary, c.name, self.class.table_name, self.class.primary_key, quote_value(id), value)


### PR DESCRIPTION
the method unserializable_attribute? no longer exists in Ar 3.2.1. New store engine returns the value as a hash, so we convert it before write the BLOB
