### PR TITLE
Fix H2/HSQLDB LIMIT and OFFSET with AR 4.2

### DIFF
--- a/lib/arel/visitors/h2.rb
+++ b/lib/arel/visitors/h2.rb
@@ -4,6 +4,10 @@ require 'arel/visitors/hsqldb'
 module Arel
   module Visitors
     class H2 < Arel::Visitors::HSQLDB
+      def visit_Arel_Nodes_SelectStatement(o, *)
+        o.limit ||= Arel::Nodes::Limit.new(-1) if o.offset
+        super
+      end if ArJdbc::AR42
     end
   end
 end

--- a/lib/arel/visitors/h2.rb
+++ b/lib/arel/visitors/h2.rb
@@ -8,6 +8,18 @@ module Arel
         o.limit ||= Arel::Nodes::Limit.new(-1) if o.offset
         super
       end if ArJdbc::AR42
+
+      def limit_offset sql, o
+        offset = o.offset || 0
+        offset = offset.expr unless (offset.nil? || offset == 0)
+        if limit = o.limit
+          "SELECT LIMIT #{offset} #{limit_for(limit)} #{sql[7..-1]}"
+        elsif offset > 0
+          "SELECT LIMIT #{offset} -1 #{sql[7..-1]}" # removes "SELECT "
+        else
+          sql
+        end
+      end unless ArJdbc::AR42
     end
   end
 end

--- a/lib/arel/visitors/hsqldb.rb
+++ b/lib/arel/visitors/hsqldb.rb
@@ -3,6 +3,10 @@ require 'arel/visitors/compat'
 module Arel
   module Visitors
     class HSQLDB < Arel::Visitors::ToSql
+      def visit_Arel_Nodes_SelectStatement(o, *)
+        o.limit ||= Arel::Nodes::Limit.new(0) if o.offset
+        super
+      end if ArJdbc::AR42
 
       def visit_Arel_Nodes_SelectStatement o, a = nil
         sql = limit_offset(o.cores.map { |x| do_visit_select_core x, a }.join, o)

--- a/test/db/hsqldb/offset_test.rb
+++ b/test/db/hsqldb/offset_test.rb
@@ -1,5 +1,5 @@
-require 'test_helper'
-require 'db/h2'
+require_relative '../../test_helper'
+require 'db/hsqldb'
 
 class H2OffsetTest < Test::Unit::TestCase
 
@@ -50,7 +50,7 @@ class H2OffsetTest < Test::Unit::TestCase
     assert_nothing_raised do
       sql = query.to_sql
       if ArJdbc::AR42
-        assert_equal 'SELECT FROM persons LIMIT -1 OFFSET 3', sql, 'SQL statement was not generated, properly'
+        assert_equal 'SELECT FROM persons LIMIT 0 OFFSET 3', sql, 'SQL statement was not generated, properly'
       else
         assert_equal "SELECT LIMIT 3", sql[0..13], "SQL statement was not generated, properly"
       end


### PR DESCRIPTION
Adds a test for LIMIT and OFFSET including having an OFFSET without a LIMIT.  This was broken for older versions of AR as well, but fixed now.