### PR TITLE
Offset can also be of type Arel::Node::Offset

### DIFF
--- a/lib/arel/visitors/hsqldb.rb
+++ b/lib/arel/visitors/hsqldb.rb
@@ -12,6 +12,7 @@ module Arel
 
       def limit_offset sql, o
         offset = o.offset || 0
+        offset = offset.expr unless(offset.nil? or offset == 0)
         bef = sql[7..-1]
         if limit = o.limit
           "SELECT LIMIT #{offset} #{limit_for(limit)} #{bef}"


### PR DESCRIPTION
# Description

---

We're currently using an H2 database in a JRuby/TorqueBox deployment. We've implemented a backp/restore feature based on [yaml_db](https://github.com/ludicast/yaml_db).

The [SerializationHelper](https://github.com/ludicast/yaml_db/blob/master/lib/serialization_helper.rb) creates a SQL query using the Arel interface:
`query = Arel::Table.new(table).order(id).skip(records_per_page*page).take(records_per_page).project(Arel.sql('*'))`

The Table.new(table)#skip method is supposed to create an offset value. This does not work properly, since the generated offset can be of type: Arel::Node::Offset.
# Solution

---

I've added a line of code to the Arel::Visitors::HSQLDB#limit_offset method. If the offset is nil or !0, I assume the offset is of type Arel::Node::Offset  and call the expr() method, which will return the actual offset.

Signed-off-by: Jason Franklin franklin@equinux.com
