### PR TITLE
support for DB2 big integer (BIGINT) data type

### DIFF
--- a/lib/arjdbc/db2/adapter.rb
+++ b/lib/arjdbc/db2/adapter.rb
@@ -117,6 +117,7 @@ module ArJdbc
     NATIVE_DATABASE_TYPES = {
       :string     => { :name => "varchar", :limit => 255 },
       :integer    => { :name => "integer" },
+      :bigint     => { :name => 'bigint' },
       :float      => { :name => "real" }, # :limit => 24
       :double     => { :name => "double" }, # :limit => 53
       :text       => { :name => "clob" },


### PR DESCRIPTION
I made this change in order to be able to create fields of type BIGINT. Without, the adapter adds a limit (e.g. ```BIGINT(19)```), which is inappropriate and causes failure.