### PR TITLE
 Oracle has a 1000 entry in clause limit. 

### DIFF
--- a/lib/arjdbc/oracle/adapter.rb
+++ b/lib/arjdbc/oracle/adapter.rb
@@ -34,8 +34,14 @@ module ::ArJdbc
       (class << mod; self; end).class_eval do
         alias_chained_method :insert, :query_dirty, :ora_insert
         alias_chained_method :columns, :query_cache, :ora_columns
+        
+        # Prevent ORA-01795 for in clauses with more than 1000 
+        def in_clause_length
+          1000
+        end
       end
     end
+    
 
     def self.column_selector
       [/oracle/i, lambda {|cfg,col| col.extend(::ArJdbc::Oracle::Column)}]

--- a/test/oracle_limit_test.rb
+++ b/test/oracle_limit_test.rb
@@ -1,0 +1,23 @@
+require 'jdbc_common'
+require 'db/oracle'
+
+class OracleLimitTest < Test::Unit::TestCase
+  include FixtureSetup
+
+  def setup
+    super
+
+    1010.times do |n|
+      Entry.create!(:user => User.create!(:login => "Test User#{n}"),
+                    :title => "Entry #{n}", 
+                    :rating => n, 
+                    :content => "Testing Content #{n}")
+    end  
+  end
+   
+  def test_oracle_limit_properly_handled
+    assert_nothing_thrown do 
+      Entry.includes(:user).all
+    end
+  end 
+end 


### PR DESCRIPTION
Updating oracle driver to properly handle Oracle's 1000 entry limit. 
