### PR TITLE
Avoid direct reference to javax.naming for Android

### DIFF
--- a/src/java/arjdbc/jdbc/RubyJdbcConnection.java
+++ b/src/java/arjdbc/jdbc/RubyJdbcConnection.java
@@ -1584,9 +1584,15 @@ public class RubyJdbcConnection extends RubyObject {
             try {
                 dataSource = (javax.sql.DataSource) getInitialContext().lookup( dsOrName.toString() );
             }
-            catch (javax.naming.NamingException e) {
-                //throw wrapException(context, context.runtime.getRuntimeError(), e);
-                throw RaiseException.createNativeRaiseException(context.runtime, e);
+            catch (Exception e) {
+                if (e.getClass().getName().equals("javax.naming.NamingException")) {
+                    // throw wrapException(context, context.runtime.getRuntimeError(), e);
+                    throw RaiseException.createNativeRaiseException(context.runtime, e);
+                } else if (e instanceof RuntimeException) {
+                    throw (RuntimeException) e;
+                } else {
+                    throw new RuntimeException("Unexpected exception " + e.getClass().getName(), e);
+                }
             }
         }
 
@@ -1647,8 +1653,15 @@ public class RubyJdbcConnection extends RubyObject {
             final Object bound = getInitialContext().lookup( name.toString() );
             return JavaUtil.convertJavaToRuby(context.runtime, bound);
         }
-        catch (javax.naming.NamingException e) {
-            throw wrapException(context, context.runtime.getNameError(), e);
+        catch (Exception e) {
+            if (e.getClass().getName().equals("javax.naming.NamingException")) {
+                // throw wrapException(context, context.runtime.getNameError(), e);
+                throw RaiseException.createNativeRaiseException(context.runtime, e);
+            } else if (e instanceof RuntimeException) {
+                throw (RuntimeException) e;
+            } else {
+                throw new RuntimeException("Unexpected exception " + e.getClass().getName(), e);
+            }
         }
     }
 


### PR DESCRIPTION
Hi @kares !

Here is a workaround for issue #623 .  Could you see if it is OK to merge?  We loose compile time checking of other checked exceptions (currently none), but it should be caught and reported at runtime.