### PR TITLE
allow database.yml or config option to set insert_returning

### DIFF
--- a/lib/arjdbc/oracle/adapter.rb
+++ b/lib/arjdbc/oracle/adapter.rb
@@ -608,10 +608,11 @@ module ArJdbc
     private :next_id_value
 
     def use_insert_returning?
-      if ( @use_insert_returning ||= nil ).nil?
+      if @use_insert_returning.nil?
         @use_insert_returning = false
       end
-      @use_insert_returning
+
+      !!@use_insert_returning
     end
 
     private

--- a/lib/arjdbc/postgresql/adapter.rb
+++ b/lib/arjdbc/postgresql/adapter.rb
@@ -58,10 +58,11 @@ module ArJdbc
     end
 
     def use_insert_returning?
-      if ( @use_insert_returning ||= nil ).nil?
+      if @use_insert_returning.nil?
         @use_insert_returning = supports_insert_with_returning?
       end
-      @use_insert_returning
+
+      !!@use_insert_returning
     end
 
     def set_client_encoding(encoding)


### PR DESCRIPTION
... without being lost by `||=`

When using the postgres adapter with a unique index that can be triggered on insert we found we need to shut off insert_returning because postgres doesn't handle the unique index violation the same with the RETURNING statement

when we shutoff `insert_returning` we found the ||= preventing us from being able to do so via the ENV variable or the configuration value
