### PR TITLE
Mssql with case sensitive collation

### DIFF
--- a/lib/arjdbc/mssql/adapter.rb
+++ b/lib/arjdbc/mssql/adapter.rb
@@ -568,7 +568,7 @@ module ArJdbc
     def remove_check_constraints(table_name, column_name)
       clear_cached_table(table_name)
       constraints = select_values "SELECT constraint_name" <<
-        " FROM information_schema.constraint_column_usage" <<
+        " FROM INFORMATION_SCHEMA.CONSTRAINT_COLUMN_USAGE" <<
         " WHERE table_name = '#{table_name}' AND column_name = '#{column_name}'"
       constraints.each do |constraint_name|
         execute "ALTER TABLE #{table_name} DROP CONSTRAINT #{constraint_name}"

--- a/test/db/mssql/ignore_system_views_test.rb
+++ b/test/db/mssql/ignore_system_views_test.rb
@@ -8,11 +8,11 @@ class MSSQLIgnoreSystemViewsTest < Test::Unit::TestCase
     assert_not_include tables, 'views'
     if ActiveRecord::Base.connection.sqlserver_version == "2000"
       assert_false table_exists?("sys.views"), %{table_exists?("sys.views")}
-      assert_false table_exists?("information_schema.views"), %{table_exists?("information_schema.views")}
+      assert_false table_exists?("INFORMATION_SCHEMA.VIEWS"), %{table_exists?("INFORMATION_SCHEMA.views")}
     else
       assert_true table_exists?("sys.views"), %{table_exists?("sys.views")}
-      assert_true table_exists?("information_schema.views"), %{table_exists?("information_schema.views")}
-      
+      assert_true table_exists?("INFORMATION_SCHEMA.VIEWS"), %{table_exists?("INFORMATION_SCHEMA.views")}
+
       assert_true table_exists?(:views), %{table_exists?(:views)}
     end
     assert_false table_exists?("dbo.views"), %{table_exists?("dbo.views")}
@@ -31,10 +31,10 @@ class MSSQLIgnoreSystemViewsTest < Test::Unit::TestCase
   def tables
     ActiveRecord::Base.connection.tables
   end
-  
+
   def table_exists?(*args)
     ActiveRecord::Base.connection.table_exists?(*args)
   end
-    
+
 end
 

--- a/test/db/mssql/ignore_system_views_test.rb
+++ b/test/db/mssql/ignore_system_views_test.rb
@@ -8,10 +8,10 @@ class MSSQLIgnoreSystemViewsTest < Test::Unit::TestCase
     assert_not_include tables, 'views'
     if ActiveRecord::Base.connection.sqlserver_version == "2000"
       assert_false table_exists?("sys.views"), %{table_exists?("sys.views")}
-      assert_false table_exists?("INFORMATION_SCHEMA.VIEWS"), %{table_exists?("INFORMATION_SCHEMA.views")}
+      assert_false table_exists?("INFORMATION_SCHEMA.VIEWS"), %{table_exists?("INFORMATION_SCHEMA.VIEWS")}
     else
       assert_true table_exists?("sys.views"), %{table_exists?("sys.views")}
-      assert_true table_exists?("INFORMATION_SCHEMA.VIEWS"), %{table_exists?("INFORMATION_SCHEMA.views")}
+      assert_true table_exists?("INFORMATION_SCHEMA.VIEWS"), %{table_exists?("INFORMATION_SCHEMA.VIEWS")}
 
       assert_true table_exists?(:views), %{table_exists?(:views)}
     end

--- a/test/db/mssql/simple_test.rb
+++ b/test/db/mssql/simple_test.rb
@@ -154,6 +154,23 @@ class MSSQLSimpleTest < Test::Unit::TestCase
     assert ! columns.find { |col| col.name == 'another_column' }
   end
 
+  def test_remove_column_with_constraint
+    ActiveRecord::Schema.define do
+      add_column :entries, 'another_column', :string
+      ActiveRecord::Base.connection.execute "ALTER TABLE entries ADD CONSTRAINT another_column_constraint CHECK (another_column != '!');"
+    end
+
+    columns = ActiveRecord::Base.connection.columns("entries")
+    assert columns.find { |col| col.name == 'another_column' }
+
+    ActiveRecord::Schema.define do
+      remove_column "entries", 'another_column'
+    end
+
+    columns = ActiveRecord::Base.connection.columns("entries")
+    assert ! columns.find { |col| col.name == 'another_column' }
+  end
+
   # from include DirtyAttributeTests :
 
 #  ActiveRecord::AttributeMethods.class_eval do


### PR DESCRIPTION
Changed selects from information schema to uppercase.
If MS SQL database has case sensitive collation, then information schema views must be accessed with uppercase schema and view names.