### PR TITLE
Tell Postgres to accept backslashes in strings.

### DIFF
--- a/lib/arjdbc/postgresql/connection_methods.rb
+++ b/lib/arjdbc/postgresql/connection_methods.rb
@@ -14,6 +14,7 @@ class ActiveRecord::Base
       config[:adapter_spec] = ::ArJdbc::PostgreSQL
       conn = jdbc_connection(config)
       conn.execute("SET SEARCH_PATH TO #{config[:schema_search_path]}") if config[:schema_search_path]
+      conn.execute("SET standard_conforming_strings=off")
       conn
     end
     alias_method :jdbcpostgresql_connection, :postgresql_connection


### PR DESCRIPTION
This was the default prior to 9.1, but as of 9.1 a backslash in a Postgres string is just a backslash, unless you say `SET standard_conforming_strings=off`.

Please see my bug report for why this is a problem:

https://github.com/jruby/activerecord-jdbc-adapter/issues/247

This change should have no effect on users running older versions of Postgres, but will fix the escaping problem for users running 9.1+.
