### PR TITLE
fix error so that jruby add_column will respect "after" option

### DIFF
--- a/lib/arjdbc/mysql/adapter.rb
+++ b/lib/arjdbc/mysql/adapter.rb
@@ -451,13 +451,18 @@ module ArJdbc
       rename_column_indexes(table_name, column_name, new_column_name) if respond_to?(:rename_column_indexes) # AR-4.0 SchemaStatements
     end
 
+    def add_column_options!(sql, options)
+      super
+      add_column_position!(sql, options[:column])
+    end
+
     def add_column_position!(sql, options)
-      if options[:first]
+      if options.first
         sql << " FIRST"
-      elsif options[:after]
-        sql << " AFTER #{quote_column_name(options[:after])}"
-      end
-    end unless const_defined? :SchemaCreation
+      elsif options.after
+        sql << " AFTER #{quote_column_name(options.after)}"
+      end if options
+    end
 
     # @note Only used with (non-AREL) ActiveRecord **2.3**.
     # @see Arel::Visitors::MySQL


### PR DESCRIPTION
In activerecord, you can specify add_column with "after" option to tell what column to append the new column after. In jRuby, this option is ignored. This patch should be able to fix it. I am not sure the existing class was tested at all. I will be happy to pair with someone to pair on writing the test.