### PR TITLE
Correct DB2 schema selection when url has parameters

### DIFF
--- a/lib/arjdbc/db2/adapter.rb
+++ b/lib/arjdbc/db2/adapter.rb
@@ -541,8 +541,8 @@ module ArJdbc
       if @config[:schema].blank?
         if as400?
           # AS400 implementation takes schema from library name (last part of url)
+          url = @config[:url].split(';').first.strip
           schema = @config[:url].split('/').last.strip
-          (schema[-1..-1] == ";") ? schema.chop : schema
         elsif @config[:username].present?
           # LUW implementation uses schema name of username by default
           @config[:username]


### PR DESCRIPTION
Hi, 

I commited change in db2 adapter. 

When jdbc url likes 

  jdbc:as400://localhost/lib1;naming=system;libraries=lib1,lib2

the schema was defined to lib1;naming=system;libraries=lib1,lib2 instead of lib1

I haven't managed to do a test.  
