### PR TITLE
Add full support for alternate schemas

### DIFF
--- a/lib/arjdbc/jdbc/jdbc.rake
+++ b/lib/arjdbc/jdbc/jdbc.rake
@@ -113,7 +113,7 @@ namespace :db do
       filename = ENV['DB_STRUCTURE'] || "db/#{rails_env}_structure.sql"
       IO.read(filename).split(/;\n*/m).each do |ddl|
         unless abcs[rails_env][:schema].blank?
-          ddl.sub! /((CREATE|ALTER) TABLE )(\w+)/i, "\\1#{abcs[rails_env][:schema].upcase}.\\3"
+          ddl.sub! /((CREATE|ALTER) TABLE |INSERT INTO )(\w+)/i, "\\1#{abcs[rails_env][:schema].upcase}.\\3"
         end
         ActiveRecord::Base.connection.execute(ddl)
       end


### PR DESCRIPTION
Currently there seem to be quite a few operations where the schema is not specified, and thus the default schema will be used. So if you specify anything other than the default schema in the database config, errors abound.

Would be good to add full support for this.
