### PR TITLE
db2 on as400: force decimal field with 0 scale to be integers because th...

### DIFF
--- a/lib/arjdbc/db2/adapter.rb
+++ b/lib/arjdbc/db2/adapter.rb
@@ -151,7 +151,7 @@ module ArJdbc
         when /^real|double/i     then :float
         when /int|serial/i       then :integer
         # if a numeric column has no scale, lets treat it as an integer.  The as400 rpg guys do this ALOT since they have no integer datatype
-        when /numeric|decfloat/i then extract_scale(field_type) == 0 && as400? ? :integer : :decimal
+        when /numeric|decfloat/i then extract_scale(field_type) == 0 ? :integer : :decimal
         when /timestamp/i        then :timestamp
         when /datetime/i         then :datetime
         when /time/i             then :time
@@ -165,11 +165,6 @@ module ArJdbc
         else
           super
         end
-      end
-
-      def as400?
-        # I can't find a better way to detect this with the limited info available in this class.
-        ActiveRecord::Base.connection.as400? rescue false
       end
 
       # Post process default value from JDBC into a Rails-friendly format (columns{-internal})


### PR DESCRIPTION
db2 on as400: force decimal field with 0 scale to be integers because they don't have integer datatypes when creating tables from rpg and because keeping it seems to fail when something like 3.0 is saved in a decimal field with no scale.

added as400 detection method and make sure only using integer for 0 scale decimals on as400
