### PR TITLE
PostgreSQL: Add support for array as root element in JSON

### DIFF
--- a/lib/arjdbc/postgresql/adapter.rb
+++ b/lib/arjdbc/postgresql/adapter.rb
@@ -825,6 +825,9 @@ module ArJdbc
         if AR4_COMPAT && column.array? # will be always falsy in AR < 4.0
           column_class = ::ActiveRecord::ConnectionAdapters::PostgreSQLColumn
           "'#{column_class.array_to_string(value, column, self).gsub(/'/, "''")}'"
+        elsif column.type == :json # only in AR-4.0
+          column_class = ::ActiveRecord::ConnectionAdapters::PostgreSQLColumn
+          super(column_class.json_to_string(value), column)
         else super
         end
       when Hash

--- a/lib/arjdbc/postgresql/column.rb
+++ b/lib/arjdbc/postgresql/column.rb
@@ -362,7 +362,7 @@ module ArJdbc
         end
 
         def json_to_string(object)
-          if Hash === object
+          if Hash === object || Array === object
             ActiveSupport::JSON.encode(object)
           else
             object

--- a/test/db/postgresql/json_test.rb
+++ b/test/db/postgresql/json_test.rb
@@ -82,5 +82,18 @@ class PostgresqlJSONTest < Test::Unit::TestCase
     x = JsonDataType.first
     assert_equal(nil, x.payload)
   end
+
+  def test_select_array_json_value
+    @connection.execute %q|insert into json_data_type (payload) VALUES ('["v0",{"k1":"v1"}]')|
+    x = JsonDataType.first
+    assert_equal(['v0', {'k1' => 'v1'}], x.payload)
+  end
+
+  def test_rewrite_array_json_value
+    @connection.execute %q|insert into json_data_type (payload) VALUES ('["v0",{"k1":"v1"}]')|
+    x = JsonDataType.first
+    x.payload = ['v1', {'k2' => 'v2'}, 'v3']
+    assert x.save!
+  end
   
 end if Test::Unit::TestCase.ar_version('4.0')


### PR DESCRIPTION
Currently when trying to store an array in a JSON column, the array is serialized as YAML, which results in:

```
ActiveRecord::StatementInvalid: ActiveRecord::JDBCError: org.postgresql.util.PSQLException: ERROR: invalid input syntax for type json
  Detail: Token "-" is invalid.
  Position: 30
  Where: JSON data, line 1: -...: UPDATE "things" SET "data" = '---
```

This fix is ported from ActiveRecord 4.0.1 (https://github.com/rails/rails/commit/9b66187622453679497ad2fed4f333e2fca32150).
