### PR TITLE
Prevent special column corruption of ORDER BY

### DIFF
--- a/lib/arjdbc/mssql/adapter.rb
+++ b/lib/arjdbc/mssql/adapter.rb
@@ -600,7 +600,7 @@ module ArJdbc
         special_columns = special_columns.sort { |n1, n2| n2.size <=> n1.size }
         for column in special_columns
           sql.gsub!(/\s?\[?#{column}\]?\s?=\s?/, " [#{column}] LIKE ")
-          sql.gsub!(/ORDER BY \[?#{column}\]?/i, '') # NOTE: a bit stupid
+          sql.gsub!(/ORDER BY \[?#{column}([^\.\w]|$)\]?/i, '') # NOTE: a bit stupid
         end
       end
       sql

--- a/test/db/mssql/types_test.rb
+++ b/test/db/mssql/types_test.rb
@@ -132,6 +132,7 @@ class MSSQLLegacyTypesTest < Test::Unit::TestCase
           [title] VARCHAR(100),
           [author] VARCHAR(60) DEFAULT 'anonymous',
           [text] TEXT,
+          [text_as_varchar] VARCHAR(100),
           [ntext] NTEXT,
           [image] IMAGE
         )
@@ -194,6 +195,10 @@ class MSSQLLegacyTypesTest < Test::Unit::TestCase
     sql = "SELECT * FROM articles WHERE text = '1' ORDER BY text"
     r_sql = Article.connection.send(:repair_special_columns, sql)
     assert_equal "SELECT * FROM articles WHERE [text] LIKE '1' ", r_sql
+
+    sql = "SELECT * FROM articles WHERE text_as_varchar = '1' ORDER BY text_as_varchar"
+    r_sql = Article.connection.send(:repair_special_columns, sql)
+    assert_equal "SELECT * FROM articles WHERE text_as_varchar = '1' ORDER BY text_as_varchar", r_sql
 
     sql = "SELECT * FROM [articles] WHERE [text]='1' AND [ntext]= '2' ORDER BY [ntext]"
     r_sql = Article.connection.send(:repair_special_columns, sql)


### PR DESCRIPTION
Special columns whose name match the beginning of a table name can
potentially corrupt the ORDER BY clause. This patch prevents this from
happening under some circumstances.
