### PR TITLE
consolidate modify_types methods across different places in the code

### DIFF
--- a/lib/arjdbc/mssql/adapter.rb
+++ b/lib/arjdbc/mssql/adapter.rb
@@ -64,11 +64,17 @@ module ::ArJdbc
     def modify_types(tp) #:nodoc:
       super(tp)
       tp[:string] = {:name => "NVARCHAR", :limit => 255}
+
       if sqlserver_version == "2000"
         tp[:text] = {:name => "NTEXT"}
       else
         tp[:text] = {:name => "NVARCHAR(MAX)"}
       end
+
+      tp[:primary_key] = "int NOT NULL IDENTITY(1, 1) PRIMARY KEY"
+      tp[:integer][:limit] = nil
+      tp[:boolean] = {:name => "bit"}
+      tp[:binary] = {:name => "image"}
       tp
     end
 

--- a/lib/arjdbc/mssql/tsql_helper.rb
+++ b/lib/arjdbc/mssql/tsql_helper.rb
@@ -1,14 +1,6 @@
 # Common methods for handling TSQL databases.
 module TSqlMethods
 
-  def modify_types(tp) #:nodoc:
-    tp[:primary_key] = "int NOT NULL IDENTITY(1, 1) PRIMARY KEY"
-    tp[:integer][:limit] = nil
-    tp[:boolean] = {:name => "bit"}
-    tp[:binary] = { :name => "image"}
-    tp
-  end
-
   def type_to_sql(type, limit = nil, precision = nil, scale = nil) #:nodoc:
     limit = nil if %w(text binary).include? type.to_s
     return 'uniqueidentifier' if (type.to_s == 'uniqueidentifier')


### PR DESCRIPTION
There really isn't a good reason to have this logic spread out across the class and module. The only place this code is used is from the class itself. Tests continue to pass.
