### PR TITLE
Fix array values escaping: backslashes should be escaped too

### DIFF
--- a/lib/arjdbc/postgresql/column.rb
+++ b/lib/arjdbc/postgresql/column.rb
@@ -445,7 +445,7 @@ module ArJdbc
           when "NULL"
             value
           else
-            "\"#{value.gsub(/"/,"\\\"")}\""
+            "\"#{value.gsub(/(["\\])/, '\\\\\1')}\""
           end
         end
 

--- a/test/db/postgresql/array_type_test.rb
+++ b/test/db/postgresql/array_type_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 require 'db/postgres'
 
 class PostgreSQLArrayTypeTest < Test::Unit::TestCase
-  
+
   class PgArray < ActiveRecord::Base
     self.table_name = 'pg_arrays'
   end
@@ -67,6 +67,10 @@ class PostgreSQLArrayTypeTest < Test::Unit::TestCase
     assert_cycle(['this has','some "s that need to be escaped"', "some 's that need to be escaped too"])
   end
 
+  def test_strings_with_quotes_and_backslashes
+    assert_cycle(['this has','some \\"s that need to be escaped"'])
+  end
+
   def test_strings_with_commas
     assert_cycle(['this,has','many,values'])
   end
@@ -97,5 +101,5 @@ class PostgreSQLArrayTypeTest < Test::Unit::TestCase
     x.reload
     assert_equal(array, x.tags)
   end
-  
+
 end if Test::Unit::TestCase.ar_version('4.0')


### PR DESCRIPTION
Current array escaping doesn't escape backslashes, leading to failures like:

```
ActiveRecord::StatementInvalid: PG::Error: ERROR:  malformed array literal: "{"this has","some \\"s that need to be escaped\""}"
 : INSERT INTO "pg_arrays" ("tags") VALUES ($1) RETURNING "id"
```

This patch fixes it. Correct escaping regexp is taken from [this line](https://github.com/rails/rails/blob/232d2223ebcfe5c9e0425c821f5d30a7d5968512/activerecord/lib/active_record/connection_adapters/postgresql/cast.rb#L73)

This bug also present in AR, see rails/rails#11477
