### PR TITLE
fix ArgumentError using invokedynamic

### DIFF
--- a/lib/arjdbc/jdbc/adapter.rb
+++ b/lib/arjdbc/jdbc/adapter.rb
@@ -452,7 +452,7 @@ module ActiveRecord
           log(sql, name, binds) { @connection.execute_query(sql, binds) }
         else
           sql = suble_binds(sql, binds) unless to_sql # deprecated behavior
-          log(sql, name) { @connection.execute_query(sql) }
+          log(sql, name) { @connection.execute_query(sql, 0) }
         end
       end
 


### PR DESCRIPTION
this fixes #691 by bypassing https://github.com/jruby/activerecord-jdbc-adapter/blob/1-3-stable/src/java/arjdbc/jdbc/RubyJdbcConnection.java#L885 and calling https://github.com/jruby/activerecord-jdbc-adapter/blob/1-3-stable/src/java/arjdbc/jdbc/RubyJdbcConnection.java#L902 directly

I can't say why but I guess the method overloading confuses the JVM/JRuby/InvokeDynamic somehow. This fixes all issues we had when enabling InvokeDynamic. Also skips one unnecessary method call.

Maybe the core of the issue lies in jruby 9k handling of invokedynamic (ping https://github.com/jruby/jruby/issues/3528) but I don't see a harm in this change.

Off topic but I also just saw that jruby 9k is not in the travis-ci matrix is there a reason for that?
