### PR TITLE
[Firebird] Not-null blobs and remove table names from set clause in update statement

### DIFF
--- a/lib/arjdbc/firebird/adapter.rb
+++ b/lib/arjdbc/firebird/adapter.rb
@@ -75,6 +75,22 @@ module ArJdbc
     # @see #emulate_booleans?
     def self.emulate_booleans=(emulate); @@emulate_booleans = emulate; end
 
+
+    # Updating records with LOB values (binary/text columns) in a separate
+    # statement can be disabled using :
+    #
+    #   ArJdbc::Firebird.update_lob_values = false
+    def self.update_lob_values?; @@update_lob_values; end
+    # @see #update_lob_values?
+    def self.update_lob_values=(update); @@update_lob_values = update; end
+
+    # @see #update_lob_values?
+    def update_lob_values?; Firebird.update_lob_values?; end
+
+    # @see #quote
+    # @private
+    BLOB_VALUE_MARKER = "''"
+
     ADAPTER_NAME = 'Firebird'.freeze
 
     def adapter_name
@@ -222,8 +238,15 @@ module ArJdbc
       return value if sql_literal?(value)
 
       type = column && column.type
+
       # BLOBs are updated separately by an after_save trigger.
-      return "NULL" if type == :binary || type == :text
+      if type == :binary || type == :text
+        if update_lob_values?
+          return value.nil? ? "NULL" : BLOB_VALUE_MARKER
+        else
+          return "'#{quote_string(value)}'"
+        end
+      end
 
       case value
       when String, ActiveSupport::Multibyte::Chars
@@ -278,6 +301,11 @@ module ArJdbc
     def quoted_false
       quote(0)
     end
+
+    # @override
+    def quote_table_name_for_assignment(table, attr)
+      quote_column_name(attr)
+    end if ::ActiveRecord::VERSION::MAJOR >= 4
 
     # @override
     def quote_column_name(column_name)


### PR DESCRIPTION
Not-null blob values were inserting null values and failing as described in #430. I basically copied the changes that were made in @47bcdcf866a6c2303d6e64cf83b8441affccf706 for the DB2 adapter.

Firebird can't have the table name in the set clause of an update statement. I added the quote_table_name_for_assignment override used in the SQLite3 adapter. (https://github.com/jruby/activerecord-jdbc-adapter/blob/master/lib/arjdbc/sqlite3/adapter.rb#L226-L228)
