### PR TITLE
'tmpdir' required to execute Rakefile

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -105,6 +105,9 @@ rescue LoadError
   end
 end
 
+# Allow Dir.mktmpdir
+require 'tmpdir'
+
 # JRuby extension compilation :
 
 if defined? JRUBY_VERSION


### PR DESCRIPTION
Causes error in Rails https://travis-ci.org/rails/rails/jobs/40567972

rake aborted!
NoMethodError: undefined method `mktmpdir' for Dir:Class
/home/travis/build/rails/rails/vendor/bundle/jruby/1.9/bundler/gems/activerecord-jdbc-adapter-9a35519775e7/Rakefile:168:in`(root)'
