### PR TITLE
arjdbc: performance improvement in setup_jndi_factory

### DIFF
--- a/lib/arjdbc/jdbc/connection.rb
+++ b/lib/arjdbc/jdbc/connection.rb
@@ -71,7 +71,19 @@ module ActiveRecord
           Java::JavaxNaming::InitialContext.new.lookup(config[:jndi].to_s)
 
         @jndi = true
-        self.connection_factory = JdbcConnectionFactory.impl { data_source.connection }
+        self.connection_factory = RubyJdbcConnectionFactory.new(data_source)
+      end
+
+      class RubyJdbcConnectionFactory
+        include JdbcConnectionFactory
+
+        def initialize(data_source)
+          @data_source = data_source
+        end
+
+        def new_connection
+          @data_source.connection
+        end
       end
 
       def setup_jdbc_factory


### PR DESCRIPTION
By implementing `JdbcConnectionFactory` using the class & mixin pattern instead of using a block, we saw some great performance improvement under high load in Kill Bill (http://github.com/killbill/killbill).

The stack is probably too complex to share details on our benchmark, but https://github.com/jruby/jruby/issues/1401 has related numbers.
