### PR TITLE
Fix rails 4-0-stable compatibility

### DIFF
--- a/lib/arjdbc/jdbc/adapter.rb
+++ b/lib/arjdbc/jdbc/adapter.rb
@@ -507,8 +507,8 @@ module ActiveRecord
 
       # @private
       # @override
-      def select_rows(sql, name = nil)
-        exec_query_raw(sql, name).map!(&:values)
+      def select_rows(sql, name = nil, binds = [])
+        exec_query_raw(sql, name, binds).map!(&:values)
       end
 
       if ActiveRecord::VERSION::MAJOR > 3 # expects AR::Result e.g. from select_all


### PR DESCRIPTION
This [commit](https://github.com/rails/rails/commit/b7fcad8ff04411a8d00f85094b172b6b99402190) broke compatibility with jdbc-adapter:

```
bundle exec rake db:test:prepare
rake aborted!
wrong number of arguments calling `select_rows` (3 for 2)
<path>/db/schema.rb:14:in `(root)'
org/jruby/RubyKernel.java:1099:in `load'
org/jruby/RubyProc.java:271:in `call'
org/jruby/RubyArray.java:1613:in `each'
org/jruby/RubyProc.java:271:in `call'
org/jruby/RubyArray.java:1613:in `each'
org/jruby/RubyProc.java:271:in `call'
org/jruby/RubyArray.java:1613:in `each'
org/jruby/RubyProc.java:271:in `call'
org/jruby/RubyArray.java:1613:in `each'
org/jruby/RubyArray.java:1613:in `each'
org/jruby/RubyKernel.java:1099:in `load'
Tasks: TOP => db:schema:load
(See full trace by running task with --trace)
```
