### PR TITLE
Use `remove_index` method and remove `remove_index!` method

### DIFF
--- a/lib/arjdbc/sqlite3/adapter.rb
+++ b/lib/arjdbc/sqlite3/adapter.rb
@@ -471,7 +471,8 @@ module ArJdbc
     end
 
     # @override
-    def remove_index!(table_name, index_name)
+    def remove_index(table_name, options = {})
+      index_name = index_name_for_remove(table_name, options)
       execute "DROP INDEX #{quote_column_name(index_name)}"
     end
 


### PR DESCRIPTION
Refer https://github.com/rails/rails/pull/21317

This pull request addresses these 19 errors for sqlite3 database adapter since https://github.com/rails/rails/pull/21317 removes `remove_index!` method then ActiveRecord JDBC adapter is now using Abstract `remove_index` method whose syntax is for MySQL.

```ruby
   1) Error:
 TestDestroyAsPartOfAutosaveAssociation#test_should_save_new_record_that_has_same_value_as_existing_record_marked_for_destruction_on_field_that_has_unique_index:
 ActiveRecord::StatementInvalid: ActiveRecord::JDBCError: [SQLITE_ERROR] SQL error or missing database (near "ON": syntax error): DROP INDEX "index_birds_on_name" ON "birds"
     arjdbc/jdbc/RubyJdbcConnection.java:587:in `execute'
     /home/yahonda/git/activerecord-jdbc-adapter/lib/arjdbc/jdbc/adapter.rb:566:in `_execute'
     /home/yahonda/git/activerecord-jdbc-adapter/lib/arjdbc/jdbc/adapter.rb:542:in `block in execute'
     /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:589:in `block in log'
     /home/yahonda/git/rails/activesupport/lib/active_support/notifications/instrumenter.rb:21:in `instrument'
     /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:583:in `log'
     /home/yahonda/git/activerecord-jdbc-adapter/lib/arjdbc/jdbc/adapter.rb:542:in `execute'
     /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb:736:in `remove_index'
     /home/yahonda/git/rails/activerecord/test/cases/autosave_association_test.rb:963:in `test_should_save_new_record_that_has_same_value_as_existing_record_marked_for_destruction_on_field_that_has_unique_index'


   2) Error:
 TestAutosaveAssociationOnAHasManyAssociation#test_should_allow_to_bypass_validations_on_the_associated_models_on_update:
 ActiveRecord::RecordNotUnique: ActiveRecord::JDBCError: column name is not unique: UPDATE "birds" SET "name" = '' WHERE "birds"."id" = 19
     arjdbc/jdbc/RubyJdbcConnection.java:673:in `execute_update'
     /home/yahonda/git/activerecord-jdbc-adapter/lib/arjdbc/jdbc/adapter.rb:477:in `block in exec_update'
     /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:589:in `block in log'
     /home/yahonda/git/rails/activesupport/lib/active_support/notifications/instrumenter.rb:21:in `instrument'
     /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:583:in `log'
     /home/yahonda/git/activerecord-jdbc-adapter/lib/arjdbc/jdbc/adapter.rb:477:in `exec_update'
     /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:133:in `update'
     /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb:14:in `update'
     /home/yahonda/git/rails/activerecord/lib/active_record/relation.rb:89:in `_update_record'
     /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:551:in `_update_record'
     /home/yahonda/git/rails/activerecord/lib/active_record/locking/optimistic.rb:79:in `_update_record'
     /home/yahonda/git/rails/activerecord/lib/active_record/attribute_methods/dirty.rb:119:in `_update_record'
     /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:306:in `block in _update_record'
     /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:97:in `__run_callbacks__'
     /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:750:in `_run_update_callbacks'
     /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:306:in `_update_record'
     /home/yahonda/git/rails/activerecord/lib/active_record/timestamp.rb:81:in `_update_record'
     /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:540:in `create_or_update'
     /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:298:in `block in create_or_update'
     /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:126:in `call'
     /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:506:in `block in compile'
     /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:455:in `call'
     /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:101:in `__run_callbacks__'
     /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:750:in `_run_save_callbacks'
     /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:298:in `create_or_update'
     /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:125:in `save'
     /home/yahonda/git/rails/activerecord/lib/active_record/validations.rb:44:in `save'
     /home/yahonda/git/rails/activerecord/lib/active_record/attribute_methods/dirty.rb:22:in `save'
     /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:319:in `block in save'
     /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:395:in `block in with_transaction_returning_status'
     /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:230:in `transaction'
     /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:211:in `transaction'
     /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:392:in `with_transaction_returning_status'
     /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:319:in `block in save'
     /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:334:in `rollback_active_record_state!'
     /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:318:in `save'
     /home/yahonda/git/rails/activerecord/lib/active_record/suppressor.rb:41:in `save'
     /home/yahonda/git/rails/activerecord/lib/active_record/autosave_association.rb:405:in `block in save_collection_association'
     org/jruby/RubyArray.java:1734:in `each'
     /home/yahonda/git/rails/activerecord/lib/active_record/autosave_association.rb:393:in `save_collection_association'
     /home/yahonda/git/rails/activerecord/lib/active_record/autosave_association.rb:185:in `block in add_autosave_association_callbacks'
     org/jruby/RubyBasicObject.java:1667:in `instance_eval'
     /home/yahonda/git/rails/activerecord/lib/active_record/autosave_association.rb:158:in `block in autosave_associated_records_for_birds'
     /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:382:in `block in make_lambda'
     /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:207:in `block in halting_and_conditional'
     /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:456:in `block in call'
     org/jruby/RubyArray.java:1734:in `each'
     /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:456:in `call'
     /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:101:in `__run_callbacks__'
     /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:750:in `_run_update_callbacks'
     /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:306:in `_update_record'
     /home/yahonda/git/rails/activerecord/lib/active_record/timestamp.rb:81:in `_update_record'
     /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:540:in `create_or_update'
     /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:298:in `block in create_or_update'
     /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:126:in `call'
     /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:506:in `block in compile'
     /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:455:in `call'
     /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:101:in `__run_callbacks__'
     /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:750:in `_run_save_callbacks'
     /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:298:in `create_or_update'
     /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:125:in `save'
     /home/yahonda/git/rails/activerecord/lib/active_record/validations.rb:44:in `save'
     /home/yahonda/git/rails/activerecord/lib/active_record/attribute_methods/dirty.rb:22:in `save'
     /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:319:in `block in save'
     /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:395:in `block in with_transaction_returning_status'
     /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:232:in `block in transaction'
     /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb:189:in `within_new_transaction'
     /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:232:in `transaction'
     /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:211:in `transaction'
     /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:392:in `with_transaction_returning_status'
     /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:319:in `block in save'
     /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:334:in `rollback_active_record_state!'
     /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:318:in `save'
     /home/yahonda/git/rails/activerecord/lib/active_record/suppressor.rb:41:in `save'
     /home/yahonda/git/rails/activerecord/test/cases/autosave_association_test.rb:1437:in `test_should_allow_to_bypass_validations_on_the_associated_models_on_update'


   3) Error:
 ActiveRecord::AdapterTest#test_remove_index_when_name_and_wrong_column_name_specified:
 ActiveRecord::StatementInvalid: ActiveRecord::JDBCError: [SQLITE_ERROR] SQL error or missing database (near "ON": syntax error): DROP INDEX "accounts_idx" ON "accounts"
     arjdbc/jdbc/RubyJdbcConnection.java:587:in `execute'
     /home/yahonda/git/activerecord-jdbc-adapter/lib/arjdbc/jdbc/adapter.rb:566:in `_execute'
     /home/yahonda/git/activerecord-jdbc-adapter/lib/arjdbc/jdbc/adapter.rb:542:in `block in execute'
     /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:589:in `block in log'
     /home/yahonda/git/rails/activesupport/lib/active_support/notifications/instrumenter.rb:21:in `instrument'
     /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:583:in `log'
     /home/yahonda/git/activerecord-jdbc-adapter/lib/arjdbc/jdbc/adapter.rb:542:in `execute'
     /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb:736:in `remove_index'
     /home/yahonda/git/rails/activerecord/test/cases/adapter_test.rb:98:in `test_remove_index_when_name_and_wrong_column_name_specified'

   7) Error:
 ActiveRecord::InvertibleMigrationTest#test_exception_on_removing_index_without_column_option:
 ActiveRecord::StatementInvalid: ActiveRecord::JDBCError: [SQLITE_ERROR] SQL error or missing database (near "ON": syntax error): DROP INDEX "index_horses_on_name_and_color" ON "horses"
     arjdbc/jdbc/RubyJdbcConnection.java:587:in `execute'
     /home/yahonda/git/activerecord-jdbc-adapter/lib/arjdbc/jdbc/adapter.rb:566:in `_execute'
     /home/yahonda/git/activerecord-jdbc-adapter/lib/arjdbc/jdbc/adapter.rb:542:in `block in execute'
     /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:589:in `block in log'
     /home/yahonda/git/rails/activesupport/lib/active_support/notifications/instrumenter.rb:21:in `instrument'
     /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:583:in `log'
     /home/yahonda/git/activerecord-jdbc-adapter/lib/arjdbc/jdbc/adapter.rb:542:in `execute'
     /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb:736:in `remove_index'
     /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb:568:in `remove_index'
     /home/yahonda/git/rails/activerecord/test/cases/invertible_migration_test.rb:77:in `block in change'
     /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb:438:in `change_table'
     /home/yahonda/git/rails/activerecord/lib/active_record/migration.rb:846:in `block in method_missing'
     /home/yahonda/git/rails/activerecord/lib/active_record/migration.rb:815:in `block in say_with_time'
     /home/yahonda/.rbenv/versions/jruby-9.1.5.0/lib/ruby/stdlib/benchmark.rb:293:in `measure'
     /home/yahonda/git/rails/activerecord/lib/active_record/migration.rb:815:in `say_with_time'
     /home/yahonda/git/rails/activerecord/lib/active_record/migration.rb:835:in `method_missing'
     /home/yahonda/git/rails/activerecord/test/cases/invertible_migration_test.rb:76:in `change'
     /home/yahonda/git/rails/activerecord/lib/active_record/migration.rb:789:in `exec_migration'
     /home/yahonda/git/rails/activerecord/lib/active_record/migration.rb:773:in `block in migrate'
     /home/yahonda/.rbenv/versions/jruby-9.1.5.0/lib/ruby/stdlib/benchmark.rb:293:in `measure'
     /home/yahonda/git/rails/activerecord/lib/active_record/migration.rb:772:in `block in migrate'
     /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb:398:in `with_connection'
     /home/yahonda/git/rails/activerecord/lib/active_record/migration.rb:771:in `migrate'
     /home/yahonda/git/rails/activerecord/test/cases/invertible_migration_test.rb:192:in `test_exception_on_removing_index_without_column_option'


   8) Error:
 ActiveRecord::InvertibleMigrationTest#test_migrate_revert_add_index_with_name:
 ActiveRecord::StatementInvalid: ActiveRecord::JDBCError: [SQLITE_ERROR] SQL error or missing database (near "ON": syntax error): DROP INDEX "horses_index_named" ON "horses"
     arjdbc/jdbc/RubyJdbcConnection.java:587:in `execute'
     /home/yahonda/git/activerecord-jdbc-adapter/lib/arjdbc/jdbc/adapter.rb:566:in `_execute'
     /home/yahonda/git/activerecord-jdbc-adapter/lib/arjdbc/jdbc/adapter.rb:542:in `block in execute'
     /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:589:in `block in log'
     /home/yahonda/git/rails/activesupport/lib/active_support/notifications/instrumenter.rb:21:in `instrument'
     /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:583:in `log'
     /home/yahonda/git/activerecord-jdbc-adapter/lib/arjdbc/jdbc/adapter.rb:542:in `execute'
     /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb:736:in `remove_index'
     /home/yahonda/git/rails/activerecord/lib/active_record/migration.rb:846:in `block in method_missing'
     /home/yahonda/git/rails/activerecord/lib/active_record/migration.rb:815:in `block in say_with_time'
     /home/yahonda/.rbenv/versions/jruby-9.1.5.0/lib/ruby/stdlib/benchmark.rb:293:in `measure'
     /home/yahonda/git/rails/activerecord/lib/active_record/migration.rb:815:in `say_with_time'
     /home/yahonda/git/rails/activerecord/lib/active_record/migration.rb:835:in `method_missing'
     /home/yahonda/git/rails/activerecord/lib/active_record/migration.rb:680:in `block in revert'
     org/jruby/RubyArray.java:1734:in `each'
     /home/yahonda/git/rails/activerecord/lib/active_record/migration.rb:679:in `revert'
     /home/yahonda/git/rails/activerecord/lib/active_record/migration.rb:787:in `exec_migration'
     /home/yahonda/git/rails/activerecord/lib/active_record/migration.rb:773:in `block in migrate'
     /home/yahonda/.rbenv/versions/jruby-9.1.5.0/lib/ruby/stdlib/benchmark.rb:293:in `measure'
     /home/yahonda/git/rails/activerecord/lib/active_record/migration.rb:772:in `block in migrate'
     /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb:398:in `with_connection'
     /home/yahonda/git/rails/activerecord/lib/active_record/migration.rb:771:in `migrate'
     /home/yahonda/git/rails/activerecord/test/cases/invertible_migration_test.rb:376:in `test_migrate_revert_add_index_with_name'


  14) Error:
 TestNestedAttributesOnAHasManyAssociation#test_should_be_possible_to_destroy_a_record:
 ActiveRecord::RecordNotUnique: ActiveRecord::JDBCError: [SQLITE_CONSTRAINT]  Abort due to constraint violation (column name is not unique): INSERT INTO "birds" ("name", "pirate_id") VALUES ('Grace OMalley', 959118196)
     arjdbc/jdbc/RubyJdbcConnection.java:587:in `execute'
     /home/yahonda/git/activerecord-jdbc-adapter/lib/arjdbc/jdbc/adapter.rb:566:in `_execute'
     /home/yahonda/git/activerecord-jdbc-adapter/lib/arjdbc/jdbc/adapter.rb:542:in `block in execute'
     /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:589:in `block in log'
     /home/yahonda/git/rails/activesupport/lib/active_support/notifications/instrumenter.rb:21:in `instrument'
     /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:583:in `log'
     /home/yahonda/git/activerecord-jdbc-adapter/lib/arjdbc/jdbc/adapter.rb:542:in `execute'
     /home/yahonda/git/activerecord-jdbc-adapter/lib/arjdbc/sqlite3/adapter.rb:423:in `exec_insert'
     /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:124:in `insert'
     /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb:14:in `insert'
     /home/yahonda/git/rails/activerecord/lib/active_record/relation.rb:65:in `insert'
     /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:560:in `_create_record'
     /home/yahonda/git/rails/activerecord/lib/active_record/counter_cache.rb:128:in `_create_record'
     /home/yahonda/git/rails/activerecord/lib/active_record/locking/optimistic.rb:75:in `_create_record'
     /home/yahonda/git/rails/activerecord/lib/active_record/attribute_methods/dirty.rb:123:in `_create_record'
     /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:302:in `block in _create_record'
     /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:97:in `__run_callbacks__'
     /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:750:in `_run_create_callbacks'
     /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:302:in `_create_record'
     /home/yahonda/git/rails/activerecord/lib/active_record/timestamp.rb:68:in `_create_record'
     /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:540:in `create_or_update'
     /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:298:in `block in create_or_update'
     /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:126:in `call'
     /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:506:in `block in compile'
     /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:455:in `call'
     /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:101:in `__run_callbacks__'
     /home/yahonda/git/rails/activesupport/lib/active_support/callbacks.rb:750:in `_run_save_callbacks'
     /home/yahonda/git/rails/activerecord/lib/active_record/callbacks.rb:298:in `create_or_update'
     /home/yahonda/git/rails/activerecord/lib/active_record/persistence.rb:152:in `save!'
     /home/yahonda/git/rails/activerecord/lib/active_record/validations.rb:50:in `save!'
     /home/yahonda/git/rails/activerecord/lib/active_record/attribute_methods/dirty.rb:30:in `save!'
     /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:324:in `block in save!'
     /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:395:in `block in with_transaction_returning_status'
     /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:230:in `transaction'
     /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:211:in `transaction'
     /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:392:in `with_transaction_returning_status'
     /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:324:in `save!'
     /home/yahonda/git/rails/activerecord/lib/active_record/suppressor.rb:45:in `save!'
     /home/yahonda/git/rails/activerecord/lib/active_record/associations/has_many_association.rb:46:in `insert_record'
     /home/yahonda/git/rails/activerecord/lib/active_record/associations/collection_association.rb:516:in `block in _create_record'
     /home/yahonda/git/rails/activerecord/lib/active_record/associations/collection_association.rb:429:in `replace_on_target'
     /home/yahonda/git/rails/activerecord/lib/active_record/associations/collection_association.rb:423:in `add_to_target'
     /home/yahonda/git/rails/activerecord/lib/active_record/associations/collection_association.rb:514:in `block in _create_record'
     /home/yahonda/git/rails/activerecord/lib/active_record/associations/collection_association.rb:203:in `block in transaction'
     /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:232:in `block in transaction'
     /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb:189:in `within_new_transaction'
     /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:232:in `transaction'
     /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:211:in `transaction'
     /home/yahonda/git/rails/activerecord/lib/active_record/associations/collection_association.rb:202:in `transaction'
     /home/yahonda/git/rails/activerecord/lib/active_record/associations/collection_association.rb:513:in `_create_record'
     /home/yahonda/git/rails/activerecord/lib/active_record/associations/has_many_association.rb:136:in `_create_record'
     /home/yahonda/git/rails/activerecord/lib/active_record/associations/collection_association.rb:176:in `create!'
     /home/yahonda/git/rails/activerecord/lib/active_record/associations/collection_proxy.rb:340:in `create!'
     /home/yahonda/git/rails/activerecord/test/cases/nested_attributes_test.rb:777:in `block in test_should_be_possible_to_destroy_a_record'
     org/jruby/RubyArray.java:1734:in `each'
     /home/yahonda/git/rails/activerecord/test/cases/nested_attributes_test.rb:776:in `test_should_be_possible_to_destroy_a_record'

  22) Error:
 ReservedWordsMigrationTest#test_drop_index_from_table_named_values:
 ActiveRecord::StatementInvalid: ActiveRecord::JDBCError: [SQLITE_ERROR] SQL error or missing database (near "ON": syntax error): DROP INDEX "index_values_on_value" ON "values"
     arjdbc/jdbc/RubyJdbcConnection.java:587:in `execute'
     /home/yahonda/git/activerecord-jdbc-adapter/lib/arjdbc/jdbc/adapter.rb:566:in `_execute'
     /home/yahonda/git/activerecord-jdbc-adapter/lib/arjdbc/jdbc/adapter.rb:542:in `block in execute'
     /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:589:in `block in log'
     /home/yahonda/git/rails/activesupport/lib/active_support/notifications/instrumenter.rb:21:in `instrument'
     /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:583:in `log'
     /home/yahonda/git/activerecord-jdbc-adapter/lib/arjdbc/jdbc/adapter.rb:542:in `execute'
     /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb:736:in `remove_index'
     /home/yahonda/git/rails/activerecord/test/cases/migration_test.rb:768:in `block in test_drop_index_from_table_named_values'
     /home/yahonda/git/rails/activesupport/lib/active_support/test_case.rb:83:in `assert_nothing_raised'
     /home/yahonda/git/rails/activerecord/test/cases/migration_test.rb:766:in `test_drop_index_from_table_named_values'


  23) Error:
 ExplicitlyNamedIndexMigrationTest#test_drop_index_by_name:
 ActiveRecord::StatementInvalid: ActiveRecord::JDBCError: [SQLITE_ERROR] SQL error or missing database (near "ON": syntax error): DROP INDEX "a_different_name" ON "values"
     arjdbc/jdbc/RubyJdbcConnection.java:587:in `execute'
     /home/yahonda/git/activerecord-jdbc-adapter/lib/arjdbc/jdbc/adapter.rb:566:in `_execute'
     /home/yahonda/git/activerecord-jdbc-adapter/lib/arjdbc/jdbc/adapter.rb:542:in `block in execute'
     /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:589:in `block in log'
     /home/yahonda/git/rails/activesupport/lib/active_support/notifications/instrumenter.rb:21:in `instrument'
     /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:583:in `log'
     /home/yahonda/git/activerecord-jdbc-adapter/lib/arjdbc/jdbc/adapter.rb:542:in `execute'
     /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb:736:in `remove_index'
     /home/yahonda/git/rails/activerecord/test/cases/migration_test.rb:784:in `block in test_drop_index_by_name'
     /home/yahonda/git/rails/activesupport/lib/active_support/test_case.rb:83:in `assert_nothing_raised'
     /home/yahonda/git/rails/activerecord/test/cases/migration_test.rb:782:in `test_drop_index_by_name'


  66) Error:
 ActiveRecord::Migration::IndexTest#test_add_index:
 ActiveRecord::StatementInvalid: ActiveRecord::JDBCError: [SQLITE_ERROR] SQL error or missing database (near "ON": syntax error): DROP INDEX "index_testings_on_last_name" ON "testings"
     arjdbc/jdbc/RubyJdbcConnection.java:587:in `execute'
     /home/yahonda/git/activerecord-jdbc-adapter/lib/arjdbc/jdbc/adapter.rb:566:in `_execute'
     /home/yahonda/git/activerecord-jdbc-adapter/lib/arjdbc/jdbc/adapter.rb:542:in `block in execute'
     /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:589:in `block in log'
     /home/yahonda/git/rails/activesupport/lib/active_support/notifications/instrumenter.rb:21:in `instrument'
     /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:583:in `log'
     /home/yahonda/git/activerecord-jdbc-adapter/lib/arjdbc/jdbc/adapter.rb:542:in `execute'
     /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb:736:in `remove_index'
     /home/yahonda/git/rails/activerecord/test/cases/migration/index_test.rb:154:in `test_add_index'


  67) Error:
 ActiveRecord::Migration::IndexTest#test_add_index_works_with_long_index_names:
 ActiveRecord::StatementInvalid: ActiveRecord::JDBCError: [SQLITE_ERROR] SQL error or missing database (near "ON": syntax error): DROP INDEX "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" ON "testings"
     arjdbc/jdbc/RubyJdbcConnection.java:587:in `execute'
     /home/yahonda/git/activerecord-jdbc-adapter/lib/arjdbc/jdbc/adapter.rb:566:in `_execute'
     /home/yahonda/git/activerecord-jdbc-adapter/lib/arjdbc/jdbc/adapter.rb:542:in `block in execute'
     /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:589:in `block in log'
     /home/yahonda/git/rails/activesupport/lib/active_support/notifications/instrumenter.rb:21:in `instrument'
     /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:583:in `log'
     /home/yahonda/git/activerecord-jdbc-adapter/lib/arjdbc/jdbc/adapter.rb:542:in `execute'
     /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb:736:in `remove_index'
     /home/yahonda/git/rails/activerecord/test/cases/migration/index_test.rb:68:in `test_add_index_works_with_long_index_names'


  68) Error:
 ActiveRecord::Migration::IndexTest#test_index_symbol_names:
 ActiveRecord::StatementInvalid: ActiveRecord::JDBCError: [SQLITE_ERROR] SQL error or missing database (near "ON": syntax error): DROP INDEX "symbol_index_name" ON "testings"
     arjdbc/jdbc/RubyJdbcConnection.java:587:in `execute'
     /home/yahonda/git/activerecord-jdbc-adapter/lib/arjdbc/jdbc/adapter.rb:566:in `_execute'
     /home/yahonda/git/activerecord-jdbc-adapter/lib/arjdbc/jdbc/adapter.rb:542:in `block in execute'
     /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:589:in `block in log'
     /home/yahonda/git/rails/activesupport/lib/active_support/notifications/instrumenter.rb:21:in `instrument'
     /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:583:in `log'
     /home/yahonda/git/activerecord-jdbc-adapter/lib/arjdbc/jdbc/adapter.rb:542:in `execute'
     /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb:736:in `remove_index'
     /home/yahonda/git/rails/activerecord/test/cases/migration/index_test.rb:95:in `test_index_symbol_names'


  69) Error:
 ActiveRecord::Migration::IndexTest#test_internal_index_with_name_matching_database_limit:
 ActiveRecord::StatementInvalid: ActiveRecord::JDBCError: [SQLITE_ERROR] SQL error or missing database (near "ON": syntax error): DROP INDEX "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" ON "testings"
     arjdbc/jdbc/RubyJdbcConnection.java:587:in `execute'
     /home/yahonda/git/activerecord-jdbc-adapter/lib/arjdbc/jdbc/adapter.rb:566:in `_execute'
     /home/yahonda/git/activerecord-jdbc-adapter/lib/arjdbc/jdbc/adapter.rb:542:in `block in execute'
     /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:589:in `block in log'
     /home/yahonda/git/rails/activesupport/lib/active_support/notifications/instrumenter.rb:21:in `instrument'
     /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:583:in `log'
     /home/yahonda/git/activerecord-jdbc-adapter/lib/arjdbc/jdbc/adapter.rb:542:in `execute'
     /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb:736:in `remove_index'
     /home/yahonda/git/rails/activerecord/test/cases/migration/index_test.rb:88:in `test_internal_index_with_name_matching_database_limit'


  70) Error:
 ActiveRecord::Migration::IndexTest#test_remove_named_index:
 ActiveRecord::StatementInvalid: ActiveRecord::JDBCError: [SQLITE_ERROR] SQL error or missing database (near "ON": syntax error): DROP INDEX "custom_index_name" ON "testings"
     arjdbc/jdbc/RubyJdbcConnection.java:587:in `execute'
     /home/yahonda/git/activerecord-jdbc-adapter/lib/arjdbc/jdbc/adapter.rb:566:in `_execute'
     /home/yahonda/git/activerecord-jdbc-adapter/lib/arjdbc/jdbc/adapter.rb:542:in `block in execute'
     /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:589:in `block in log'
     /home/yahonda/git/rails/activesupport/lib/active_support/notifications/instrumenter.rb:21:in `instrument'
     /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:583:in `log'
     /home/yahonda/git/activerecord-jdbc-adapter/lib/arjdbc/jdbc/adapter.rb:542:in `execute'
     /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb:736:in `remove_index'
     /home/yahonda/git/rails/activerecord/test/cases/migration/index_test.rb:142:in `test_remove_named_index'


  71) Error:
 ActiveRecord::Migration::IndexTest#test_rename_index:
 ActiveRecord::StatementInvalid: ActiveRecord::JDBCError: [SQLITE_ERROR] SQL error or missing database (near "ON": syntax error): DROP INDEX "old_idx" ON "testings"
     arjdbc/jdbc/RubyJdbcConnection.java:587:in `execute'
     /home/yahonda/git/activerecord-jdbc-adapter/lib/arjdbc/jdbc/adapter.rb:566:in `_execute'
     /home/yahonda/git/activerecord-jdbc-adapter/lib/arjdbc/jdbc/adapter.rb:542:in `block in execute'
     /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:589:in `block in log'
     /home/yahonda/git/rails/activesupport/lib/active_support/notifications/instrumenter.rb:21:in `instrument'
     /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:583:in `log'
     /home/yahonda/git/activerecord-jdbc-adapter/lib/arjdbc/jdbc/adapter.rb:542:in `execute'
     /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb:736:in `remove_index'
     /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb:752:in `rename_index'
     /home/yahonda/git/rails/activerecord/test/cases/migration/index_test.rb:32:in `test_rename_index'


  72) Error:
 ActiveRecord::Migration::CompatibilityTest#test_migration_does_remove_unnamed_index:
 StandardError: An error has occurred, this and all later migrations canceled:

 ActiveRecord::JDBCError: [SQLITE_ERROR] SQL error or missing database (near "ON": syntax error): DROP INDEX "index_testings_on_bar" ON "testings"
     arjdbc/jdbc/RubyJdbcConnection.java:587:in `execute'
     /home/yahonda/git/activerecord-jdbc-adapter/lib/arjdbc/jdbc/adapter.rb:566:in `_execute'
     /home/yahonda/git/activerecord-jdbc-adapter/lib/arjdbc/jdbc/adapter.rb:542:in `block in execute'
     /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:589:in `block in log'
     /home/yahonda/git/rails/activesupport/lib/active_support/notifications/instrumenter.rb:21:in `instrument'
     /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:583:in `log'
     /home/yahonda/git/activerecord-jdbc-adapter/lib/arjdbc/jdbc/adapter.rb:542:in `execute'
     /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb:736:in `remove_index'
     /home/yahonda/git/rails/activerecord/lib/active_record/migration.rb:846:in `block in method_missing'
     /home/yahonda/git/rails/activerecord/lib/active_record/migration.rb:815:in `block in say_with_time'
     /home/yahonda/.rbenv/versions/jruby-9.1.5.0/lib/ruby/stdlib/benchmark.rb:293:in `measure'
     /home/yahonda/git/rails/activerecord/lib/active_record/migration.rb:815:in `say_with_time'
     /home/yahonda/git/rails/activerecord/lib/active_record/migration.rb:835:in `method_missing'
     /home/yahonda/git/rails/activerecord/lib/active_record/migration/compatibility.rb:81:in `remove_index'
     /home/yahonda/git/rails/activerecord/test/cases/migration/compatibility_test.rb:48:in `migrate'
     /home/yahonda/git/rails/activerecord/lib/active_record/migration.rb:1212:in `block in execute_migration_in_transaction'
     /home/yahonda/git/rails/activerecord/lib/active_record/migration.rb:1280:in `block in ddl_transaction'
     /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:232:in `block in transaction'
     /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb:189:in `within_new_transaction'
     /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:232:in `transaction'
     /home/yahonda/git/rails/activerecord/lib/active_record/transactions.rb:211:in `transaction'
     /home/yahonda/git/rails/activerecord/lib/active_record/migration.rb:1280:in `ddl_transaction'
     /home/yahonda/git/rails/activerecord/lib/active_record/migration.rb:1211:in `execute_migration_in_transaction'
     /home/yahonda/git/rails/activerecord/lib/active_record/migration.rb:1184:in `block in migrate_without_lock'
     org/jruby/RubyArray.java:1734:in `each'
     /home/yahonda/git/rails/activerecord/lib/active_record/migration.rb:1183:in `migrate_without_lock'
     /home/yahonda/git/rails/activerecord/lib/active_record/migration.rb:1134:in `migrate'
     /home/yahonda/git/rails/activerecord/test/cases/migration/compatibility_test.rb:53:in `test_migration_does_remove_unnamed_index'


  73) Error:
 ActiveRecord::Migration::RenameTableTest#test_rename_table_with_an_index:
 ActiveRecord::StatementInvalid: ActiveRecord::JDBCError: [SQLITE_ERROR] SQL error or missing database (near "ON": syntax error): DROP INDEX "index_test_models_on_url" ON "octopi"
     arjdbc/jdbc/RubyJdbcConnection.java:587:in `execute'
     /home/yahonda/git/activerecord-jdbc-adapter/lib/arjdbc/jdbc/adapter.rb:566:in `_execute'
     /home/yahonda/git/activerecord-jdbc-adapter/lib/arjdbc/jdbc/adapter.rb:542:in `block in execute'
     /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:589:in `block in log'
     /home/yahonda/git/rails/activesupport/lib/active_support/notifications/instrumenter.rb:21:in `instrument'
     /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:583:in `log'
     /home/yahonda/git/activerecord-jdbc-adapter/lib/arjdbc/jdbc/adapter.rb:542:in `execute'
     /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb:736:in `remove_index'
     /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb:752:in `rename_index'
     /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb:1232:in `block in rename_table_indexes'
     org/jruby/RubyArray.java:1734:in `each'
     /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb:1229:in `rename_table_indexes'
     /home/yahonda/git/activerecord-jdbc-adapter/lib/arjdbc/sqlite3/adapter.rb:481:in `rename_table'
     /home/yahonda/git/rails/activerecord/test/cases/migration/helper.rb:36:in `rename_table'
     /home/yahonda/git/rails/activerecord/test/cases/migration/rename_table_test.rb:54:in `test_rename_table_with_an_index'

 Error:
 ActiveRecord::Migration::RenameTableTest#test_rename_table_with_an_index:
 ArgumentError: Index name 'index_test_models_on_url' on table 'test_models' already exists
     /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb:1145:in `add_index_options'
     /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb:712:in `add_index'
     /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb:751:in `rename_index'
     /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb:1232:in `block in rename_table_indexes'
     org/jruby/RubyArray.java:1734:in `each'
     /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb:1229:in `rename_table_indexes'
     /home/yahonda/git/activerecord-jdbc-adapter/lib/arjdbc/sqlite3/adapter.rb:481:in `rename_table'
     /home/yahonda/git/rails/activerecord/test/cases/migration/helper.rb:36:in `rename_table'
     /home/yahonda/git/rails/activerecord/test/cases/migration/rename_table_test.rb:18:in `block in teardown'
     /home/yahonda/git/rails/activesupport/lib/active_support/deprecation/reporting.rb:36:in `silence'
     /home/yahonda/git/rails/activesupport/lib/active_support/deprecation/instance_delegator.rb:20:in `silence'
     /home/yahonda/git/rails/activerecord/test/cases/migration/rename_table_test.rb:18:in `teardown'


  74) Error:
 ActiveRecord::Migration::ColumnsTest#test_add_rename:
 ActiveRecord::StatementInvalid: ActiveRecord::JDBCError: [SQLITE_ERROR] SQL error or missing database (table "test_models" already exists): CREATE TABLE "test_models" ("id" INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, "created_at" datetime, "updated_at" datetime)
     arjdbc/jdbc/RubyJdbcConnection.java:587:in `execute'
     /home/yahonda/git/activerecord-jdbc-adapter/lib/arjdbc/jdbc/adapter.rb:566:in `_execute'
     /home/yahonda/git/activerecord-jdbc-adapter/lib/arjdbc/jdbc/adapter.rb:542:in `block in execute'
     /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:589:in `block in log'
     /home/yahonda/git/rails/activesupport/lib/active_support/notifications/instrumenter.rb:21:in `instrument'
     /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:583:in `log'
     /home/yahonda/git/activerecord-jdbc-adapter/lib/arjdbc/jdbc/adapter.rb:542:in `execute'
     /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb:278:in `create_table'
     /home/yahonda/git/rails/activerecord/test/cases/migration/helper.rb:20:in `setup'

  76) Error:
 ActiveRecord::Migration::ColumnsTest#test_rename_column_with_an_index:
 ActiveRecord::StatementInvalid: ActiveRecord::JDBCError: [SQLITE_ERROR] SQL error or missing database (near "ON": syntax error): DROP INDEX "index_test_models_on_hat_name" ON "test_models"
     arjdbc/jdbc/RubyJdbcConnection.java:587:in `execute'
     /home/yahonda/git/activerecord-jdbc-adapter/lib/arjdbc/jdbc/adapter.rb:566:in `_execute'
     /home/yahonda/git/activerecord-jdbc-adapter/lib/arjdbc/jdbc/adapter.rb:542:in `block in execute'
     /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:589:in `block in log'
     /home/yahonda/git/rails/activesupport/lib/active_support/notifications/instrumenter.rb:21:in `instrument'
     /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:583:in `log'
     /home/yahonda/git/activerecord-jdbc-adapter/lib/arjdbc/jdbc/adapter.rb:542:in `execute'
     /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb:736:in `remove_index'
     /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb:752:in `rename_index'
     /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb:1245:in `block in rename_column_indexes'
     org/jruby/RubyArray.java:1734:in `each'
     /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb:1239:in `rename_column_indexes'
     /home/yahonda/git/activerecord-jdbc-adapter/lib/arjdbc/sqlite3/adapter.rb:541:in `rename_column'
     /home/yahonda/git/rails/activerecord/test/cases/migration/helper.rb:36:in `rename_column'
     /home/yahonda/git/rails/activerecord/test/cases/migration/columns_test.rb:98:in `test_rename_column_with_an_index'


  77) Error:
 ActiveRecord::Migration::ColumnsTest#test_rename_column_with_multi_column_index:
 ActiveRecord::StatementInvalid: ActiveRecord::JDBCError: [SQLITE_ERROR] SQL error or missing database (near "ON": syntax error): DROP INDEX "index_test_models_on_hat_style_and_hat_size" ON "test_models"
     arjdbc/jdbc/RubyJdbcConnection.java:587:in `execute'
     /home/yahonda/git/activerecord-jdbc-adapter/lib/arjdbc/jdbc/adapter.rb:566:in `_execute'
     /home/yahonda/git/activerecord-jdbc-adapter/lib/arjdbc/jdbc/adapter.rb:542:in `block in execute'
     /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:589:in `block in log'
     /home/yahonda/git/rails/activesupport/lib/active_support/notifications/instrumenter.rb:21:in `instrument'
     /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:583:in `log'
     /home/yahonda/git/activerecord-jdbc-adapter/lib/arjdbc/jdbc/adapter.rb:542:in `execute'
     /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb:736:in `remove_index'
     /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb:752:in `rename_index'
     /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb:1245:in `block in rename_column_indexes'
     org/jruby/RubyArray.java:1734:in `each'
     /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb:1239:in `rename_column_indexes'
     /home/yahonda/git/activerecord-jdbc-adapter/lib/arjdbc/sqlite3/adapter.rb:541:in `rename_column'
     /home/yahonda/git/rails/activerecord/test/cases/migration/helper.rb:36:in `rename_column'
     /home/yahonda/git/rails/activerecord/test/cases/migration/columns_test.rb:108:in `test_rename_column_with_multi_column_index'

```
