### PR TITLE
Allow multiple parallell nested transactions on DERBY.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ jndi_test/jdbc/.bindings
 .bundle/config
 gemfiles/.bundle/config
 Gemfile.lock
+/.idea

--- a/lib/arjdbc/derby/adapter.rb
+++ b/lib/arjdbc/derby/adapter.rb
@@ -147,6 +147,13 @@ module ArJdbc
       NATIVE_DATABASE_TYPES
     end
 
+    # Ensure the savepoint name is unused before creating it.
+    # @override
+    def create_savepoint(name = current_savepoint_name(true))
+      release_savepoint(name) if @connection.marked_savepoint_names.include?(name)
+      super(name)
+    end
+
     # @override
     def quote(value, column = nil)
       return value.quoted_id if value.respond_to?(:quoted_id)


### PR DESCRIPTION
This should work for all supported adapters. Fixes #490
