### PR TITLE
Repair postgres array support

### DIFF
--- a/lib/arjdbc/postgresql/base/oid.rb
+++ b/lib/arjdbc/postgresql/base/oid.rb
@@ -403,6 +403,9 @@ module ActiveRecord
         register_type 'json', OID::Json.new
         register_type 'jsonb', OID::Jsonb.new
         register_type 'ltree', OID::Identity.new
+        
+        register_type 'array', OID::Array.new
+
 
         register_type 'cidr', OID::Cidr.new
         alias_type 'inet', 'cidr'

--- a/lib/arjdbc/postgresql/oid/array.rb
+++ b/lib/arjdbc/postgresql/oid/array.rb
@@ -1,3 +1,3 @@
-class ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Array::PG < ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Array
+class ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Array
   
 end

--- a/lib/arjdbc/postgresql/oid/array.rb
+++ b/lib/arjdbc/postgresql/oid/array.rb
@@ -1,3 +1,105 @@
-class ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Array
-  
+module ActiveRecord
+  module ConnectionAdapters
+    module PostgreSQL
+      module OID # :nodoc:
+        class Array < Type::Value # :nodoc:
+          include Type::Helpers::Mutable
+
+          # Loads pg_array_parser if available. String parsing can be
+          # performed quicker by a native extension, which will not create
+          # a large amount of Ruby objects that will need to be garbage
+          # collected. pg_array_parser has a C and Java extension
+          begin
+            require 'pg_array_parser'
+            include PgArrayParser
+          rescue LoadError
+            require 'active_record/connection_adapters/postgresql/array_parser'
+            include PostgreSQL::ArrayParser
+          end
+
+          attr_reader :subtype, :delimiter
+          delegate :type, :user_input_in_time_zone, :limit, to: :subtype
+
+          def initialize(subtype, delimiter = ',')
+            @subtype = subtype
+            @delimiter = delimiter
+          end
+
+          def deserialize(value)
+            if value.is_a?(::String)
+              type_cast_array(parse_pg_array(value), :deserialize)
+            else
+              super
+            end
+          end
+
+          def cast(value)
+            if value.is_a?(::String)
+              value = parse_pg_array(value)
+            end
+            type_cast_array(value, :cast)
+          end
+
+          def serialize(value)
+            if value.is_a?(::Array)
+              cast_value_for_database(value)
+            else
+              super
+            end
+          end
+
+          def ==(other)
+            other.is_a?(Array) &&
+              subtype == other.subtype &&
+              delimiter == other.delimiter
+          end
+
+          private
+
+          def type_cast_array(value, method)
+            if value.is_a?(::Array)
+              value.map { |item| type_cast_array(item, method) }
+            else
+              @subtype.public_send(method, value)
+            end
+          end
+
+          def cast_value_for_database(value)
+            if value.is_a?(::Array)
+              casted_values = value.map { |item| cast_value_for_database(item) }
+              "{#{casted_values.join(delimiter)}}"
+            else
+              quote_and_escape(subtype.serialize(value))
+            end
+          end
+
+          ARRAY_ESCAPE = "\\" * 2 * 2 # escape the backslash twice for PG arrays
+
+          def quote_and_escape(value)
+            case value
+            when ::String
+              if string_requires_quoting?(value)
+                value = value.gsub(/\\/, ARRAY_ESCAPE)
+                value.gsub!(/"/,"\\\"")
+                %("#{value}")
+              else
+                value
+              end
+            when nil then "NULL"
+            else value
+            end
+          end
+
+          # See http://www.postgresql.org/docs/9.2/static/arrays.html#ARRAYS-IO
+          # for a list of all cases in which strings will be quoted.
+          def string_requires_quoting?(string)
+            string.empty? ||
+              string == "NULL" ||
+              string =~ /[\{\}"\\\s]/ ||
+              string.include?(delimiter)
+          end
+        end
+      end
+    end
+  end
 end

--- a/lib/arjdbc/postgresql/oid/array.rb
+++ b/lib/arjdbc/postgresql/oid/array.rb
@@ -1,2 +1,3 @@
-class ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Array
+class ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Array::PG < ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Array
+  
 end

--- a/lib/arjdbc/postgresql/oid/array.rb
+++ b/lib/arjdbc/postgresql/oid/array.rb
@@ -14,7 +14,6 @@ module ActiveRecord
             require 'pg_array_parser'
             include PgArrayParser
           rescue LoadError
-            require 'active_record/connection_adapters/postgresql/array_parser'
             include PostgreSQL::ArrayParser
           end
 

--- a/lib/arjdbc/postgresql/oid/array.rb
+++ b/lib/arjdbc/postgresql/oid/array.rb
@@ -1,2 +1,2 @@
-class ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Array
+class ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Array::PG
 end

--- a/lib/arjdbc/postgresql/oid/array.rb
+++ b/lib/arjdbc/postgresql/oid/array.rb
@@ -1,3 +1,4 @@
+##copied from rails/active_record history as they changed the implementation to use the PG gem fo speed (C) reasons
 module ActiveRecord
   module ConnectionAdapters
     module PostgreSQL

--- a/lib/arjdbc/postgresql/oid/array.rb
+++ b/lib/arjdbc/postgresql/oid/array.rb
@@ -1,2 +1,2 @@
-class ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Bytea
+class ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Array
 end

--- a/lib/arjdbc/postgresql/oid/array.rb
+++ b/lib/arjdbc/postgresql/oid/array.rb
@@ -1,0 +1,2 @@
+class ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Bytea
+end

--- a/lib/arjdbc/postgresql/oid/array.rb
+++ b/lib/arjdbc/postgresql/oid/array.rb
@@ -14,6 +14,7 @@ module ActiveRecord
             require 'pg_array_parser'
             include PgArrayParser
           rescue LoadError
+            require 'arjdbc/postgresql/base/array_parser.rb'
             include PostgreSQL::ArrayParser
           end
 

--- a/lib/arjdbc/postgresql/oid/array.rb
+++ b/lib/arjdbc/postgresql/oid/array.rb
@@ -1,2 +1,2 @@
-class ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Array::PG
+class ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Array
 end

--- a/lib/arjdbc/postgresql/oid_types.rb
+++ b/lib/arjdbc/postgresql/oid_types.rb
@@ -6,6 +6,8 @@ module ArJdbc
     if AR42
       require 'active_record/connection_adapters/postgresql/oid'
       require 'arjdbc/postgresql/oid/bytea.rb'
+      require 'arjdbc/postgresql/oid/array.rb'
+
     else
       require 'arjdbc/postgresql/base/oid'
     end

--- a/lib/arjdbc/postgresql/oid_types.rb
+++ b/lib/arjdbc/postgresql/oid_types.rb
@@ -199,7 +199,7 @@ module ArJdbc
         m.register_type 'citext', OID::SpecializedString.new(:citext)
         m.register_type 'ltree', OID::SpecializedString.new(:ltree)
         
-        m.register_type 'array', OID:Array.new
+        m.register_type 'array', Type:Array.new
 
         # FIXME: why are we keeping these types as strings?
         m.alias_type 'interval', 'varchar'

--- a/lib/arjdbc/postgresql/oid_types.rb
+++ b/lib/arjdbc/postgresql/oid_types.rb
@@ -196,6 +196,8 @@ module ArJdbc
         m.register_type 'macaddr', OID::SpecializedString.new(:macaddr)
         m.register_type 'citext', OID::SpecializedString.new(:citext)
         m.register_type 'ltree', OID::SpecializedString.new(:ltree)
+        
+        m.register_type 'array', OID:Array.new
 
         # FIXME: why are we keeping these types as strings?
         m.alias_type 'interval', 'varchar'

--- a/lib/arjdbc/postgresql/oid_types.rb
+++ b/lib/arjdbc/postgresql/oid_types.rb
@@ -6,7 +6,6 @@ module ArJdbc
     if AR42
       require 'active_record/connection_adapters/postgresql/oid'
       require 'arjdbc/postgresql/oid/bytea.rb'
-      require 'arjdbc/postgresql/oid/array.rb'
 
     else
       require 'arjdbc/postgresql/base/oid'

--- a/lib/arjdbc/postgresql/oid_types.rb
+++ b/lib/arjdbc/postgresql/oid_types.rb
@@ -6,6 +6,7 @@ module ArJdbc
     if AR42
       require 'active_record/connection_adapters/postgresql/oid'
       require 'arjdbc/postgresql/oid/bytea.rb'
+      require 'arjdbc/postgresql/oid/array.rb'
 
     else
       require 'arjdbc/postgresql/base/oid'


### PR DESCRIPTION
They way activerecord implemented array support changed from ruby based to a C based implementation to apparently speed it up, this reverts that change for our purposes for obvious reasons of not supporting C
Also note that I discovered a gem called pg_array_parser that implements a C based and a Java based speedier method.

Another tick along the line of resolving #708 