### PR TITLE
 Fix postgres array test for Rails 4.2

### DIFF
--- a/lib/arjdbc/postgresql/column.rb
+++ b/lib/arjdbc/postgresql/column.rb
@@ -52,6 +52,9 @@ module ArJdbc
     module Column
 
       attr_accessor :array
+      def array?
+        array
+      end
 
       def initialize(name, default, cast_type, sql_type = nil, null = true, default_function = nil,
         oid = nil, adapter = nil) # added arguments

--- a/test/db/postgresql/simple_test.rb
+++ b/test/db/postgresql/simple_test.rb
@@ -101,7 +101,7 @@ class PostgresSimpleTest < Test::Unit::TestCase
   def test_create_table_with_array
     connection.create_table :my_posts do |t|
       t.string :name; t.text :description
-      t.string :tags, :array => true, :default => []
+      t.string :tags, :array => true, :default => '{}'
       t.timestamps
     end
 


### PR DESCRIPTION
 - Defined array? method in ArJdbc::Postgresql::Column module which is
   used in tests for Rails 4.2.
 - Also fixed default value of array in PostgreSQL in tests.