### PR TITLE
Bypass redefining of ActiveRecord array_parser constants on or after Rails 4.1

### DIFF
--- a/lib/arjdbc/postgresql/base/array_parser.rb
+++ b/lib/arjdbc/postgresql/base/array_parser.rb
@@ -5,11 +5,16 @@ module ActiveRecord
     module PostgreSQL
       module ArrayParser
 
-        DOUBLE_QUOTE = '"'
-        BACKSLASH = "\\"
-        COMMA = ','
-        BRACKET_OPEN = '{'
-        BRACKET_CLOSE = '}'
+        # These are defined in ActiveRecord's built-in postgresql connection_adapter as of Rails 4.1
+        # See: https://github.com/rails/rails/commit/a03cfdedddbfb9566e73335cf730310c99810045
+        unless ::ActiveRecord::VERSION::MAJOR > 4 ||
+            ( ::ActiveRecord::VERSION::MAJOR == 4 && ::ActiveRecord::VERSION::MINOR >= 1 )
+          DOUBLE_QUOTE = '"'
+          BACKSLASH = "\\"
+          COMMA = ','
+          BRACKET_OPEN = '{'
+          BRACKET_CLOSE = '}'
+        end
 
         def parse_pg_array(string)
           local_index = 0


### PR DESCRIPTION
To address: 
``` need to check and avoid double loading (e.g. postgresql/array_parser.rb) ```
from
https://github.com/jruby/activerecord-jdbc-adapter/issues/599

The warnings were driving me batty. This is a simple fix. A more elegant one might be to avoid loading the jruby version of the library at all if a current or newer one exists in ActiveRecord (assuming that remains a dependency)

I am afraid I was not able to run the full test suite because of Java loading errors.
I made changes to the rakefile and to ``` /lib/arjdbc/jdbc/java.rb ``` just to get things to compile.
but was not able to get all the pieces working together. Ruby is more of my strong suit. I would be happy to take any pointers, though.
```
Using ActiveRecord::VERSION = 4.2.0
NoMethodError: undefined method `load_java_part' for ArJdbc:Module
                (root) at /Users/kevin/src/prime/activerecord-jdbc-adapter/lib/arjdbc/mysql/adapter.rb:1
               require at org/jruby/RubyKernel.java:1071
               require at /Users/kevin/.rvm/gems/jruby-1.7.18/gems/activesupport-4.2.0/lib/active_support/dependencies.rb:274
       load_dependency at /Users/kevin/.rvm/gems/jruby-1.7.18/gems/activesupport-4.2.0/lib/active_support/dependencies.rb:240
               require at /Users/kevin/.rvm/gems/jruby-1.7.18/gems/activesupport-4.2.0/lib/active_support/dependencies.rb:274
                (root) at /Users/kevin/src/prime/activerecord-jdbc-adapter/lib/arjdbc/mysql.rb:1
               require at org/jruby/RubyKernel.java:1071
               require at /Users/kevin/.rvm/gems/jruby-1.7.18/gems/activesupport-4.2.0/lib/active_support/dependencies.rb:274
       load_dependency at /Users/kevin/.rvm/gems/jruby-1.7.18/gems/activesupport-4.2.0/lib/active_support/dependencies.rb:240
               require at /Users/kevin/.rvm/gems/jruby-1.7.18/gems/activesupport-4.2.0/lib/active_support/dependencies.rb:274
                (root) at /Users/kevin/src/prime/activerecord-jdbc-adapter/lib/arjdbc/mysql.rb:2
                (root) at /Users/kevin/src/prime/activerecord-jdbc-adapter/lib/arjdbc/jdbc/adapter_require.rb:1
               require at /Users/kevin/src/prime/activerecord-jdbc-adapter/lib/arjdbc/jdbc/adapter_require.rb:30
                  spec at /Users/kevin/.rvm/gems/jruby-1.7.18/gems/activerecord-4.2.0/lib/active_record/connection_adapters/connection_specification.rb:175
               require at org/jruby/RubyKernel.java:1071
               require at /Users/kevin/.rvm/gems/jruby-1.7.18/gems/activesupport-4.2.0/lib/active_support/dependencies.rb:274
       load_dependency at /Users/kevin/.rvm/gems/jruby-1.7.18/gems/activesupport-4.2.0/lib/active_support/dependencies.rb:240
               require at /Users/kevin/.rvm/gems/jruby-1.7.18/gems/activesupport-4.2.0/lib/active_support/dependencies.rb:274
  establish_connection at /Users/kevin/.rvm/gems/jruby-1.7.18/gems/activerecord-4.2.0/lib/active_record/connection_handling.rb:50
               require at org/jruby/RubyKernel.java:1071
                (root) at /Users/kevin/src/prime/activerecord-jdbc-adapter/test/db/mysql.rb:4
               require at org/jruby/RubyKernel.java:1071
                (root) at /Users/kevin/.rvm/gems/jruby-1.7.18/gems/rake-10.4.2/lib/rake/rake_test_loader.rb:15
                select at org/jruby/RubyArray.java:2468
                (root) at /Users/kevin/.rvm/gems/jruby-1.7.18/gems/rake-10.4.2/lib/rake/rake_test_loader.rb:4
```