### PR TITLE
Ensuring that H2 uses custom column class.

### DIFF
--- a/lib/arjdbc/h2/adapter.rb
+++ b/lib/arjdbc/h2/adapter.rb
@@ -10,6 +10,11 @@ module ArJdbc
       ::ActiveRecord::ConnectionAdapters::H2JdbcConnection
     end
 
+    # @see ActiveRecord::ConnectionAdapters::JdbcAdapter#jdbc_column_class
+    def jdbc_column_class
+      ::ActiveRecord::ConnectionAdapters::H2Column
+    end
+
     # @see ActiveRecord::ConnectionAdapters::JdbcColumn#column_types
     def self.column_selector
       [ /\.h2\./i, lambda { |config, column| column.extend(Column) } ]
@@ -298,6 +303,10 @@ module ActiveRecord::ConnectionAdapters
 
   class H2Adapter < JdbcAdapter
     include ArJdbc::H2
+  end
+
+  class H2Column < JdbcColumn
+    include ::ArJdbc::H2::Column
   end
 
 end


### PR DESCRIPTION
It appears that when I create a model class, and invoke `create!` using h2, the ID (primary key) field on the returned object is always `0`. After some investigation, it appears that the code exists in the h2 adapter to address this, but the `Column` module wasn't getting used. I've copied the pattern used in the Oracle adapter to use that module. 

My environment:
ARJDBC: 1.3.20
JRuby: 1.7.20
Rails: 4.1.1
h2 driver: 1.4.187
Java: 1.8.0_66

In my application, where the problem was encountered, the h2 connection is setup externally, in some custom Java code.