### PR TITLE
Port of lexrupy's fix for rails 3.2 for oracle

### DIFF
--- a/lib/arjdbc/oracle/adapter.rb
+++ b/lib/arjdbc/oracle/adapter.rb
@@ -10,10 +10,12 @@ module ::ArJdbc
           def after_save_with_oracle_lob
             self.class.columns.select { |c| c.sql_type =~ /LOB\(|LOB$/i }.each do |c|
               value = self[c.name]
-              if respond_to?(:unserializable_attribute?)
-                value = value.to_yaml if unserializable_attribute?(c.name, c)
-              else
-                value = value.to_yaml if value.is_a?(Hash)
+              if coder = self.class.serialized_attributes[c.name]
+                if coder.respond_to?(:dump)
+                  value = coder.dump(value)
+                else
+                  value = value.to_yaml
+                end
               end
               next if value.nil?  || (value == '')
 


### PR DESCRIPTION
I've ported lexrupy's pull request #167 with the fix for the "unserializable_attribute?" error for oracle.

Sadly i wasn't able to run the tests as i don't use it within a rails application. I use activerecord as a standalone plugin for one of my jruby projects but i've tested it with my real world application and got rid of the error message mentioned above.
