### PR TITLE
MSSQL - rake db:migrate:reset can drop database

### DIFF
--- a/lib/arjdbc/mssql/adapter.rb
+++ b/lib/arjdbc/mssql/adapter.rb
@@ -325,6 +325,8 @@ module ArJdbc
     end
 
     def drop_database(name)
+      current_db = current_database
+      use_database('master') if current_db.to_s == name
       execute "DROP DATABASE #{quote_table_name(name)}"
     end
 


### PR DESCRIPTION
If i run the rake task `db:migrate:reset` i got the message

```
** Invoke db:migrate:reset (first_time)
** Invoke db:drop (first_time)
** Invoke db:load_config (first_time)
** Execute db:load_config
** Invoke rails_env (first_time)
** Execute rails_env
** Execute db:drop
Couldn't drop EHSIGBDB_test_sm : #<ActiveRecord::StatementInvalid: ActiveRecord::JDBCError: Cannot drop database "EHSIGBDB_test_sm" because it is currently in use.: DROP DATABASE [EHSIGBDB_test_sm]>
```

I think it is the same problem like here http://jira.codehaus.org/browse/JRUBY-2912

With this patch in `lib/arjdbc/mssql/adapter.rb method drop_database(name)` the rake task run successfully.
