### PR TITLE
JDBCError in jdbc/connection.rb misses exception information

### DIFF
--- a/lib/arjdbc/jdbc/connection.rb
+++ b/lib/arjdbc/jdbc/connection.rb
@@ -88,7 +88,7 @@ module ActiveRecord
       rescue ::ActiveRecord::ActiveRecordError
         raise
       rescue Exception => e
-        raise ::ActiveRecord::JDBCError.new("The driver encountered an unknown error: #{e}").tap { |err|
+        raise ::ActiveRecord::JDBCError.new("The driver encountered an unknown error: #{e.inspect}").tap { |err|
           err.errno = 0
           err.sql_exception = e
         }


### PR DESCRIPTION
JDBCError should say what type of exception was thrown.

In trying to use this module with VoltDB and JRuby,
I got the following error message which really didn't help me.

"ActiveRecord::JDBCError: The driver encountered an unknown error: "
<stacktrace>

Instead, after this change, I got:
"ActiveRecord::JDBCError: The driver encountered an unknown error: java.sql.SQLFeatureNotSupportedException"

which helps me make a more informed decision about my next action
