### PR TITLE
Update PG: rename sequence during table rename

### DIFF
--- a/lib/arjdbc/postgresql/adapter.rb
+++ b/lib/arjdbc/postgresql/adapter.rb
@@ -623,6 +623,11 @@ module ::ArJdbc
 
     def rename_table(name, new_name)
       execute "ALTER TABLE #{name} RENAME TO #{new_name}"
+      pk, seq = pk_and_sequence_for(new_name)
+      if seq == "#{name}_#{pk}_seq"
+        new_seq = "#{new_name}_#{pk}_seq"
+        execute "ALTER TABLE #{quote_table_name(seq)} RENAME TO #{quote_table_name(new_seq)}"
+      end
     end
 
     # Adds a new column to the named table.


### PR DESCRIPTION
This keeps the ARJDBC implementation behavior in sync with Rails' Active Record following the acceptance of rails/rails#6874 update to Rails master and rails/rails#7031 backport to 3.2.

This runs fine within the activerecord-jdbc-adapter tests, but I am having difficulty running the Active Record test suite under jruby + activerecord-jdbc-adapter with or without this change. Given that, this is probably in some need of review.
