### PR TITLE
Fix connection without user and password

### DIFF
--- a/lib/arjdbc/jdbc/connection.rb
+++ b/lib/arjdbc/jdbc/connection.rb
@@ -78,8 +78,8 @@ module ActiveRecord
         end
 
         url = jdbc_url
-        username = config[:username].to_s
-        password = config[:password].to_s
+        username = config[:username]
+        password = config[:password]
         jdbc_driver = ( config[:driver_instance] ||=
             JdbcDriver.new(config[:driver].to_s, config[:properties]) )
 

--- a/lib/arjdbc/jdbc/driver.rb
+++ b/lib/arjdbc/jdbc/driver.rb
@@ -34,8 +34,8 @@ module ActiveRecord
       def connection(url, user, pass)
         # bypass DriverManager to get around problem with dynamically loaded jdbc drivers
         properties = self.properties.clone
-        properties.setProperty("user", user) if user
-        properties.setProperty("password", pass) if pass
+        properties.setProperty("user", user.to_s) if user
+        properties.setProperty("password", pass.to_s) if pass
         @driver.connect(url, properties)
       end
     end


### PR DESCRIPTION
With DB2 for i native driver, the system allows connection without user and password only if they aren't specified. 

The nil.to_s produces an empty string that is not nil.
