### PR TITLE
Fix inline rescue syntax

### DIFF
--- a/lib/arjdbc/mssql/column.rb
+++ b/lib/arjdbc/mssql/column.rb
@@ -140,11 +140,7 @@ module ArJdbc
           return value unless value.is_a?(String)
           return nil if value.empty?
 
-          fast_string_to_time(value) ||
-            begin
-              DateTime.parse(value).to_time
-            rescue nil
-            end
+          fast_string_to_time(value) || DateTime.parse(value).to_time rescue nil
         end
 
         ISO_TIME = /\A(\d\d)\:(\d\d)\:(\d\d)(\.\d+)?\z/


### PR DESCRIPTION
Otherwise it fails in jruby with:
  "class or module required for rescue clause"

In MRI, it would still not work as intended, as it would try to match an exception to nil, so the rescue clause would never be triggered
