### PR TITLE
Replacing use of ActiveRecord::ConnectionFailed with ActiveRecord::Conne...

### DIFF
--- a/lib/arjdbc/derby/adapter.rb
+++ b/lib/arjdbc/derby/adapter.rb
@@ -96,7 +96,7 @@ module ArJdbc
       md = jdbc_connection.meta_data
       major_version = md.database_major_version; minor_version = md.database_minor_version
       if major_version < 10 || (major_version == 10 && minor_version < 5)
-        raise ::ActiveRecord::ConnectionFailed, "Derby adapter requires Derby >= 10.5"
+        raise ::ActiveRecord::ConnectionNotEstablished, "Derby adapter requires Derby >= 10.5"
       end
       if major_version == 10 && minor_version < 8 # 10.8 ~ supports JDBC 4.1
         config[:connection_alive_sql] ||=

--- a/lib/arjdbc/mysql/adapter.rb
+++ b/lib/arjdbc/mysql/adapter.rb
@@ -20,7 +20,7 @@ module ArJdbc
     def init_connection(jdbc_connection)
       meta = jdbc_connection.meta_data
       if meta.driver_major_version < 5
-        raise ::ActiveRecord::ConnectionFailed,
+        raise ::ActiveRecord::ConnectionNotEstablished,
           "MySQL adapter requires driver >= 5.0 got: '#{meta.driver_version}'"
       elsif meta.driver_major_version == 5 && meta.driver_minor_version < 1
         config[:connection_alive_sql] ||= 'SELECT 1' # need 5.1 for JDBC 4.0


### PR DESCRIPTION
ActiveRecord::ConnectionFailed was deprecated/removed sometime in 2007 as AR wasn't using the exception anywhere. ActiveRecord::ConnectionNotEstablished is current and has been in use since at least 1.2. We hit this when updating the AR JDBC adapter on a JRuby/Rails app running an ancient version of the connector.
