### PR TITLE
Fixing substring issue that prevents detecting a query that contains *

### DIFF
--- a/lib/arjdbc/mssql/limit_helpers.rb
+++ b/lib/arjdbc/mssql/limit_helpers.rb
@@ -97,7 +97,7 @@ module ::ArJdbc
             if rest_of_query[0...1] == "1" && rest_of_query !~ /1 AS/i
               rest_of_query[0] = "*"
             end
-            if rest_of_query[0] == "*"
+            if rest_of_query[0...1] == "*"
               from_table = LimitHelpers.get_table_name(rest_of_query)
               rest_of_query = from_table + '.' + rest_of_query
             end


### PR DESCRIPTION
This fixes issue #171 by properly detecting the case where a query begins with an asterisk so that the table name is prefixed.

Sorry there are no tests for this as I am not sure how to add tests for this project. I'm happy to add them with a bit of guidance.
