### PR TITLE
Remove brackets from column_name for sql server 2000

### DIFF
--- a/lib/arjdbc/mssql/adapter.rb
+++ b/lib/arjdbc/mssql/adapter.rb
@@ -226,7 +226,8 @@ module ::ArJdbc
     end
 
     def quote_column_name(name)
-      "[#{name}]"
+      #do not enclose in brackets for sql server 2000; can't reference table from another owner
+      sqlserver_version == "2000" ? "#{name}" : "[#{name}]"
     end
 
     def quoted_true


### PR DESCRIPTION
ex: 

[owner_name.table_name] won't work in sql server 2000. 

Ideally it should be [owner_name].[table_name] but I've removed the braces entirely for now.
