### PR TITLE
Store binary data as-is for PostgreSQL

### DIFF
--- a/lib/arjdbc/postgresql/adapter.rb
+++ b/lib/arjdbc/postgresql/adapter.rb
@@ -918,7 +918,7 @@ module ArJdbc
     def _quote(value)
       case value
       when Type::Binary::Data
-        "'#{escape_bytea(value.to_s)}'"
+        "E'#{escape_bytea(value.to_s)}'"
       when OID::Xml::Data
         "xml '#{quote_string(value.to_s)}'"
       when OID::Bit::Data

--- a/lib/arjdbc/postgresql/oid/bytea.rb
+++ b/lib/arjdbc/postgresql/oid/bytea.rb
@@ -1,0 +1,3 @@
+class ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Bytea
+  remove_method :type_cast_from_database
+end

--- a/lib/arjdbc/postgresql/oid_types.rb
+++ b/lib/arjdbc/postgresql/oid_types.rb
@@ -5,6 +5,7 @@ module ArJdbc
 
     if AR42
       require 'active_record/connection_adapters/postgresql/oid'
+      require 'arjdbc/postgresql/oid/bytea.rb'
     else
       require 'arjdbc/postgresql/base/oid'
     end


### PR DESCRIPTION
Use the "E" prefix to mark the input as escaped binary data, and do not unescape when reading the data back from the DB.

Fixes #675 