### PR TITLE
Reduce memory consumption when retrieving BINARY columns with MySQL adapter

### DIFF
--- a/src/java/arjdbc/mysql/MySQLRubyJdbcConnection.java
+++ b/src/java/arjdbc/mysql/MySQLRubyJdbcConnection.java
@@ -54,6 +54,7 @@ import org.jruby.exceptions.RaiseException;
 import org.jruby.runtime.ObjectAllocator;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
+import org.jruby.util.ByteList;
 
 /**
  *
@@ -101,6 +102,12 @@ public class MySQLRubyJdbcConnection extends RubyJdbcConnection {
         if ( type == Types.BIT ) {
             final int value = resultSet.getInt(column);
             return resultSet.wasNull() ? runtime.getNil() : runtime.newFixnum(value);
+        }
+        else if ( type == Types.BINARY || type == Types.VARBINARY) {
+            final byte[] bytes = resultSet.getBytes(column);
+            if ( bytes == null || resultSet.wasNull() ) return runtime.getNil();
+            final ByteList byteList = new ByteList(bytes, false);
+            return new RubyString(runtime, runtime.getString(), byteList);
         }
         return super.jdbcToRuby(context, runtime, column, type, resultSet);
     }


### PR DESCRIPTION
When retrieving data for a BINARY column with the MySQL adapter, the adapter is allocating 2K for each field and is being read as a stream. However I believe MySQL only allows a size of 255 bytes for BINARY and VARBINARY fields. For example this causes excessive memory to be consumed when retrieving a large number(100K+) of binary ids (UUIDs).

This is a fix for: https://github.com/jruby/activerecord-jdbc-adapter/issues/741

BINARY treated as stream:
https://github.com/jruby/activerecord-jdbc-adapter/blob/e9366a5a25dc919e7fe7d6319410aec2e9532edb/src/java/arjdbc/jdbc/RubyJdbcConnection.java#L2161
https://github.com/jruby/activerecord-jdbc-adapter/blob/e9366a5a25dc919e7fe7d6319410aec2e9532edb/src/java/arjdbc/jdbc/RubyJdbcConnection.java#L2464-L2481

Storage requirements for MySQL BINARY and VARBINARY:
http://dev.mysql.com/doc/refman/5.7/en/storage-requirements.html


Before this fix doing an ActiveRecord pluck(:uuid) where 500k rows are returned consumes over 1G, where it should only be around 8M.

![image](https://cloud.githubusercontent.com/assets/121275/17837273/c2cae11a-677c-11e6-861d-b154f3338c29.png)


With this fix the MySQL adapter consumes the expected memory:

![image](https://cloud.githubusercontent.com/assets/121275/17837275/e7a9af66-677c-11e6-8b15-87575690bf1f.png)


The ActiveRecord time for the above went from (3745.0ms) to (1992.0ms).

My testing was done with activerecord-jdbc-adapter 1.3.21, JRuby 1.7.19, and Rails 4.2, but I believe every version has this issue.
The existing MySQLBinaryTest seems sufficient for testing.