### PR TITLE
Correct logic in tasks.rb

### DIFF
--- a/lib/arjdbc/tasks.rb
+++ b/lib/arjdbc/tasks.rb
@@ -1,6 +1,6 @@
 if defined?(Rake.application) && Rake.application
   skip = ENV["SKIP_AR_JDBC_RAKE_REDEFINES"] # jruby -J-Darjdc.tasks.skip=true -S rake ...
-  if ! Java::JavaLang::Boolean.getBoolean('arjdbc.tasks.skip') || ! ( skip && skip != 'false' )
+  if !(Java::JavaLang::Boolean.getBoolean('arjdbc.tasks.skip') || ( skip && skip != 'false' ))
     databases_rake = File.expand_path('tasks/databases.rake', File.dirname(__FILE__))
     if Rake.application.lookup("db:create")
       load databases_rake # load the override tasks now


### PR DESCRIPTION
- Should skip if either ENV variable OR Java config is set to skip.

We're trying to skip loading the rake tasks because it throws an exception from rake (see #459), but we're unable to do so because the boolean logic here seems incorrect. Our expectation is setting either the Java bool or the ENV var should skip the rake task loading and we've updated this file to be consistent with that expectation. 
