### PR TITLE
namespace unquote_table_name for SQL Server 2000

### DIFF
--- a/lib/arjdbc/mssql/limit_helpers.rb
+++ b/lib/arjdbc/mssql/limit_helpers.rb
@@ -117,7 +117,7 @@ module ArJdbc
           if order =~ /(\w*id\w*)/i
             $1
           else
-            unquoted_name = unquote_table_name(table_name)
+            unquoted_name = Utils.unquote_table_name(table_name)
             model = descendants.find { |m| m.table_name == table_name || m.table_name == unquoted_name }
             model ? model.primary_key : 'id'
           end


### PR DESCRIPTION
Running on SQL Server 2000, I came across this issue:

```
undefined method `unquote_table_name' for #<Arel::Visitors::SQLServer2000:0x484b4f3a> - C:/dev/repos/..../vendor/cache/activerecord-jdbc-adapter-bfe4217f0793/lib/arjdbc/mssql/limit_helpers.rb:119:in `get_primary_key'
C:/dev/repos/..../vendor/cache/activerecord-jdbc-adapter-bfe4217f0793/lib/arjdbc/mssql/limit_helpers.rb:58:in `replace_limit_offset!'
C:/dev/repos/..../vendor/cache/activerecord-jdbc-adapter-bfe4217f0793/lib/arel/visitors/sql_server.rb:35:in `visit_Arel_Nodes_SelectStatement'
org/jruby/RubyBasicObject.java:1665:in `__send__'
org/jruby/RubyKernel.java:2090:in `send'
C:/dev/repos/..../vendor/bundle/jruby/1.9/gems/arel-3.0.2/lib/arel/visitors/visitor.rb:19:in `visit'
C:/dev/repos/..../vendor/bundle/jruby/1.9/gems/arel-3.0.2/lib/arel/visitors/visitor.rb:5:in `accept'
C:/dev/repos/..../vendor/bundle/jruby/1.9/gems/arel-3.0.2/lib/arel/visitors/to_sql.rb:19:in `accept'
C:/dev/repos/..../vendor/cache/activerecord-jdbc-adapter-bfe4217f0793/lib/arjdbc/jdbc/adapter.rb:411:in `to_sql'
C:/dev/repos/..../vendor/bundle/jruby/1.9/gems/activerecord-3.2.13/lib/active_record/connection_adapters/abstract/query_cache.rb:60:in `select_all'
C:/dev/repos/..../vendor/bundle/jruby/1.9/gems/activerecord-3.2.13/lib/active_record/querying.rb:38:in `find_by_sql'
C:/dev/repos/..../vendor/bundle/jruby/1.9/gems/activerecord-3.2.13/lib/active_record/explain.rb:41:in `logging_query_plan'
C:/dev/repos/..../vendor/bundle/jruby/1.9/gems/activerecord-3.2.13/lib/active_record/querying.rb:37:in `find_by_sql'
C:/dev/repos/..../vendor/bundle/jruby/1.9/gems/newrelic_rpm-3.6.0.83/lib/new_relic/agent/method_tracer.rb:486:in `find_by_sql_with_trace_ActiveRecord_self_name_find_by_sql'
C:/dev/repos/..../vendor/bundle/jruby/1.9/gems/newrelic_rpm-3.6.0.83/lib/new_relic/agent/method_tracer.rb:235:in `trace_execution_scoped'
C:/dev/repos/..../vendor/bundle/jruby/1.9/gems/newrelic_rpm-3.6.0.83/lib/new_relic/agent/method_tracer.rb:234:in `trace_execution_scoped'
C:/dev/repos/..../vendor/bundle/jruby/1.9/gems/newrelic_rpm-3.6.0.83/lib/new_relic/agent/method_tracer.rb:481:in `find_by_sql_with_trace_ActiveRecord_self_name_find_by_sql'
C:/dev/repos/..../vendor/bundle/jruby/1.9/gems/activerecord-3.2.13/lib/active_record/relation.rb:171:in `exec_queries'
C:/dev/repos/..../vendor/bundle/jruby/1.9/gems/activerecord-3.2.13/lib/active_record/relation.rb:160:in `to_a'
C:/dev/repos/..../vendor/bundle/jruby/1.9/gems/activerecord-3.2.13/lib/active_record/explain.rb:41:in `logging_query_plan'
C:/dev/repos/..../vendor/bundle/jruby/1.9/gems/activerecord-3.2.13/lib/active_record/relation.rb:159:in `to_a'
C:/dev/repos/..../vendor/bundle/jruby/1.9/gems/activerecord-3.2.13/lib/active_record/relation/finder_methods.rb:380:in `find_first'
C:/dev/repos/..../vendor/bundle/jruby/1.9/gems/activerecord-3.2.13/lib/active_record/relation/finder_methods.rb:122:in `first'
```

It seems this method was not prefixed with `Utils` module.
