### PR TITLE
Retrieve AM::Type::Boolean::FALSE_VALUES for Rails 5.

### DIFF
--- a/lib/arjdbc/jdbc/type_cast.rb
+++ b/lib/arjdbc/jdbc/type_cast.rb
@@ -7,7 +7,7 @@ module ActiveRecord::ConnectionAdapters
     module TypeCast
 
       TRUE_VALUES = Column::TRUE_VALUES if Column.const_defined?(:TRUE_VALUES)
-      FALSE_VALUES = Column::FALSE_VALUES
+      FALSE_VALUES = Column.const_defined?(:FALSE_VALUES) ? Column::FALSE_VALUES : ActiveModel::Type::Boolean::FALSE_VALUES
 
       #module Format
       ISO_DATE = Column::Format::ISO_DATE


### PR DESCRIPTION
Relates to #704.

`FALSE_VALUES` isn't found in `AR::ConnectionAdapters::Column` anymore, but rather in `AM::Type::Boolean`.

EDIT: Not complete as I need to test it out with a new Rails project. I've just encountered other issues. Stand by.

@kares Help me review it? Thanks! <3