### PR TITLE
Primary key with spaces

### DIFF
--- a/lib/arjdbc/mssql/adapter.rb
+++ b/lib/arjdbc/mssql/adapter.rb
@@ -569,7 +569,7 @@ module ArJdbc
         raise "no columns for table: #{table_name}" if columns.empty?
       end
       # NOTE: if still no PK column simply get something for ORDER BY ...
-      "#{table_name}.#{(primary_column || columns.first).name}"
+      "#{table_name}.[#{(primary_column || columns.first).name}]"
     end
 
     # Support for executing a stored procedure.


### PR DESCRIPTION
Some evil developer at my work, in MSSQL, created a table with a primary key with a space, something like: 'Id Stabile' :weary: 
With this simple edit I was able to query the table. I don't want to put an if around the pickup of the primary key, it will slow down the code without a reason. Only adding the square brackets che code works in any cases.

I would like to add some tests but I don't have a MSSQL right now...
