### PR TITLE
true/false for Rails 4.2, boolean-type MySQL columns

### DIFF
--- a/lib/arjdbc/mysql/abstract_adapter.rb
+++ b/lib/arjdbc/mysql/abstract_adapter.rb
@@ -1,0 +1,41 @@
+module ActiveRecord
+  module ConnectionAdapters # :nodoc:
+
+    class AbstractAdapter
+      protected
+
+      def initialize_type_map(m) # :nodoc:
+        register_class_with_limit m, %r(boolean)i,   Type::Boolean
+        register_class_with_limit m, %r(char)i,      Type::String
+        register_class_with_limit m, %r(binary)i,    Type::Binary
+        register_class_with_limit m, %r(text)i,      Type::Text
+        register_class_with_limit m, %r(date)i,      Type::Date
+        register_class_with_limit m, %r(time)i,      Type::Time
+        register_class_with_limit m, %r(datetime)i,  Type::DateTime
+        register_class_with_limit m, %r(float)i,     Type::Float
+        register_class_with_limit m, %r(int)i,       Type::Integer
+        register_class_with_limit m, %r(tinyint)i,   Type::Boolean
+
+        m.alias_type %r(blob)i,      'binary'
+        m.alias_type %r(clob)i,      'text'
+        m.alias_type %r(timestamp)i, 'datetime'
+        m.alias_type %r(numeric)i,   'decimal'
+        m.alias_type %r(number)i,    'decimal'
+        m.alias_type %r(double)i,    'float'
+
+        m.register_type(%r(decimal)i) do |sql_type|
+          scale = extract_scale(sql_type)
+          precision = extract_precision(sql_type)
+
+          if scale == 0
+            # FIXME: Remove this class as well
+            Type::DecimalWithoutScale.new(precision: precision)
+          else
+            Type::Decimal.new(precision: precision, scale: scale)
+          end
+        end
+      end
+
+    end
+  end
+end

--- a/lib/arjdbc/mysql/adapter.rb
+++ b/lib/arjdbc/mysql/adapter.rb
@@ -9,6 +9,7 @@ module ArJdbc
     # @private
     AR42 = ActiveRecord::VERSION::STRING >= '4.2'
 
+    require 'arjdbc/mysql/abstract_adapter' if AR42 # AR 4.x
     require 'arjdbc/mysql/column'
     require 'arjdbc/mysql/bulk_change_table'
     require 'arjdbc/mysql/explain_support'


### PR DESCRIPTION
fixes #626
"initialize_type_map" method in "AbstractAdapter" class does not register "tinyint", so has ben overwritten.