### PR TITLE
Fixed MySQL primary key for MySQL >= 5.7.3

### DIFF
--- a/lib/arjdbc/mysql/adapter.rb
+++ b/lib/arjdbc/mysql/adapter.rb
@@ -98,7 +98,7 @@ module ArJdbc
     def self.emulate_booleans=(emulate); @@emulate_booleans = emulate; end
 
     NATIVE_DATABASE_TYPES = {
-      :primary_key => "int(11) DEFAULT NULL auto_increment PRIMARY KEY",
+      :primary_key => "int(11) auto_increment PRIMARY KEY",
       :string => { :name => "varchar", :limit => 255 },
       :text => { :name => "text" },
       :integer => { :name => "int", :limit => 4 },


### PR DESCRIPTION
Same PR as https://github.com/jruby/activerecord-jdbc-adapter/pull/694 but aiming to target the next 1.3 release.