### PR TITLE
 name of a sequence name must be a usual DB meta-identifier: 31 chars maximum in Firebird

### DIFF
--- a/lib/arjdbc/firebird/adapter.rb
+++ b/lib/arjdbc/firebird/adapter.rb
@@ -192,9 +192,10 @@ module ArJdbc
       table_name = table_name.to_s
       columns(table_name).count { |column| column.primary } == 1
     end
-
-    def default_sequence_name(table_name, column=nil)
-      "#{table_name}_seq"
+    # The name of a sequence name must be a usual DB meta-identifier: 31 chars maximum
+    IDENTIFIER_LENGTH = 31
+    def default_sequence_name(table_name, column = nil)
+      "#{table_name.to_s[0, IDENTIFIER_LENGTH - 4]}_seq"
     end
 
     # Set the sequence to the max value of the table's column.


### PR DESCRIPTION
Fix seq name limit in firebird driver 
http://stackoverflow.com/questions/22096198/rails-jaybird-set-seq-name-for-generator

The name of a generator must be a usual DB meta-identifier: 31 chars maximum
http://www.firebirdsql.org/manual/generatorguide-sqlsyntax.html
