### PR TITLE
Fix array quote escaping

### DIFF
--- a/lib/arjdbc/postgresql/adapter.rb
+++ b/lib/arjdbc/postgresql/adapter.rb
@@ -1043,7 +1043,7 @@ module ArJdbc
       when Array
         if AR4_COMPAT && column.array? # will be always falsy in AR < 4.0
           column_class = ::ActiveRecord::ConnectionAdapters::PostgreSQLColumn
-          "'#{column_class.array_to_string(value, column, self)}'"
+          "'#{column_class.array_to_string(value, column, self).gsub(/'/, "''")}'"
         else super
         end
       when Hash

--- a/test/db/postgresql/array_type_test.rb
+++ b/test/db/postgresql/array_type_test.rb
@@ -64,7 +64,7 @@ class PostgreSQLArrayTypeTest < Test::Unit::TestCase
   end
 
   def test_strings_with_quotes
-    assert_cycle(['this has','some "s that need to be escaped"'])
+    assert_cycle(['this has','some "s that need to be escaped"', "some 's that need to be escaped too"])
   end
 
   def test_strings_with_commas


### PR DESCRIPTION
Porting correct escaping of single quotes in arrays from AR (see https://github.com/rails/rails/blob/master/activerecord/lib/active_record/connection_adapters/postgresql/quoting.rb#L36)

Failure of modified test before patch:

```
Error: test_strings_with_quotes(PostgreSQLArrayTypeTest)
  ActiveRecord::StatementInvalid: ActiveRecord::JDBCError: org.postgresql.util.PSQLException: ERROR: syntax error at or near "s"
    Position: 99: INSERT INTO "pg_arrays" ("tags") VALUES ('{"this has","some \"s that need to be escaped\"","some 's that need to be escaped too"}') RETURNING "id"
```
