### PR TITLE
Issue 649: Correct the getConnectionInternal for JNDI Regression

### DIFF
--- a/src/java/arjdbc/jdbc/RubyJdbcConnection.java
+++ b/src/java/arjdbc/jdbc/RubyJdbcConnection.java
@@ -3089,7 +3089,7 @@ public class RubyJdbcConnection extends RubyObject {
     private Connection getConnectionInternal(final boolean required) throws SQLException {
         Connection connection = getConnectionImpl();
         if ( connection == null ) {
-            if ( required || ! connected ) {
+            if ( required && ! connected ) {
                 final Ruby runtime = getRuntime();
                 final RubyClass errorClass = getConnectionNotEstablished( runtime );
                 throw new RaiseException(runtime, errorClass, "no connection available", false);


### PR DESCRIPTION
Fixes the GetConnectionInternal() function so that any lazy connection source will function correctly.

This seems to have been a simple coding error that was not exposed until it was used with a Connection source that was set to being lazy, and at this point I can only find that being set for JNDI connections.

This corrects it as the flow is allowed to fall through to the existing code below the test that actually forces the creation of a connection if none exists.