### PR TITLE
Fix incorrect postgresql_version when running RC

### DIFF
--- a/lib/arjdbc/postgresql/adapter.rb
+++ b/lib/arjdbc/postgresql/adapter.rb
@@ -55,7 +55,7 @@ module ArJdbc
       @postgresql_version ||=
         begin
           version = select_version
-          if version =~ /PostgreSQL (\d+)\.(\d+)\.(\d+)/
+          if version =~ /PostgreSQL (\d+)\.(\d+)(?:\.(\d+))?/
             ($1.to_i * 10000) + ($2.to_i * 100) + $3.to_i
           else
             0


### PR DESCRIPTION
PostgreSQL server release candidates might not follow a semantic versioning scheme, but instead a `<major>.<minor>rc<#>`. This patches `postgresql_version()` to take that into account. Resolves #717 
