### PR TITLE
[Firebird] Rails 4 Fixes

### DIFF
--- a/lib/arel/visitors/firebird.rb
+++ b/lib/arel/visitors/firebird.rb
@@ -11,7 +11,7 @@ module Arel
         ].compact.join(' ').strip
 
         sql = [
-         o.cores.map { |x| visit_Arel_Nodes_SelectCore x }.join,
+         o.cores.map { |x| do_visit_select_core x, a }.join,
          ("ORDER BY #{o.orders.map { |x| do_visit x, a }.join(', ')}" unless o.orders.empty?),
         ].compact.join ' '
 


### PR DESCRIPTION
Calling `visit_Arel_Nodes_SelectCore(x)` raised an Argument Error with Rails 4. It looks like this change was made for other adapters with @ce7d68df455c0c5bf246a3ed2a781e6c88725359.

Not-null blob values were inserting null values and failing as described in #430. I basically copied the changes that were made in @47bcdcf866a6c2303d6e64cf83b8441affccf706 for the DB2 adapter.

Firebird can't have the table name in the set clause of an update statement. I added the quote_table_name_for_assignment override used in the SQLite3 adapter. (https://github.com/jruby/activerecord-jdbc-adapter/blob/master/lib/arjdbc/sqlite3/adapter.rb#L226-L228)
