### PR TITLE
INSERT..RETURNING fix related to rails 3.2.2, postgresql 8.2 chop suey

### DIFF
--- a/lib/arjdbc/postgresql/adapter.rb
+++ b/lib/arjdbc/postgresql/adapter.rb
@@ -459,7 +459,7 @@ module ::ArJdbc
 
     # take id from result of insert query
     def last_inserted_id(result)
-      Hash[Array(*result)].fetch("id") { result }
+      Hash[Array(*result)].fetch("id") { result.class.to_s == 'Fixnum' ? result : Hash[Array(*result)].first[1] }
     end
 
     def last_insert_id(table, sequence_name)


### PR DESCRIPTION
Postgresql 8.2 does not return a column named 'id' for INSERT ... RETURNING "myid"'.  Instead, it is the column name of the primary key: 'myid'.  Therefore, it was impossible to insert new rows into any table not using a column named 'id' for the primary key.  This was exposed by a recent upgrade to rails 3.2.2 from 3.1.3. So to make it work the way it was AND support Postgresql 8.2, a result's column type is tested to see if it's a number.  If so, return otherwise (Postgresql 8.2) grab the first key from hash (returned as an array) and grab the 2nd element (the value).  Sadly, I cannot upgrade postgresql; rails 3.2.2 requires 1.2.2.
Please accept.
