### PR TITLE
Allow reading "infinity" and "BC timestamps

### DIFF
--- a/lib/arjdbc/jdbc/type_cast.rb
+++ b/lib/arjdbc/jdbc/type_cast.rb
@@ -33,6 +33,7 @@ module ActiveRecord::ConnectionAdapters
       def string_to_time(string)
         return string unless string.is_a?(String)
         return nil if string.empty?
+        return string if string =~ /^-?infinity$/.freeze
 
         fast_string_to_time(string) || fallback_string_to_time(string)
       end
@@ -134,6 +135,7 @@ module ActiveRecord::ConnectionAdapters
         def fallback_string_to_time(string)
           time_hash = Date._parse(string)
           time_hash[:sec_fraction] = microseconds(time_hash)
+          time_hash[:year] *= -1 if time_hash[:zone] == 'BC'
 
           new_time(*time_hash.values_at(:year, :mon, :mday, :hour, :min, :sec, :sec_fraction, :offset))
         end

--- a/test/db/postgresql/array_type_test.rb
+++ b/test/db/postgresql/array_type_test.rb
@@ -60,7 +60,7 @@ class PostgreSQLArrayTypeTest < Test::Unit::TestCase
     assert_equal :integer, column.type
     assert column.array
     assert_equal 'integer', column.sql_type
-    assert_equal ar_version('4.2') ? '{}' : [], column.default
+    assert_equal [], column.default
   end
 
   def test_change_column_with_array
@@ -71,7 +71,7 @@ class PostgreSQLArrayTypeTest < Test::Unit::TestCase
     column = PgArray.columns.find { |c| c.name == 'snippets' }
 
     assert_equal :text, column.type
-    assert_equal ar_version('4.2') ? '{}' : [], column.default
+    assert_equal [], column.default
     assert column.array
   end
 

--- a/test/db/postgresql/json_test.rb
+++ b/test/db/postgresql/json_test.rb
@@ -102,7 +102,7 @@ class PostgresqlJSONTest < Test::Unit::TestCase
     if ar_version('4.2')
       column.type_cast_from_database data
     else
-      column.class.type_cast data
+      column.type_cast data
     end
   end
 

--- a/test/db/postgresql/simple_test.rb
+++ b/test/db/postgresql/simple_test.rb
@@ -124,23 +124,11 @@ class PostgresSimpleTest < Test::Unit::TestCase
 
   def test_resolves_correct_columns_default
     assert column = DbType.columns.find { |col| col.name == 'sample_small_decimal' }
-    unless ar_version('4.2')
-      assert_equal 3.14, column.default
-    else
-      assert_equal '3.14', column.default
-    end
+    assert_equal 3.14, column.default
     assert column = DbType.columns.find { |col| col.name == 'sample_integer_no_limit' }
-    unless ar_version('4.2')
-      assert_equal 42, column.default
-    else
-      assert_equal '42', column.default
-    end
+    assert_equal 42, column.default
     assert column = DbType.columns.find { |col| col.name == 'sample_integer_neg_default' }
-    unless ar_version('4.2')
-      assert_equal -1, column.default
-    else
-      assert_equal '-1', column.default
-    end
+    assert_equal -1, column.default
   end
 
   def test_supports_standard_conforming_string

--- a/test/db/postgresql/types_test.rb
+++ b/test/db/postgresql/types_test.rb
@@ -674,7 +674,15 @@ _SQL
         @first_bit_string.save
       end
     end
-  end if ar_version('4.0')
+  end if ar_version('4.0') && !ar_version('4.2')
+
+  def test_hex_to_bit_string
+    @first_bit_string.bit_string = 'FF'
+    disable_logger do
+      @first_bit_string.save
+      assert_equal '11111111', @first_bit_string.reload.bit_string
+    end
+  end if ar_version('4.2')
 
   def test_update_oid
     new_value = 567890


### PR DESCRIPTION
Reverted tests mistakenly adjusted to AR42

Tests are green for PostgreSQL locally for AR41 and AR42.