### PR TITLE
Execute CREATE USER explicitly to support MySQL 5.7

### DIFF
--- a/rakelib/db.rake
+++ b/rakelib/db.rake
@@ -8,6 +8,7 @@ namespace :db do
     load 'test/db/mysql_config.rb' # rescue nil
     script = sql_script <<-SQL, 'mysql'
 DROP DATABASE IF EXISTS `#{MYSQL_CONFIG[:database]}`;
+CREATE USER #{MYSQL_CONFIG[:username]}@localhost;
 CREATE DATABASE `#{MYSQL_CONFIG[:database]}` DEFAULT CHARACTER SET `utf8` COLLATE `utf8_general_ci`;
 GRANT ALL PRIVILEGES ON `#{MYSQL_CONFIG[:database]}`.* TO #{MYSQL_CONFIG[:username]}@localhost;
 GRANT ALL PRIVILEGES ON `test\_%`.* TO #{MYSQL_CONFIG[:username]}@localhost;
@@ -20,7 +21,7 @@ SQL
       params['--password'] = password
     end
     puts "Creating MySQL (test) database: #{MYSQL_CONFIG[:database]}"
-    sh "cat #{script.path} | #{mysql} #{params.to_a.join(' ')}", :verbose => $VERBOSE # so password is not echoed
+    sh "cat #{script.path} | #{mysql} -f #{params.to_a.join(' ')}", :verbose => $VERBOSE # so password is not echoed
   end
 
   desc "Creates the test database for PostgreSQL"


### PR DESCRIPTION
This pull request addresses this error when `rails-5` branch tested with MySQL 5.7.
- Steps to reproduce

``` ruby
$ git checkout rails-5
$ bundle exec rake test_mysql
Creating MySQL (test) database: arjdbc_test
ERROR 1133 (42000) at line 3: Can't find any matching row in the user table
rake aborted!
Command failed with status (1): [cat /tmp/mysql20160519-4782-1dsvwfl | /usr...]
/home/yahonda/git/activerecord-jdbc-adapter/rakelib/db.rake:23:in `block in (root)'
/home/yahonda/.rbenv/versions/jruby-9.1.0.0/bin/bundle:22:in `<top>'
Tasks: TOP => test_mysql => db:mysql
(See full trace by running task with --trace)
```

Since MySQL 5.7 `grant` statements will not create database users anymore. https://dev.mysql.com/doc/relnotes/mysql/5.7/en/news-5-7-7.html

> In MySQL 5.7.6, the NO_AUTO_CREATE_USER was deprecated. (It is preferable to create MySQL accounts with CREATE USER rather than GRANT.) Now the default SQL mode includes NO_AUTO_CREATE_USER and assignments to sql_mode that change the NO_AUTO_CREATE_USER mode state produce a warning, except assignments that set sql_mode to DEFAULT. NO_AUTO_CREATE_USER will be removed in a future MySQL release, at which point its effect will be enabled at all times (GRANT will not create accounts).

Also added -f option to ignore `ERROR 1396 (HY000) at line 2: Operation CREATE USER failed for 'arjdbc'@'localhost'` error when `bundle exec rake test_mysql` executed twice. I think it is acceptable to add -f option to ignore errors for this rake tasks.  
- Environment

``` sql
$ mysql -uroot
Welcome to the MySQL monitor.  Commands end with ; or \g.
Your MySQL connection id is 1038
Server version: 5.7.12-0ubuntu1 (Ubuntu)
```

```
$ ruby -v
jruby 9.1.0.0 (2.3.0) 2016-05-02 a633c63 Java HotSpot(TM) 64-Bit Server VM 25.91-b14 on 1.8.0_91-b14 +jit [linux-x86_64]
```

```
$ java -version
java version "1.8.0_91"
Java(TM) SE Runtime Environment (build 1.8.0_91-b14)
Java HotSpot(TM) 64-Bit Server VM (build 25.91-b14, mixed mode)
```
