### PR TITLE
MSSQL: Throwing exceptions in the hot path results in slow code

### DIFF
--- a/lib/arjdbc/mssql/column.rb
+++ b/lib/arjdbc/mssql/column.rb
@@ -51,24 +51,19 @@ module ArJdbc
         return nil if value.nil?
         case type
         when :integer
-          if value.respond_to?(:delete)
-            value.delete('()').to_i
+          case value
+          when String
+            unquote value
           else
-            if value.is_a?(Fixnum)
-              value
-            elsif value.respond_to?(:to_s)
-              unquote(value).to_i
-            else
-              value ? 1 : 0
-            end
-          end
-        when :primary_key then value == true || value == false ? value == true ? 1 : 0 : value.to_i
+            value || 0
+          end.to_i
+        when :primary_key then value.respond_to?(:to_i) ? value.to_i : ((value && 1) || 0)
         when :decimal   then self.class.value_to_decimal(unquote(value))
         when :date      then self.class.string_to_date(value)
         when :datetime  then self.class.string_to_time(value)
         when :timestamp then self.class.string_to_time(value)
         when :time      then self.class.string_to_dummy_time(value)
-        when :boolean   then value == true || (value =~ /^t(rue)?$/i) == 0 || unquote(value) == '1'
+        when :boolean   then !!(value ? value =~ /^t(?:rue)?$/i || unquote(value) == '1' : value)
         when :binary    then unquote value
         else value
         end


### PR DESCRIPTION
On MSSQL, the following code gets 2800 inserts to the CSV per second on MRI,
and 300/s (indy off) on 1.7.12.

```
class Widget < ActiveRecord::Base
end

CSV.open('test.csv','wb') do |csv|
  Widget.find_each do |w|
    csv << w.attributes.values
  end
end
```

I ran it through the JRuby profiler.
79%self was being spent in ArJdbc::MSSQL ArJdbc::MSSQL::Column.type_cast.

Since generating backtraces etc for exceptions are very slow on JRuby,
I guessed at the kind of exceptions this code would encounter.
I'm almost certain there are things I am missing, but this code now performs identically
on MRI and JRuby 1.7.12 (indy off.)

If there is anything else I need to do to make this suitable for merging, I'm happy to do it.
