### PR TITLE
DateTime columns are always returned as nil values.

### DIFF
--- a/lib/arjdbc/jdbc/type_cast.rb
+++ b/lib/arjdbc/jdbc/type_cast.rb
@@ -104,9 +104,10 @@ module ActiveRecord::ConnectionAdapters
             return nil unless time
 
             time -= offset
-            Base.default_timezone == :utc ? time : time.getlocal
+            ActiveRecord::Base.default_timezone == :utc ? time : time.getlocal
           else
-            Time.public_send(Base.default_timezone, year, mon, mday, hour, min, sec, microsec) rescue nil
+            timezone = ActiveRecord::Base.default_timezone
+            Time.public_send(timezone, year, mon, mday, hour, min, sec, microsec) rescue nil
           end
         end
 


### PR DESCRIPTION
Since I've upgraded to Rails 4.2 all the DateTime columns are being returned as nil values.
In response to the commit https://github.com/rails/rails/pull/15184 in the Rails project a module has been added (ActiveRecord::ConnectionAdapters::Jdbc::TypeCast) to handle the compatibility issues.
This module is using "Base" instead of "ActiveRecord::Base" to obtain the default_timezone and the "rescue nil" in the module is hiding the error.

#### Versions
Rails 4.2
jruby 1.7.10 (1.9.3p392) 2014-01-09 c4ecd6b on OpenJDK 64-Bit Server VM 1.7.0_51-b31 [linux-amd64]
activerecord-jdbc-adapter 1.3.13
activerecord-jdbcpostgresql-adapter 1.3.13
PostgreSQL: 9.3.4

#### Sample
```ruby
pry(main)> User.create(name: 'Foo', email: 'foo@ba.r')
=> #<User:0x558c760c
 id: 2,
 name: "Before",
 created_at: 2015-01-16 23:08:38 UTC,
 updated_at: 2015-01-16 23:08:38 UTC,
 email: "be@fo.r">

pry(main)> u = User.where(id: 2)
=>   User Load (17.0ms)  SELECT "users".* FROM "users" WHERE "users"."id" = 2
[#<User:0x14aadcf4
  id: 2,
  name: "Foo",
  created_at: nil,
  updated_at: nil,
  email: "foo@ba.r">]
pry(main)> u.first.created_at
=> nil
```