### PR TITLE
Adds citext to Postgres AR42 Native database types.

### DIFF
--- a/lib/arjdbc/postgresql/adapter.rb
+++ b/lib/arjdbc/postgresql/adapter.rb
@@ -274,7 +274,8 @@ module ArJdbc
       :bigserial => "bigserial",
       :bigint => { :name => "bigint" },
       :bit => { :name => "bit" },
-      :bit_varying => { :name => "bit varying" }
+      :bit_varying => { :name => "bit varying" },
+      :citext => { :name => "citext" }
     ) if AR42
 
     def native_database_types


### PR DESCRIPTION
In the current version of the postgres adapter,  Rails has problems generating a schema.rb for a table that uses a citext. Instead of the table's schema, it generate:

```
#  Could not dump table "whatever_table_name_is" because of following StandardError
#   Unknown type 'citext' for column 'email'
```

The cause is that valid_type? is coming back false for citext since it isn't included in NATIVE_DATABASE_TYPES.  

Let me know if you'd like me to add a test (and where a good place to add one would be!)
