### PR TITLE
Fixed an undefined exception error

### DIFF
--- a/lib/arjdbc/mysql/adapter.rb
+++ b/lib/arjdbc/mysql/adapter.rb
@@ -542,7 +542,7 @@ module ArJdbc
         when 0..0xfff; "varbinary(#{limit})"
         when nil; "blob"
         when 0x1000..0xffffffff; "blob(#{limit})"
-        else raise(ActiveRecordError, "No binary type has character length #{limit}")
+        else raise ActiveRecord::ActiveRecordError, "No binary type has character length #{limit}"
         end
       when 'integer'
         case limit
@@ -551,7 +551,7 @@ module ArJdbc
         when 3; 'mediumint'
         when nil, 4, 11; 'int(11)' # compatibility with MySQL default
         when 5..8; 'bigint'
-        else raise(ActiveRecordError, "No integer type has byte size #{limit}")
+        else raise ActiveRecord::ActiveRecordError, "No integer type has byte size #{limit}"
         end
       when 'text'
         case limit
@@ -559,7 +559,7 @@ module ArJdbc
         when nil, 0x100..0xffff; 'text'
         when 0x10000..0xffffff; 'mediumtext'
         when 0x1000000..0xffffffff; 'longtext'
-        else raise(ActiveRecordError, "No text type has character length #{limit}")
+        else raise ActiveRecord::ActiveRecordError, "No text type has character length #{limit}"
         end
       else
         super

--- a/test/db/mysql/types_test.rb
+++ b/test/db/mysql/types_test.rb
@@ -9,6 +9,12 @@ class MySQLTypesTest < Test::Unit::TestCase
     assert_equal 'blob', type_to_sql(:binary)
   end
 
+  def test_error_handling
+    assert_raise ActiveRecord::ActiveRecordError { type_to_sql(:binary, 5_000_000_000) }
+    assert_raise ActiveRecord::ActiveRecordError { type_to_sql(:integer, 10) }
+    assert_raise ActiveRecord::ActiveRecordError { type_to_sql(:text, 5_000_000_000) }
+  end
+
   def type_to_sql(*args)
     ActiveRecord::Base.connection.type_to_sql(*args)
   end


### PR DESCRIPTION
In the PG adapter, the `ActiveRecordError` class is defined, in `rename_column` in the MySQL adapter, it calls `ActiveRecord::ActiveRecordError` so I went with being consistent to the MySQL adapter.

Working on getting the test suite to run at the moment