### PR TITLE
exposing the driver_jar instead of (auto) loading it in jdbc-* gems 

### DIFF
--- a/activerecord-jdbcpostgresql-adapter/lib/active_record/connection_adapters/jdbcpostgresql_adapter.rb
+++ b/activerecord-jdbcpostgresql-adapter/lib/active_record/connection_adapters/jdbcpostgresql_adapter.rb
@@ -1,1 +1,2 @@
 require 'arjdbc/postgresql'
+Jdbc::Postgres.load_driver(:require)

--- a/activerecord-jdbcsqlite3-adapter/lib/active_record/connection_adapters/jdbcsqlite3_adapter.rb
+++ b/activerecord-jdbcsqlite3-adapter/lib/active_record/connection_adapters/jdbcsqlite3_adapter.rb
@@ -1,1 +1,2 @@
 require 'arjdbc/sqlite3'
+Jdbc::SQLite3.load_driver(:require)

--- a/jdbc-postgres/lib/jdbc/postgres.rb
+++ b/jdbc-postgres/lib/jdbc/postgres.rb
@@ -2,12 +2,18 @@ module Jdbc
   module Postgres
     VERSION = "9.2.1002"
 
-    def self.require_driver_jar
-      vers  = VERSION.split( '.' )
-      vers << jdbc_version
-      require( "postgresql-%s.%s-%s.jdbc%d.jar" % vers )
+    def self.driver_jar
+      version_jdbc_version = VERSION.split( '.' )
+      version_jdbc_version << jdbc_version
+      'postgresql-%s.%s-%s.jdbc%d.jar' % version_jdbc_version
+    end
+    
+    def self.load_driver(method = :load)
+      send method, driver_jar
     end
 
+    private
+    
     # JDBC version 4 if Java >=1.6, else 3
     def self.jdbc_version
       vers = Java::java.lang.System::get_property( "java.specification.version" )
@@ -18,8 +24,6 @@ module Jdbc
   end
 end
 
-if RUBY_PLATFORM =~ /java/
-  Jdbc::Postgres::require_driver_jar
-elsif $VERBOSE
-  warn "jdbc-postgres is only for use with JRuby"
+if $VERBOSE && (JRUBY_VERSION.nil? rescue true)
+  warn "Jdbc-Postgres is only for use with JRuby"
 end

--- a/jdbc-sqlite3/lib/jdbc/sqlite3.rb
+++ b/jdbc-sqlite3/lib/jdbc/sqlite3.rb
@@ -1,10 +1,18 @@
 module Jdbc
   module SQLite3
     VERSION = "3.7.2"
+    
+    def self.driver_jar
+      "sqlite-jdbc-#{VERSION}.jar"
+    end
+    
+    def self.load_driver(method = :load)
+      send method, driver_jar
+    end
+    
   end
 end
-if RUBY_PLATFORM =~ /java/
-  require "sqlite-jdbc-#{Jdbc::SQLite3::VERSION}.jar"
-elsif $VERBOSE
-  warn "jdbc-SQLite3 is only for use with JRuby"
+
+if $VERBOSE && (JRUBY_VERSION.nil? rescue true)
+  warn "Jdbc-SQLite3 is only for use with JRuby"
 end

--- a/lib/arjdbc/postgresql/connection_methods.rb
+++ b/lib/arjdbc/postgresql/connection_methods.rb
@@ -4,7 +4,8 @@ $LOADED_FEATURES << "active_record/connection_adapters/postgresql_adapter.rb"
 class ActiveRecord::Base
   class << self
     def postgresql_connection(config)
-      require "arjdbc/postgresql"
+      require 'active_record/connection_adapters/jdbcpostgresql_adapter'
+      
       config[:host] ||= "localhost"
       config[:port] ||= 5432
       config[:url] ||= "jdbc:postgresql://#{config[:host]}:#{config[:port]}/#{config[:database]}"
@@ -19,5 +20,3 @@ class ActiveRecord::Base
     alias_method :jdbcpostgresql_connection, :postgresql_connection
   end
 end
-
-

--- a/lib/arjdbc/sqlite3/connection_methods.rb
+++ b/lib/arjdbc/sqlite3/connection_methods.rb
@@ -5,7 +5,7 @@ $LOADED_FEATURES << "active_record/connection_adapters/sqlite3_adapter.rb"
 class ActiveRecord::Base
   class << self
     def sqlite3_connection(config)
-      require "arjdbc/sqlite3"
+      require 'active_record/connection_adapters/jdbcsqlite3_adapter'
 
       parse_sqlite3_config!(config)
       database = config[:database]
@@ -16,6 +16,7 @@ class ActiveRecord::Base
       config[:adapter_spec] = ::ArJdbc::SQLite3
       jdbc_connection(config)
     end
+    alias_method :jdbcsqlite3_connection, :sqlite3_connection
 
     def parse_sqlite3_config!(config)
       config[:database] ||= config[:dbfile]
@@ -29,7 +30,5 @@ class ActiveRecord::Base
         config[:database] = File.expand_path(config[:database], rails_root)
       end
     end
-
-    alias_method :jdbcsqlite3_connection, :sqlite3_connection
   end
 end


### PR DESCRIPTION
this allows for better re-use of the "driver-jar" gems

pls let me know if there are any issues or drawbacks with this refactoring if not I'm willing to **convert all** remaining driver gems ... would be great since than I can re-use all the gems with the trinidad_dbpool extensions (and possibly others can too).
