### PR TITLE
Fall back to rollback_savepoint for MS SQL Server driver

### DIFF
--- a/lib/arjdbc/mssql/adapter.rb
+++ b/lib/arjdbc/mssql/adapter.rb
@@ -6,13 +6,14 @@ require 'arjdbc/mssql/limit_helpers'
 require 'arjdbc/mssql/lock_methods'
 require 'arjdbc/mssql/column'
 require 'arjdbc/mssql/explain_support'
+require 'arjdbc/mssql/driver_info'
 
 module ArJdbc
   module MSSQL
     include LimitHelpers
     include Utils
-
     include ExplainSupport
+    include DriverInfo
 
     # @private
     def self.extended(adapter)
@@ -575,6 +576,15 @@ module ArJdbc
       else
         sql = suble_binds(sql, binds) unless to_sql # deprecated behavior
         log(sql, name) { @connection.execute_query_raw(sql, &block) }
+      end
+    end
+
+    # @override
+    def release_savepoint(name = current_savepoint_name)
+      if sqlserver_driver?(config)
+        @connection.rollback_savepoint(name)
+      else
+        @connection.release_savepoint(name)
       end
     end
 

--- a/lib/arjdbc/mssql/connection_methods.rb
+++ b/lib/arjdbc/mssql/connection_methods.rb
@@ -1,11 +1,14 @@
+require 'arjdbc/mssql/driver_info'
+
 ArJdbc::ConnectionMethods.module_eval do
+  include ArJdbc::MSSQL::DriverInfo
 
   # Default connection method for MS-SQL adapter (`adapter: mssql`),
   # uses the (open-source) jTDS driver.
   # If you'd like to use the "official" MS's SQL-JDBC driver, it's preferable
   # to use the {#sqlserver_connection} method (set `adapter: sqlserver`).
   def mssql_connection(config)
-    if config[:driver] =~ /SQLServerDriver$/ || config[:url] =~ /^jdbc:sqlserver:/
+    if sqlserver_driver?(config)
       return sqlserver_connection(config)
     end
 

--- a/lib/arjdbc/mssql/driver_info.rb
+++ b/lib/arjdbc/mssql/driver_info.rb
@@ -1,0 +1,11 @@
+module ArJdbc
+  module MSSQL
+    module DriverInfo
+      def sqlserver_driver?(config)
+        config[:driver] =~ /SQLServerDriver$/ || config[:url] =~ /^jdbc:sqlserver:/
+      end
+      module_function :sqlserver_driver?
+    end
+  end
+end
+

--- a/test/db/mssql/savepoint_support.rb
+++ b/test/db/mssql/savepoint_support.rb
@@ -1,0 +1,33 @@
+require 'test_helper'
+require 'arjdbc/mssql/adapter'
+
+class SavepointSupport < Test::Unit::TestCase
+
+  def setup
+    @config = {
+      adapter: 'jdbc',
+      sqlserver_version: '2008'
+    }
+    @connection = mock('connection')
+    @connection.stubs(:jndi?).returns(false)
+  end
+
+  context 'SQL Server Driver' do
+    def test_release_savepoint_falls_back_to_rollback
+      @config[:driver] = 'com.microsoft.sqlserver.jdbc.SQLServerDriver'
+      @adapter = ActiveRecord::ConnectionAdapters::MSSQLAdapter.new(@connection, nil, @config)
+      @connection.expects(:rollback_savepoint)
+      @adapter.release_savepoint('test')
+    end
+  end
+
+  context 'jTDS Driver' do
+    def test_release_savepoint_invoked
+      @config[:driver] = 'net.sourceforge.jtds.jdbc.Driver'
+      @adapter = ActiveRecord::ConnectionAdapters::MSSQLAdapter.new(@connection, nil, @config)
+      @connection.expects(:release_savepoint)
+      @adapter.release_savepoint('test')
+    end
+  end
+
+end


### PR DESCRIPTION
For nested transactions, ActiveRecord makes use of savepoints. When committing these transactions, ActiveRecord will call release_savepoint.

See https://github.com/rails/rails/blob/master/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb#L199

It seems that both the jTDS and Microsoft's own JDBC driver report that they support save points, however the latest Microsoft SQL Server driver (http://msdn.microsoft.com/en-us/sqlserver/aa937724.aspx) does not implement release_savepoint:

```
jruby-1.7.5 :003 > ActiveRecord::Base.connection.jdbc_connection.release_savepoint('foo')
Java::ComMicrosoftSqlserverJdbc::SQLServerException: This operation is not supported.
```

[This article](http://technet.microsoft.com/en-us/library/ms378414.aspx]) seems to show how Microsoft expect savepoints to be used with their driver. They use rollback with the savepoint name instead of invoking the JDBC releaseSavepoint method.

This pull request adds release_savepoint to the MSSQL adapter, overriding the version in the JdbcAdapter base class. It checks to see if the MSSQL adapter is using the Microsoft driver and if so calls rollback_savepoint instead.
