### PR TITLE
sql server 2000 doesn't contain a sys.view table - fix broken test

### DIFF
--- a/test/mssql_ignore_system_views_test.rb
+++ b/test/mssql_ignore_system_views_test.rb
@@ -8,8 +8,13 @@ class IgnoreSystemViewsTest < Test::Unit::TestCase
   include MigrationSetup
 
   def test_system_views_ignored
-    assert_equal true, table_exists?("sys.views"), %{table_exists?("sys.views")}
-    assert_equal true, table_exists?("information_schema.views"), %{table_exists?("information_schema.views")}
+    if ActiveRecord::Base.connection.sqlserver_version == "2000"
+      assert_equal false, table_exists?("sys.views"), %{table_exists?("sys.views")}
+      assert_equal false, table_exists?("information_schema.views"), %{table_exists?("information_schema.views")}
+    else
+      assert_equal true, table_exists?("sys.views"), %{table_exists?("sys.views")}
+      assert_equal true, table_exists?("information_schema.views"), %{table_exists?("information_schema.views")}
+    end
     assert_equal false, table_exists?("dbo.views"), %{table_exists?("dbo.views")}
     assert_equal false, table_exists?(:views), %{table_exists?(:views)}
     ActiveRecord::Schema.define { suppress_messages { create_table :views } }


### PR DESCRIPTION
The sys.view test assumes that the sys.view table exists in all versions of SQL Server. It doesn't exist in SQL Server 2000, I've updated the expected value for that version of the database.
