### PR TITLE
Detect identity columns in db2 structure_dump

### DIFF
--- a/lib/arjdbc/db2/adapter.rb
+++ b/lib/arjdbc/db2/adapter.rb
@@ -467,13 +467,15 @@ module ArJdbc
             col_size = "(#{col_precision})"
           end
           nulling = (rs2.getString(18) == 'NO' ? " NOT NULL" : "")
+          autoincrement = (rs2.getString(23) == 'YES' ? " GENERATED ALWAYS AS IDENTITY" : "")
           create_col_string = add_quotes(expand_double_quotes(strip_quotes(col_name))) +
             " " +
             type +
             col_size +
             "" +
             nulling +
-            default
+            default +
+            autoincrement
           if !first_col
             create_col_string = ",\n #{create_col_string}"
           else


### PR DESCRIPTION
Suggested fix for #208. Adds a test for JDBC getColumns field 23,
IS_AUTOINCREMENT. If 'YES', assume GENERATED ALWAYS AS IDENTITY for the
column (don't believe the JDBC adapter reports this with any more
granularity, see JDBC API docs: http://bit.ly/LxjW8f).
