### PR TITLE
Fix compound arrays

### DIFF
--- a/test/db/postgresql/array_type_test.rb
+++ b/test/db/postgresql/array_type_test.rb
@@ -13,6 +13,8 @@ class PostgreSQLArrayTypeTest < Test::Unit::TestCase
     @connection.transaction do
       @connection.create_table('pg_arrays') do |t|
         t.string 'tags', :array => true
+
+        t.json 'objs', :array => true
       end
 
       @connection.add_column 'pg_arrays', 'added_tags', :string, :array => true
@@ -102,6 +104,21 @@ class PostgreSQLArrayTypeTest < Test::Unit::TestCase
 
   def test_contains_nils
     assert_cycle(['1',nil,nil])
+  end
+
+  def test_array_of_json
+    array = [{'a' => 1, 'b' => 'str'},{}]
+
+    x = PgArray.create!(:objs => array)
+    x.reload
+    assert_equal(array, x.objs)
+
+    # test updating
+    x = PgArray.create!(:objs => [])
+    x.objs = array
+    x.save!
+    x.reload
+    assert_equal(array, x.objs)
   end
 
   private

--- a/test/db/postgresql/array_type_test.rb
+++ b/test/db/postgresql/array_type_test.rb
@@ -13,7 +13,7 @@ class PostgreSQLArrayTypeTest < Test::Unit::TestCase
     @connection.transaction do
       @connection.create_table('pg_arrays') do |t|
         t.string 'tags', :array => true
-
+        t.integer 'ints', :array => true
         t.json 'objs', :array => true
       end
 
@@ -119,6 +119,19 @@ class PostgreSQLArrayTypeTest < Test::Unit::TestCase
     x.save!
     x.reload
     assert_equal(array, x.objs)
+  end
+
+  def test_insert_fixture_int_array
+    int_values = [1,2,4,6]
+    @connection.insert_fixture({"ints" => int_values}, "pg_arrays" )
+    assert_equal(PgArray.last.ints, int_values)
+  end
+
+  def test_insert_fixture_int_array_from_strings
+    int_values = [1,2,4,6]
+    int_values_for_insert = ['1','2','4','6']
+    @connection.insert_fixture({"ints" => int_values_for_insert}, "pg_arrays" )
+    assert_equal(PgArray.last.ints, int_values)
   end
 
   private


### PR DESCRIPTION
Calling type_cast for array elements, which fixes serialization of int arrays from strings and compound arrays (for example, arrays of json objects).

Also fixes deserializing compound arrays (calling type_cast for deserialized element)
