### PR TITLE
Change jdbc-h2 dependency version to 1.4

### DIFF
--- a/activerecord-jdbch2-adapter/activerecord-jdbch2-adapter.gemspec
+++ b/activerecord-jdbch2-adapter/activerecord-jdbch2-adapter.gemspec
@@ -21,5 +21,6 @@ Gem::Specification.new do |gem|
   gem.files = `git ls-files`.split("\n") # assuming . working directory
 
   gem.add_dependency 'activerecord-jdbc-adapter', "~>#{version}"
-  gem.add_dependency 'jdbc-h2', '~> 1.3.0'
+  gem.add_dependency 'jdbc-h2', '~> 1.4.0'
+
 end


### PR DESCRIPTION
Hi, we want to give H2 1.4 a shot in order to experiment with the new file locking method FS.
Unfortunately the current version of activerecord-jdbch2-adapter enforces jdbc-h2 version 1.3, which hinders us to do so.
This PR changes the version dependency to 1.4 (>= 1.3 would also be fine for us).