### PR TITLE
Return early if table name is nil

### DIFF
--- a/lib/arjdbc/jdbc/adapter.rb
+++ b/lib/arjdbc/jdbc/adapter.rb
@@ -571,6 +571,7 @@ module ActiveRecord
 
       # @override
       def table_exists?(name)
+        return false unless name
         @connection.table_exists?(name) # schema_name = nil
       end
 


### PR DESCRIPTION
When trying to upgrade to version 1.3.0, I encountered an error when running the MSSQL adapter that previously wasn't there on 1.2.9.1. I'm using [PaperTrail](https://github.com/airblade/paper_trail) and when calling the `has_paper_trail` method from an abstract model, one of its callbacks was sending `nil` to the connection adapter's `table_exists?` method causing an `Argument Error: nil table name` to be raised.

It could be argued that the caller shouldn't pass `nil`, but I noticed that Rails' adapters check for the `nil` case (e.g. [mysql adapter](https://github.com/rails/rails/blob/master/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb#L429)).
