### PR TITLE
true/false for Rails 4.2, boolean-type MySQL columns

### DIFF
--- a/lib/arjdbc/jdbc/adapter.rb
+++ b/lib/arjdbc/jdbc/adapter.rb
@@ -617,6 +617,13 @@ module ActiveRecord
       end
 
       protected
+      if ActiveRecord::VERSION::STRING >= '4.2'
+        # Override the method in ActiveRecord to include support for tinyint(1)
+        def initialize_type_map(m)
+          super
+          register_class_with_limit m, %r(tinyint)i,   Type::Boolean
+        end
+      end
 
       # @override so that we do not have to care having 2 arguments on 3.0
       def log(sql, name = nil, binds = [])


### PR DESCRIPTION
fixes #626 "initialize_type_map" method in "AbstractAdapter" class does not register "tinyint", so has ben overwritten for all adapters.