### PR TITLE
Require all lib/ files for activerecord gems

### DIFF
--- a/activerecord-jdbcderby-adapter/activerecord-jdbcderby-adapter.gemspec
+++ b/activerecord-jdbcderby-adapter/activerecord-jdbcderby-adapter.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.files = [
     "README.txt",
     "LICENSE.txt",
-    "lib/active_record/connection_adapters/jdbcderby_adapter.rb"
+    *Dir["lib/**/*"].to_a
   ]
   s.homepage = %q{https://github.com/jruby/activerecord-jdbc-adapter}
   s.require_paths = ["lib"]

--- a/activerecord-jdbch2-adapter/activerecord-jdbch2-adapter.gemspec
+++ b/activerecord-jdbch2-adapter/activerecord-jdbch2-adapter.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
     "Rakefile",
     "README.txt",
     "LICENSE.txt",
-    "lib/active_record/connection_adapters/jdbch2_adapter.rb"
+    *Dir["lib/**/*"].to_a
   ]
   s.homepage = %q{https://github.com/jruby/activerecord-jdbc-adapter}
   s.require_paths = ["lib"]

--- a/activerecord-jdbchsqldb-adapter/activerecord-jdbchsqldb-adapter.gemspec
+++ b/activerecord-jdbchsqldb-adapter/activerecord-jdbchsqldb-adapter.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
     "Rakefile",
     "README.txt",
     "LICENSE.txt",
-    "lib/active_record/connection_adapters/jdbchsqldb_adapter.rb"
+    *Dir["lib/**/*"].to_a
   ]
   s.homepage = %q{https://github.com/jruby/activerecord-jdbc-adapter}
   s.require_paths = ["lib"]

--- a/activerecord-jdbcmssql-adapter/activerecord-jdbcmssql-adapter.gemspec
+++ b/activerecord-jdbcmssql-adapter/activerecord-jdbcmssql-adapter.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
     "Rakefile",
     "README.rdoc",
     "LICENSE.txt",
-    "lib/active_record/connection_adapters/jdbcmssql_adapter.rb"
+    *Dir["lib/**/*"].to_a
   ]
   s.homepage = %q{https://github.com/jruby/activerecord-jdbc-adapter}
   s.require_paths = ["lib"]

--- a/activerecord-jdbcmysql-adapter/activerecord-jdbcmysql-adapter.gemspec
+++ b/activerecord-jdbcmysql-adapter/activerecord-jdbcmysql-adapter.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
     "Rakefile",
     "README.txt",
     "LICENSE.txt",
-    "lib/active_record/connection_adapters/jdbcmysql_adapter.rb"
+    *Dir["lib/**/*"].to_a
   ]
   s.homepage = %q{https://github.com/jruby/activerecord-jdbc-adapter}
   s.require_paths = ["lib"]

--- a/activerecord-jdbcpostgresql-adapter/activerecord-jdbcpostgresql-adapter.gemspec
+++ b/activerecord-jdbcpostgresql-adapter/activerecord-jdbcpostgresql-adapter.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
     "Rakefile",
     "README.txt",
     "LICENSE.txt",
-    "lib/active_record/connection_adapters/jdbcpostgresql_adapter.rb"
+    *Dir["lib/**/*"].to_a
   ]
   s.homepage = %q{https://github.com/jruby/activerecord-jdbc-adapter}
   s.require_paths = ["lib"]

--- a/activerecord-jdbcsqlite3-adapter/activerecord-jdbcsqlite3-adapter.gemspec
+++ b/activerecord-jdbcsqlite3-adapter/activerecord-jdbcsqlite3-adapter.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
     "Rakefile",
     "README.txt",
     "LICENSE.txt",
-    "lib/active_record/connection_adapters/jdbcsqlite3_adapter.rb"
+    *Dir["lib/**/*"].to_a
   ]
   s.homepage = %q{https://github.com/jruby/activerecord-jdbc-adapter}
   s.require_paths = ["lib"]


### PR DESCRIPTION
Before, they were all missing their namesake file. Thus, bundler could not autorequire these gems.

```
bash-3.2$ gem install activerecord-jdbcpostgresql-adapter
Successfully installed activerecord-jdbcpostgresql-adapter-1.3.0
1 gem installed
bash-3.2$ irb
jruby-1.7.4 :001 > require "activerecord-jdbcpostgresql-adapter"
LoadError: no such file to load -- activerecord-jdbcpostgresql-adapter
    from org/jruby/RubyKernel.java:1054:in `require'
    from /Users/pivotal/.rvm/rubies/jruby-1.7.4/lib/ruby/shared/rubygems/core_ext/kernel_require.rb:53:in `require'
    from (irb):1:in `evaluate'
    from org/jruby/RubyKernel.java:1093:in `eval'
    from org/jruby/RubyKernel.java:1489:in `loop'
    from org/jruby/RubyKernel.java:1254:in `catch'
    from org/jruby/RubyKernel.java:1254:in `catch'
    from /Users/pivotal/.rvm/rubies/jruby-1.7.4/bin/irb:13:in `(root)'
```
