### PR TITLE
mssql: Fix pessimistic locking

### DIFF
--- a/lib/arel/visitors/sql_server.rb
+++ b/lib/arel/visitors/sql_server.rb
@@ -37,6 +37,13 @@ module Arel
         add_lock!(sql, :lock => o.lock && true)
         sql
       end
+
+      # MS-SQL doesn't support "SELECT...FOR UPDATE".  Instead, it needs
+      # WITH(ROWLOCK,UPDLOCK) specified after each table in the FROM clause.
+      #
+      # So, we return nothing here and add the appropriate stuff using add_lock! above.
+      def visit_Arel_Nodes_Lock o
+      end
     end
 
     class SQLServer2000 < SQLServer

--- a/test/row_locking.rb
+++ b/test/row_locking.rb
@@ -4,6 +4,12 @@ require 'thread'
 
 module RowLockingTestMethods
 
+  # Simple SELECT ... FOR UPDATE test
+  def test_select_all_for_update
+    @row1_id = Entry.create!(:title => "row1").id
+    assert Entry.lock(true).all.map{|row| row.id}.include?(@row1_id)
+  end
+
   def test_row_locking
     row_locking_test_template
   end


### PR DESCRIPTION
This fixes the error:

  ActiveRecord::StatementInvalid: ActiveRecord::JDBCError: Line 1: FOR UPDATE clause allowed only for DECLARE CURSOR.

when executing code like this:

  Entry.lock(true).all

Before, it would generate SQL like this:

  SELECT [entries].\* FROM [entries]  FOR UPDATE WITH(ROWLOCK,UPDLOCK)

Now, it generates SQL like this:

  SELECT [entries].\* FROM [entries]  WITH(ROWLOCK,UPDLOCK)
