### PR TITLE
Improve message for 'no columns for table' error

### DIFF
--- a/lib/arjdbc/mssql/adapter.rb
+++ b/lib/arjdbc/mssql/adapter.rb
@@ -650,7 +650,7 @@ module ArJdbc
       unless primary_column # look for an id column and return it,
         # without changing case, to cover DBs with a case-sensitive collation :
         primary_column = columns.find { |column| column.name =~ /^id$/i }
-        raise "no columns for table: #{table_name}" if columns.empty?
+        raise "no columns for table: #{table_name} (SQL query: ' #{sql} ')" if columns.empty?
       end
       # NOTE: if still no PK column simply get something for ORDER BY ...
       "#{quote_table_name(table_name)}.#{quote_column_name((primary_column || columns.first).name)}"


### PR DESCRIPTION
This error message is very unlikely to happen, but it did, when JRuby had a bug with Regexes: jruby/jruby/#3670
Knowing, that the generated query was OK would have saved us many hours thinking about our queries...
