### PR TITLE
Match 'int' as well as 'integer' when converting to SQL types for MSSQL

### DIFF
--- a/lib/arjdbc/mssql/adapter.rb
+++ b/lib/arjdbc/mssql/adapter.rb
@@ -123,7 +123,7 @@ module ArJdbc
         'NVARCHAR(MAX)'
       elsif NO_LIMIT_TYPES.include?(type_s)
         super(type)
-      elsif type_s == 'integer'
+      elsif type_s == 'integer' || type_s == 'int'
         if limit.nil? || limit == 4
           'int'
         elsif limit == 2


### PR DESCRIPTION
(As described in Issue #526)

When doing a Rails migration that added a new column of type integer, e.g.

```
  change_table(:users) do |t| 
      t.integer  :sign_in_count, default: 0, null: false
      ...
  end
```

We were getting the following error:

`cannot specify a column width on data type int`

Examining the SQL output you could see that the alter table statement had appended a size parameter to the `INT` type, i.e. `INT(10)`, which SQL Server does not support.

It seems to be because `ArJdbc::MSSQL::type_to_sql` was not matching the integer type and so not following the special case code needed for SQL Server. Instead it was delegating back up to the default implementation (which appends the size parameter to int).

This pull request makes a small change that has `type_to_sql` match `int` as well as `integer`. We are already using this in a monkey patch with success.
