### PR TITLE
Don't barf on the datetime2 data type when connecting to MS SQL 2008

### DIFF
--- a/lib/arjdbc/jdbc/type_converter.rb
+++ b/lib/arjdbc/jdbc/type_converter.rb
@@ -48,7 +48,7 @@ module ActiveRecord
                           lambda {|r| r['type_name'] =~ /^integer/i}],  #Num of milliseconds for SQLite3 JDBC Driver
         :timestamp   => [ lambda {|r| Jdbc::Types::TIMESTAMP == r['data_type'].to_i},
                           lambda {|r| r['type_name'] =~ /^timestamp$/i},
-                          lambda {|r| r['type_name'] =~ /^datetime/i},
+                          lambda {|r| r['type_name'] =~ /^datetime$/i},
                           lambda {|r| r['type_name'] =~ /^date/i},
                           lambda {|r| r['type_name'] =~ /^integer/i}],  #Num of milliseconds for SQLite3 JDBC Driver
         :time        => [ lambda {|r| Jdbc::Types::TIME == r['data_type'].to_i},


### PR DESCRIPTION
Don't barf on the datetime2 data type when connecting to MS SQL 2008
