### PR TITLE
Fixed Undefined method array? for  ActiveRecord::ConnectionAdapters::PostgreSQLAdapter::ColumnDefinition

### DIFF
--- a/lib/arjdbc/postgresql/adapter.rb
+++ b/lib/arjdbc/postgresql/adapter.rb
@@ -1256,6 +1256,7 @@ module ActiveRecord::ConnectionAdapters
     end
 
     class ColumnDefinition < ActiveRecord::ConnectionAdapters::ColumnDefinition
+
       attr_accessor :array
 
       def array?


### PR DESCRIPTION
Just added  array? to ActiveRecord::ConnectionAdapters::PostgreSQLAdapter::ColumnDefinition
