### PR TITLE
Fixed issue #692 (for 4.2 create table with reference failed, created index twice) 

### DIFF
--- a/lib/arjdbc/mysql/adapter.rb
+++ b/lib/arjdbc/mysql/adapter.rb
@@ -224,6 +224,11 @@ module ArJdbc
     end
 
     # @override
+    def supports_indexes_in_create?
+      true
+    end
+
+    # @override
     def supports_transaction_isolation?
       # MySQL 4 technically support transaction isolation, but it is affected by
       # a bug where the transaction level gets persisted for the whole session:

--- a/test/db/mysql/simple_test.rb
+++ b/test/db/mysql/simple_test.rb
@@ -123,6 +123,24 @@ class MySQLSimpleTest < Test::Unit::TestCase
     connection.drop_table :values rescue nil
   end
 
+  # see https://github.com/jruby/activerecord-jdbc-adapter/issues/629
+  def test_tables_with_refrences
+    connection = Entry.connection
+    connection.create_table :as do |t|
+      t.integer :value
+    end
+    connection.create_table :bs do |t|
+      t.references :b, index: true
+    end
+
+    assert_nothing_raised do
+      connection.add_foreign_key :bs, :as
+    end
+
+    connection.drop_table :as rescue nil
+    connection.drop_table :bs rescue nil
+  end
+
   def test_find_in_other_schema_with_include
     user_1 = User.create :login => 'user1'
     user_2 = User.create :login => 'user2'

--- a/test/db/mysql/simple_test.rb
+++ b/test/db/mysql/simple_test.rb
@@ -139,7 +139,7 @@ class MySQLSimpleTest < Test::Unit::TestCase
 
     connection.drop_table :as rescue nil
     connection.drop_table :bs rescue nil
-  end
+  end if ar_version("4.2")
 
   def test_find_in_other_schema_with_include
     user_1 = User.create :login => 'user1'


### PR DESCRIPTION
Hi

Please review fix for #692. I know - this is probably bigger problem with AR 4.2 compatibility, hope it may help somehow however. I'm working on few more 4.2 issues and may pull some additional fixes. Added necessary test case.
