### PR TITLE
fix row_number errors on SQL Server 2000

### DIFF
--- a/lib/arjdbc/mssql/limit_helpers.rb
+++ b/lib/arjdbc/mssql/limit_helpers.rb
@@ -57,7 +57,7 @@ module ::ArJdbc
           if options[:limit]
             order = "ORDER BY #{options[:order] || determine_order_clause(sql)}"
             sql.sub!(/ ORDER BY.*$/i, '')
-            SqlServerReplaceLimitOffset.replace_limit_offset!(sql, options[:limit], options[:offset], order)
+            SqlServer2000ReplaceLimitOffset.replace_limit_offset!(sql, options[:limit], options[:offset], order)
           end
         end
       end


### PR DESCRIPTION
SqlServer2000AddLimitOffset was calling the wrong version of ReplaceLimitOffset  This fixes issue #143. 

This fix clears up 23 errors from the rails23 test suite. All tests continue to pass in rails30 and rails32. 

Rails31 removes 39 errors but only when sqlserver_version is explicitly set to 2000 in the database config. This may highlights a possible bug in another issue - I intend to take a look later. But without this set rails31 will fail, unlike rails23, rails30 and rails32 which don't require this explicit setting.
