### PR TITLE
Introduce JDBC connection level support for Sybase ASE adapter

### DIFF
--- a/src/java/arjdbc/jdbc/AdapterJavaService.java
+++ b/src/java/arjdbc/jdbc/AdapterJavaService.java
@@ -43,6 +43,7 @@ import arjdbc.oracle.OracleRubyJdbcConnection;
 import arjdbc.postgresql.PostgresqlRubyJdbcConnection;
 import arjdbc.sqlite3.SQLite3Module;
 import arjdbc.sqlite3.SQLite3RubyJdbcConnection;
+import arjdbc.sybase.SybaseASERubyJdbcConnection;
 
 import org.jruby.Ruby;
 import org.jruby.RubyClass;
@@ -62,6 +63,7 @@ public class AdapterJavaService implements BasicLibraryService {
         H2RubyJdbcConnection.createH2JdbcConnectionClass(runtime, jdbcConnection);
         MySQLRubyJdbcConnection.createMySQLJdbcConnectionClass(runtime, jdbcConnection);
         DB2RubyJdbcConnection.createDB2JdbcConnectionClass(runtime, jdbcConnection);
+		SybaseASERubyJdbcConnection.createSybaseASEJdbcConnectionClass(runtime, jdbcConnection);
         // ArJdbc :
         RubyModule arJdbc = runtime.getOrCreateModule("ArJdbc");
         MySQLModule.load(arJdbc);

--- a/src/java/arjdbc/sybase/SybaseASERubyJdbcConnection.java
+++ b/src/java/arjdbc/sybase/SybaseASERubyJdbcConnection.java
@@ -1,0 +1,95 @@
+package arjdbc.sybase;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+import org.jruby.Ruby;
+import org.jruby.RubyClass;
+import org.jruby.exceptions.RaiseException;
+import org.jruby.runtime.ObjectAllocator;
+import org.jruby.runtime.ThreadContext;
+import org.jruby.runtime.builtin.IRubyObject;
+
+import arjdbc.jdbc.RubyJdbcConnection;
+
+public class SybaseASERubyJdbcConnection extends RubyJdbcConnection {
+
+	// The JDBC JavaDoc for the java.sql.Statement#getGeneratedKeys() method states that in case an
+	// empty ResultSet is returned from the database, it should be returned as well from the method call.
+	// Sybase ASE's jConnect family of JDBC drivers however follow a different behavior here:
+	// although connection.getMetaData().supportsGetGeneratedKeys() returns true, the call to the
+	// getGeneratedKeys() method may throw java.sql.SQLException in the case of empty ResultSet.
+	
+	private static final String SYBASE_DRIVER_GENERATEDKEYS_ERRORCODE = "JZ0NK";
+
+	protected SybaseASERubyJdbcConnection(Ruby runtime, RubyClass metaClass) {
+		super(runtime, metaClass);		
+	}
+	
+	public static RubyClass createSybaseASEJdbcConnectionClass(Ruby runtime, RubyClass jdbcConnection) {
+        RubyClass clazz = RubyJdbcConnection.getConnectionAdapters(runtime).defineClassUnder("SybaseASEJdbcConnection",
+                jdbcConnection, SYBASE_JDBCCONNECTION_ALLOCATOR);
+        clazz.defineAnnotatedMethods(SybaseASERubyJdbcConnection.class);
+
+        return clazz;
+    }
+
+    private static ObjectAllocator SYBASE_JDBCCONNECTION_ALLOCATOR = new ObjectAllocator() {
+        public IRubyObject allocate(Ruby runtime, RubyClass klass) {
+            return new SybaseASERubyJdbcConnection(runtime, klass);
+        }
+    };   
+    
+    @Override    
+    public IRubyObject insert_bind(ThreadContext context, IRubyObject[] args) throws SQLException { 
+    	try {
+    		return super.insert_bind(context, args);
+    	} catch (SQLException sqlExc) {   
+    		// Check the special case when the jConnect JDBC driver for Sybase complains about the getGeneratedKeys() invocation.
+    		// Proceed normally in this case (consider empty ResultSet returned); otherwise rethrow the exception.
+    		if (sqlExc.getMessage().contains(SYBASE_DRIVER_GENERATEDKEYS_ERRORCODE)) {
+    			return context.getRuntime().getNil();
+    		} else {
+    			throw sqlExc;
+    		}
+    	}
+    }
+    
+    @Override    
+    public IRubyObject execute_insert(ThreadContext context, IRubyObject sql) throws SQLException {    	
+    	try {    		
+    		return super.execute_insert(context, sql);
+    	} catch (SQLException sqlExc) {  
+    		// Check the special case when the jConnect JDBC driver for Sybase complains about the getGeneratedKeys() invocation.
+    		// Proceed normally in this case (consider empty ResultSet returned); otherwise rethrow the exception.
+    		if (sqlExc.getMessage().contains(SYBASE_DRIVER_GENERATEDKEYS_ERRORCODE)) {
+    			return context.getRuntime().getNil();
+    		} else {
+    			throw sqlExc;
+    		}	
+    	} catch (RaiseException rExc) {
+    		// It is possible to have the driver exception wrapped in org.jruby.exceptions.RaiseException
+    		if (rExc.getMessage().contains(SYBASE_DRIVER_GENERATEDKEYS_ERRORCODE)) {
+    			return context.getRuntime().getNil();
+    		} else {
+    			throw rExc;
+    		}	
+    	}
+    }
+    
+    @Override
+    protected IRubyObject unmarshalKeysOrUpdateCount(ThreadContext context, Connection c, Statement stmt) throws SQLException {    	
+    	try {
+    		return super.unmarshalKeysOrUpdateCount(context, c, stmt);
+    	} catch (SQLException sqlExc){    	
+    		// Check the special case when the jConnect JDBC driver for Sybase complains about the getGeneratedKeys() invocation.
+    		// Proceed normally in this case; otherwise rethrow the exception.
+    		if (sqlExc.getMessage().contains(SYBASE_DRIVER_GENERATEDKEYS_ERRORCODE)) {
+    			return context.getRuntime().newFixnum(stmt.getUpdateCount());
+    		} else {
+    			throw sqlExc;
+    		}	
+    	}
+    }
+}


### PR DESCRIPTION
Hi guys,

We intend to open source and publish soon our _ActiveRecord JDBC adapter for Sybase ASE_ gem on GitHub. It will need this Java part for handling specific behavior when the jConnect JDBC drivers are used.

Taking a look at other overriden Ruby-JDBC connection classes, that are used from other adapters, I guess that this is the right place to contribute Sybase ASE's one. I couldn't find a suitable way to build and deploy the Java part from the adapter itself.

Best Regards,
Krum.

Signed-off-by: Krum Bakalsky krum.bakalsky@sap.com
