### PR TITLE
Added sqlite3 EXPLAIN support borrowed heavily from rails/activerecord

### DIFF
--- a/test/sqlite3_simple_test.rb
+++ b/test/sqlite3_simple_test.rb
@@ -236,6 +236,18 @@ class SQLite3SimpleTest < Test::Unit::TestCase
   ensure
     @connection.drop_table :xml_testings rescue nil
   end
+  
+  def test_supports_explain
+    assert_nothing_raised do
+      assert_equal @connection.supports_explain?, true
+    end
+  end
+  
+  def test_explain
+    assert_nothing_raised do
+      Entry.joins(:user).explain
+    end
+  end
 end
 
 # assert_raise ActiveRecord::RecordInvalid do


### PR DESCRIPTION
Added EXPLAIN QUERY PLAN support for the jdbcsqlite3 driver, borrowed heavily from the activerecord/sqlite3 and jdbcmysql support already in place
