### PR TITLE
return nil if using jndi and schema/user is not set

### DIFF
--- a/lib/arjdbc/db2/adapter.rb
+++ b/lib/arjdbc/db2/adapter.rb
@@ -502,9 +502,14 @@ module ArJdbc
           # AS400 implementation takes schema from library name (last part of url)
           schema = @config[:url].split('/').last.strip
           (schema[-1..-1] == ";") ? schema.chop : schema
-        else
+        elsif @config[:username].present?
           # LUW implementation uses schema name of username by default
-          @config[:username] or ENV['USER']
+          @config[:username]
+        elsif @config[:jndi].present?
+          # let jndi worry about schema
+          nil
+        else
+          ENV['USER']
         end
       else
         @config[:schema]


### PR DESCRIPTION
This pull request is for an issue where the db2 driver tries to set the schema, even if it's already set in the JNDI connection. This causes an error stating that a table does not exist.
