### PR TITLE
More tweaks to the driver gems before releasing

### DIFF
--- a/jdbc-derby/lib/jdbc/derby.rb
+++ b/jdbc-derby/lib/jdbc/derby.rb
@@ -1,9 +1,10 @@
 module Jdbc
   module Derby
-    VERSION = "10.8.3.0.1"
+    DRIVER_VERSION = "10.8.3.0"
+    VERSION = DRIVER_VERSION
 
     def self.driver_jar
-      "derby-#{VERSION.split('.')[0..3].join('.')}.jar"
+      "derby-#{DRIVER_VERSION}.jar"
     end
 
     def self.load_driver(method = :load)
@@ -20,7 +21,7 @@ if $VERBOSE && (JRUBY_VERSION.nil? rescue true)
   warn "Jdbc-Derby is only for use with JRuby"
 end
 
-unless Java::JavaLang::Boolean.get_boolean("arjdbc.skip.autoload")
-  warn "Autoloading driver which is now deprecated.  Set arjdbc.skip.autoload=true to disable autoload."
+if Java::JavaLang::Boolean.get_boolean("arjdbc.force.autoload")
+  warn "Autoloading driver which is now deprecated."
   Jdbc::Derby::load_driver :require
 end

--- a/jdbc-h2/lib/jdbc/h2.rb
+++ b/jdbc-h2/lib/jdbc/h2.rb
@@ -1,9 +1,10 @@
 module Jdbc
   module H2
-    VERSION = "1.3.170.1"
+    DRIVER_VERSION = '1.3.170'
+    VERSION = DRIVER_VERSION + '.1'
 
     def self.driver_jar
-      "h2-#{VERSION.split('.')[0..2].join('.')}.jar"
+      "h2-#{DRIVER_VERSION}.jar"
     end
 
     def self.load_driver(method = :load)
@@ -20,7 +21,7 @@ if $VERBOSE && (JRUBY_VERSION.nil? rescue true)
   warn "Jdbc-H2 is only for use with JRuby"
 end
 
-unless Java::JavaLang::Boolean.get_boolean("arjdbc.skip.autoload")
-  warn "Autoloading driver which is now deprecated.  Set arjdbc.skip.autoload=true to disable autoload."
+if Java::JavaLang::Boolean.get_boolean("arjdbc.force.autoload")
+  warn "Autoloading driver which is now deprecated."
   Jdbc::H2::load_driver :require
 end

--- a/jdbc-hsqldb/lib/jdbc/hsqldb.rb
+++ b/jdbc-hsqldb/lib/jdbc/hsqldb.rb
@@ -1,9 +1,10 @@
 module Jdbc
   module HSQLDB
-    VERSION = "2.2.9.1"
+    DRIVER_VERSION = '2.2.9'
+    VERSION = DRIVER_VERSION + '.1'
 
     def self.driver_jar
-      "hsqldb-#{VERSION.split('.')[0..2].join('.')}.jar"
+      "hsqldb-#{DRIVER_VERSION}.jar"
     end
 
     def self.load_driver(method = :load)
@@ -20,7 +21,7 @@ if $VERBOSE && (JRUBY_VERSION.nil? rescue true)
   warn "Jdbc-HSQLDB is only for use with JRuby"
 end
 
-unless Java::JavaLang::Boolean.get_boolean("arjdbc.skip.autoload")
-  warn "Autoloading driver which is now deprecated.  Set arjdbc.skip.autoload=true to disable autoload."
+if Java::JavaLang::Boolean.get_boolean("arjdbc.force.autoload")
+  warn "Autoloading driver which is now deprecated."
   Jdbc::HSQLDB::load_driver :require
 end

--- a/jdbc-jtds/lib/jdbc/jtds.rb
+++ b/jdbc-jtds/lib/jdbc/jtds.rb
@@ -1,9 +1,10 @@
 module Jdbc
   module JTDS
-    VERSION = "1.3.0.1"
+    DRIVER_VERSION = '1.3.0'
+    VERSION = DRIVER_VERSION = '.1'
 
     def self.driver_jar
-      "jtds-#{VERSION.split('.')[0..2].join('.')}.jar"
+      "jtds-#{DRIVER_VERSION}.jar"
     end
 
     def self.load_driver(method = :load)
@@ -26,7 +27,7 @@ if $VERBOSE && (JRUBY_VERSION.nil? rescue true)
   warn "Jdbc-JTDS is only for use with JRuby"
 end
 
-unless Java::JavaLang::Boolean.get_boolean("arjdbc.skip.autoload")
-  warn "Autoloading driver which is now deprecated.  Set arjdbc.skip.autoload=true to disable autoload."
+if Java::JavaLang::Boolean.get_boolean("arjdbc.force.autoload")
+  warn "Autoloading driver which is now deprecated."
   Jdbc::JTDS::load_driver :require
 end

--- a/jdbc-mysql/lib/jdbc/mysql.rb
+++ b/jdbc-mysql/lib/jdbc/mysql.rb
@@ -1,9 +1,10 @@
 module Jdbc
   module MySQL
-    VERSION = "5.1.22.1"
+    DRIVER_VERSION = '5.1.22'
+    VERSION = DRIVER_VERSION + '.1'
 
     def self.driver_jar
-      "mysql-connector-java-#{VERSION.split('.')[0..2].join('.')}.jar"
+      "mysql-connector-java-#{DRIVER_VERSION}.jar"
     end
 
     def self.load_driver(method = :load)
@@ -20,7 +21,7 @@ if $VERBOSE && (JRUBY_VERSION.nil? rescue true)
   warn "Jdbc-MySQL is only for use with JRuby"
 end
 
-unless Java::JavaLang::Boolean.get_boolean("arjdbc.skip.autoload")
-  warn "Autoloading driver which is now deprecated.  Set arjdbc.skip.autoload=true to disable autoload."
+if Java::JavaLang::Boolean.get_boolean("arjdbc.force.autoload")
+  warn "Autoloading driver which is now deprecated."
   Jdbc::MySQL::load_driver :require
 end

--- a/jdbc-postgres/lib/jdbc/postgres.rb
+++ b/jdbc-postgres/lib/jdbc/postgres.rb
@@ -1,9 +1,10 @@
 module Jdbc
   module Postgres
-    VERSION = "9.2.1002.1"
+    DRIVER_VERSION = '9.2.1002'
+    VERSION = DRIVER_VERSION + '.1'
 
     def self.driver_jar
-      version_jdbc_version = VERSION.split( '.' )[0..2]
+      version_jdbc_version = DRIVER_VERSION.split( '.' )
       version_jdbc_version << jdbc_version
       'postgresql-%s.%s-%s.jdbc%d.jar' % version_jdbc_version
     end
@@ -31,7 +32,7 @@ if $VERBOSE && (JRUBY_VERSION.nil? rescue true)
   warn "Jdbc-Postgres is only for use with JRuby"
 end
 
-unless Java::JavaLang::Boolean.get_boolean("arjdbc.skip.autoload")
-  warn "Autoloading driver which is now deprecated.  Set arjdbc.skip.autoload=true to disable autoload."
+if Java::JavaLang::Boolean.get_boolean("arjdbc.force.autoload")
+  warn "Autoloading driver which is now deprecated."
   Jdbc::Postgres::load_driver :require
 end

--- a/jdbc-sqlite3/lib/jdbc/sqlite3.rb
+++ b/jdbc-sqlite3/lib/jdbc/sqlite3.rb
@@ -1,9 +1,10 @@
 module Jdbc
   module SQLite3
-    VERSION = "3.7.2.1"
+    DRIVER_VERSION = '3.7.2'
+    VERSION = DRIVER_VERSION + '.1'
 
     def self.driver_jar
-      "sqlite-jdbc-#{VERSION.split('.')[0..2].join('.')}.jar"
+      "sqlite-jdbc-#{DRIVER_VERSION}.jar"
     end
 
     def self.load_driver(method = :load)
@@ -20,7 +21,7 @@ if $VERBOSE && (JRUBY_VERSION.nil? rescue true)
   warn "Jdbc-SQLite3 is only for use with JRuby"
 end
 
-unless Java::JavaLang::Boolean.get_boolean("arjdbc.skip.autoload")
-  warn "Autoloading driver which is now deprecated.  Set arjdbc.skip.autoload=true to disable autoload."
+if Java::JavaLang::Boolean.get_boolean("arjdbc.force.autoload")
+  warn "Autoloading driver which is now deprecated."
   Jdbc::SQLite3::load_driver :require
 end


### PR DESCRIPTION
- Update the version handling.  Rather than string mangling, use
  simpler DRIVER_VERSION and VERSION constants.
- Invert the (never released) autoload property behavior.  Instead
  of requiring a property to opt in to the new behavior, require a
  property (arjdbc.force.autoload) to retain the old behavior.

Closes #307.
