### PR TITLE
[Firebird] Initialize update_lob_values

### DIFF
--- a/lib/arjdbc/firebird/adapter.rb
+++ b/lib/arjdbc/firebird/adapter.rb
@@ -76,6 +76,8 @@ module ArJdbc
     def self.emulate_booleans=(emulate); @@emulate_booleans = emulate; end
 
 
+    @@update_lob_values = true
+
     # Updating records with LOB values (binary/text columns) in a separate
     # statement can be disabled using :
     #


### PR DESCRIPTION
The update_lob_values method is defined, but it the variable isn't initialized. This line didn't make it into my last pull request (#519). An error will occur without it.
