### PR TITLE
Correct an error with Time type with H2 and HSQLDB

### DIFF
--- a/lib/arjdbc/hsqldb/adapter.rb
+++ b/lib/arjdbc/hsqldb/adapter.rb
@@ -57,7 +57,7 @@ module ::ArJdbc
       tp[:string][:limit] = 255
       tp[:datetime] = { :name => "DATETIME" }
       tp[:timestamp] = { :name => "DATETIME" }
-      tp[:time] = { :name => "TIME" }
+      tp[:time] = { :name => "DATETIME" }
       tp[:date] = { :name => "DATE" }
       tp
     end


### PR DESCRIPTION
H2 and HSQLDB are strict about time format. Rails store time with date value and their databases doesn't support this. 
