### PR TITLE
fixed uninitialized constant Jdbc

### DIFF
--- a/activerecord-jdbcderby-adapter/lib/active_record/connection_adapters/jdbcderby_adapter.rb
+++ b/activerecord-jdbcderby-adapter/lib/active_record/connection_adapters/jdbcderby_adapter.rb
@@ -1,2 +1,2 @@
-require 'arjdbc/derby'
+require 'jdbc/derby'
 Jdbc::Derby.load_driver(:require) if Jdbc::Derby.respond_to?(:load_driver)

--- a/activerecord-jdbch2-adapter/lib/active_record/connection_adapters/jdbch2_adapter.rb
+++ b/activerecord-jdbch2-adapter/lib/active_record/connection_adapters/jdbch2_adapter.rb
@@ -1,2 +1,2 @@
-require 'arjdbc/h2'
+require 'jdbc/h2'
 Jdbc::H2.load_driver(:require) if Jdbc::H2.respond_to?(:load_driver)

--- a/activerecord-jdbchsqldb-adapter/lib/active_record/connection_adapters/jdbchsqldb_adapter.rb
+++ b/activerecord-jdbchsqldb-adapter/lib/active_record/connection_adapters/jdbchsqldb_adapter.rb
@@ -1,2 +1,2 @@
-require 'arjdbc/hsqldb'
+require 'jdbc/hsqldb'
 Jdbc::HSQLDB.load_driver(:require) if Jdbc::HSQLDB.respond_to?(:load_driver)

--- a/activerecord-jdbcmssql-adapter/lib/active_record/connection_adapters/jdbcmssql_adapter.rb
+++ b/activerecord-jdbcmssql-adapter/lib/active_record/connection_adapters/jdbcmssql_adapter.rb
@@ -1,4 +1,4 @@
-require 'arjdbc/mssql'
+require 'jdbc/mssql'
 # NOTE: the adapter has only support for working with the
 # open-source jTDS driver (won't work with MS's driver) !
 Jdbc::JTDS.load_driver(:require) if Jdbc::JTDS.respond_to?(:load_driver)

--- a/activerecord-jdbcmysql-adapter/lib/active_record/connection_adapters/jdbcmysql_adapter.rb
+++ b/activerecord-jdbcmysql-adapter/lib/active_record/connection_adapters/jdbcmysql_adapter.rb
@@ -1,2 +1,2 @@
-require 'arjdbc/mysql'
+require 'jdbc/mysql'
 Jdbc::MySQL.load_driver(:require) if Jdbc::MySQL.respond_to?(:load_driver)

--- a/activerecord-jdbcpostgresql-adapter/lib/active_record/connection_adapters/jdbcpostgresql_adapter.rb
+++ b/activerecord-jdbcpostgresql-adapter/lib/active_record/connection_adapters/jdbcpostgresql_adapter.rb
@@ -1,2 +1,2 @@
-require 'arjdbc/postgresql'
+require 'jdbc/postgres'
 Jdbc::Postgres.load_driver(:require) if Jdbc::Postgres.respond_to?(:load_driver)

--- a/activerecord-jdbcsqlite3-adapter/lib/active_record/connection_adapters/jdbcsqlite3_adapter.rb
+++ b/activerecord-jdbcsqlite3-adapter/lib/active_record/connection_adapters/jdbcsqlite3_adapter.rb
@@ -1,2 +1,2 @@
-require 'arjdbc/sqlite3'
+require 'jdbc/sqlite3'
 Jdbc::SQLite3.load_driver(:require) if Jdbc::SQLite3.respond_to?(:load_driver)


### PR DESCRIPTION
I did a release and found that we got into some problem with error 

``` ruby

uninitialized constant Jdbc

```

I think this needs to be fixed and released again.
