### PR TITLE
Prevent rake from throwing an exception when task w/o comment is redefined

### DIFF
--- a/lib/arjdbc/tasks/databases.rake
+++ b/lib/arjdbc/tasks/databases.rake
@@ -27,7 +27,7 @@ Rake::DSL.module_eval do
     end
 
     new_task = task(*args, &block)
-    new_task.comment = old_comment # if old_comment
+    new_task.comment = old_comment if old_comment
     new_task.actions.concat(old_actions) if old_actions
     new_task.prerequisites.concat(old_prereqs) if old_prereqs
     new_task


### PR DESCRIPTION
w/ Rails 3.2.14 and Rake 10.1.0 the redefine_task method will set a nil comment on a rake task, which causes an exception when rake -T is run. 

Technically rake should handle this issue, but as a workaround it might be nice to avoid setting it until this gets fixed in rake. 
