### PR TITLE
substitute_binds was calling reverse on bindings (e.g. abcd -> dcba)

### DIFF
--- a/lib/arjdbc/jdbc/adapter.rb
+++ b/lib/arjdbc/jdbc/adapter.rb
@@ -199,7 +199,7 @@ module ActiveRecord
           sql
         else
           copy = binds.dup
-          sql.gsub('?') { quote(*copy.shift.reverse) }
+          sql.gsub('?') { quote(copy.shift) }
         end
       end
 

--- a/test/simple.rb
+++ b/test/simple.rb
@@ -100,6 +100,12 @@ end
 module SimpleTestMethods
   include FixtureSetup
 
+  def test_substitute_binds_does_substitutions_in_correct_order_without_corruption
+    binds = ['foo', 'bar', 'baz']
+    sql = 'select * from entries where a = ? and b = ? and c = ?'
+    assert_match /foo.*bar.*baz/, Entry.connection.substitute_binds(sql, binds)
+  end
+  
   def test_substitute_binds_has_no_side_effect_on_binds_parameter
     binds = [[Entry.columns_hash['title'], 'test1']]
     binds2 = binds.dup


### PR DESCRIPTION
BTW... Did I miss something with setting up my development environment so I can run the activerecord-jdbc-adapter tests? It was ridiculously slow. I wound up having to comment out all other tests just to get the test run down to 1 minute. Attempting to run just oracle_simple_test with the command below took about 16 minutes. That's not typical right?

$  BUNDLE_GEMFILE=/Users/Shared/lenny/build/activerecord-jdbc-adapter/gemfiles/rails30.gemfile bundle exec /Users/Shared/RubyGems/bin/rake test_oracle TEST=test/oracle_simple_test
No "postgres" role? You might need to execute `createuser postgres -drs' first.
Using activerecord version 3.0.17
Loaded suite /Users/Shared/RubyGems/gems/rake-0.9.2.2/lib/rake/rake_test_loader
Started
...............................................
Finished in 997.658000 seconds.

47 tests, 65 assertions, 0 failures, 0 errors, 0 skips

Test run options: --seed 27194
Loaded suite /Users/Shared/RubyGems/bin/rake
Started

Finished in 0.000000 seconds.

0 tests, 0 assertions, 0 failures, 0 errors, 0 skips

Test run options: --seed 65156
     1030.39 real       103.31 user        15.87 sys
