### PR TITLE
Rake Task db:structure:load does not create schema for test db.

### DIFF
--- a/lib/arjdbc/tasks/databases3.rake
+++ b/lib/arjdbc/tasks/databases3.rake
@@ -118,7 +118,7 @@ namespace :db do
     end
 
     redefine_task :load do
-      config = ActiveRecord::Base.configurations[rails_env] # current_config
+      config = current_config 
       filename = structure_sql
 
       case config['adapter']


### PR DESCRIPTION
- The redifined structure:load task was using the wrong config, should
  be using current_config, otherwise it reloads the structure for development if you just run `rake db:test:prepare`
- Tests (test_postgres, test_sqlite3) successful.
- This was tested against master
- Running Rails 3.2.14
- JRuby 1.7.4
- No backtraces, but the test schema would be empty before this fix
