### PR TITLE
Enable DDL transactions for Derby

### DIFF
--- a/lib/arjdbc/derby/adapter.rb
+++ b/lib/arjdbc/derby/adapter.rb
@@ -422,6 +422,9 @@ module ArJdbc
     end
 
     # @override
+    def supports_ddl_transactions?; true end
+
+    # @override
     def supports_foreign_keys?; true end
 
     def truncate(table_name, name = nil)


### PR DESCRIPTION
DDL (migration) transactions used to be enabled for Derby.  Not sure when/how/why it was disabled.

OK, to merge?