### PR TITLE
Raise exception with user-friendly message when offset is specified but limit is not under MsSQL adapter

### DIFF
--- a/lib/arel/visitors/sql_server.rb
+++ b/lib/arel/visitors/sql_server.rb
@@ -15,6 +15,9 @@ module Arel
       # Need to mimic the subquery logic in ARel 1.x for select count with limit
       # See arel/engines/sql/compilers/mssql_compiler.rb for details
       def visit_Arel_Nodes_SelectStatement o
+        if !o.limit && o.offset
+          raise ActiveRecord::ActiveRecordError, "You must specify :limit with :offset."
+        end
         order = "ORDER BY #{o.orders.map { |x| visit x }.join(', ')}" unless o.orders.empty?
         if o.limit
           if select_count?(o)

--- a/test/mssql_limit_offset_test.rb
+++ b/test/mssql_limit_offset_test.rb
@@ -162,5 +162,15 @@ class MsSQLLimitOffsetTest < Test::Unit::TestCase
     assert_equal(["Adam", "Carl", "Ben"], vikings.map(&:name))
 
   end
-  
+ 
+  def test_offset_without_limit
+    %w(one two three four five six seven eight).each do |name|
+      LongShip.create!(:name => name)
+    end
+    error = assert_raise ActiveRecord::ActiveRecordError do
+      LongShip.find(:all, :offset => 2)
+    end
+    assert_equal("You must specify :limit with :offset.", error.message)
+  end
+
 end


### PR DESCRIPTION
Current MsSQL implementation to support :offset needs to be used with :limit option.
But if :limit option isn't present, the query is executed and users get the InvalidStatement Exception.
This error message is not user-friendly to notice users that :limit option is needed.

This patch raises ActiveRecordError with a message which notices users that :limit option is also needed.
