### PR TITLE
Remove count distinct restriction from postgresql adapter to match native ruby adapter.

### DIFF
--- a/lib/arjdbc/postgresql/adapter.rb
+++ b/lib/arjdbc/postgresql/adapter.rb
@@ -235,10 +235,6 @@ module ::ArJdbc
       true
     end
 
-    def supports_count_distinct? #:nodoc:
-      false
-    end
-
     def create_savepoint
       execute("SAVEPOINT #{current_savepoint_name}")
     end


### PR DESCRIPTION
Remove count distinct restriction from postgresql adapter to match native ruby adapter.

Fixes query errors with count distinct. See http://www.redmine.org/issues/10336
