### PR TITLE
Import quote_table_name_for_assignment for postgresql from AR4

### DIFF
--- a/lib/arjdbc/postgresql/adapter.rb
+++ b/lib/arjdbc/postgresql/adapter.rb
@@ -1120,7 +1120,11 @@ module ArJdbc
         "#{quote_column_name(schema)}.#{quote_column_name(table_name)}"
       end
     end
-    
+
+    def quote_table_name_for_assignment(table, attr)
+      quote_column_name(attr)
+    end
+
     def quote_column_name(name)
       %("#{name.to_s.gsub("\"", "\"\"")}")
     end


### PR DESCRIPTION
Fixes generation of queries like:

```
UPDATE "entries" SET "entries"."updated_on"
```

which cause error

```
ActiveRecord::StatementInvalid: ActiveRecord::JDBCError: org.postgresql.util.PSQLException: ERROR: column "entries" of relation "entries" does not exist
```
