### PR TITLE
Add reversible syntax for change_column_default

### DIFF
--- a/lib/arjdbc/sqlite3/adapter.rb
+++ b/lib/arjdbc/sqlite3/adapter.rb
@@ -504,7 +504,8 @@ module ArJdbc
       end
     end
 
-    def change_column_default(table_name, column_name, default) #:nodoc:
+    def change_column_default(table_name, column_name, default_or_changes) #:nodoc:
+      default = extract_new_default_value(default_or_changes)
       alter_table(table_name) do |definition|
         definition[column_name].default = default
       end


### PR DESCRIPTION
Refer https://github.com/rails/rails/pull/20018

This pull request addresses these two errors.

```ruby
$ bundle exec ruby -W -w -I"lib:test" test/cases/migration/columns_test.rb -n test_change_column_default_with_from_and_to
/home/yahonda/.rbenv/versions/jruby-9.1.5.0/lib/ruby/stdlib/tmpdir.rb:40: warning: shadowing outer local variable - dir
Using jdbcsqlite3
/home/yahonda/git/activerecord-jdbc-adapter/lib/arjdbc/jdbc/adapter.rb:731: warning: `*' interpreted as argument prefix
Run options: -n test_change_column_default_with_from_and_to --seed 54298

# Running:

E

Finished in 0.181000s, 5.5249 runs/s, 0.0000 assertions/s.

  1) Error:
ActiveRecord::Migration::ColumnsTest#test_change_column_default_with_from_and_to:
TypeError: can't quote Hash
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb:177:in `_quote'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/sqlite3/quoting.rb:27:in `_quote'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb:22:in `quote'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb:110:in `quote_default_expression'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/schema_creation.rb:17:in `quote_default_expression'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/schema_creation.rb:113:in `add_column_options!'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/sqlite3/schema_creation.rb:17:in `add_column_options!'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/schema_creation.rb:34:in `visit_ColumnDefinition'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/schema_creation.rb:14:in `accept'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/schema_creation.rb:45:in `block in visit_TableDefinition'
    org/jruby/RubyArray.java:2492:in `map'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/schema_creation.rb:45:in `visit_TableDefinition'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/schema_creation.rb:14:in `accept'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb:278:in `create_table'
    /home/yahonda/git/activerecord-jdbc-adapter/lib/arjdbc/util/table_copier.rb:33:in `copy_table'
    /home/yahonda/git/activerecord-jdbc-adapter/lib/arjdbc/util/table_copier.rb:25:in `move_table'
    /home/yahonda/git/activerecord-jdbc-adapter/lib/arjdbc/util/table_copier.rb:18:in `block in alter_table'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:232:in `block in transaction'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb:189:in `within_new_transaction'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:232:in `transaction'
    /home/yahonda/git/activerecord-jdbc-adapter/lib/arjdbc/util/table_copier.rb:14:in `alter_table'
    /home/yahonda/git/activerecord-jdbc-adapter/lib/arjdbc/sqlite3/adapter.rb:508:in `change_column_default'
    test/cases/migration/columns_test.rb:272:in `test_change_column_default_with_from_and_to'

1 runs, 0 assertions, 0 failures, 1 errors, 0 skips
$
```


```ruby
$ bundle exec ruby -W -w -I"lib:test" test/cases/migration/columns_test.rb -n test_change_column_default_with_from_and_to
/home/yahonda/.rbenv/versions/jruby-9.1.5.0/lib/ruby/stdlib/tmpdir.rb:40: warning: shadowing outer local variable - dir
Using jdbcsqlite3
/home/yahonda/git/activerecord-jdbc-adapter/lib/arjdbc/jdbc/adapter.rb:731: warning: `*' interpreted as argument prefix
Run options: -n test_change_column_default_with_from_and_to --seed 31369

# Running:

E

Finished in 0.150000s, 6.6667 runs/s, 0.0000 assertions/s.

  1) Error:
ActiveRecord::Migration::ColumnsTest#test_change_column_default_with_from_and_to:
TypeError: can't quote Hash
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb:177:in `_quote'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/sqlite3/quoting.rb:27:in `_quote'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb:22:in `quote'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb:110:in `quote_default_expression'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/schema_creation.rb:17:in `quote_default_expression'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/schema_creation.rb:113:in `add_column_options!'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/sqlite3/schema_creation.rb:17:in `add_column_options!'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/schema_creation.rb:34:in `visit_ColumnDefinition'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/schema_creation.rb:14:in `accept'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/schema_creation.rb:45:in `block in visit_TableDefinition'
    org/jruby/RubyArray.java:2492:in `map'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/schema_creation.rb:45:in `visit_TableDefinition'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/schema_creation.rb:14:in `accept'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb:278:in `create_table'
    /home/yahonda/git/activerecord-jdbc-adapter/lib/arjdbc/util/table_copier.rb:33:in `copy_table'
    /home/yahonda/git/activerecord-jdbc-adapter/lib/arjdbc/util/table_copier.rb:25:in `move_table'
    /home/yahonda/git/activerecord-jdbc-adapter/lib/arjdbc/util/table_copier.rb:18:in `block in alter_table'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:232:in `block in transaction'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb:189:in `within_new_transaction'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:232:in `transaction'
    /home/yahonda/git/activerecord-jdbc-adapter/lib/arjdbc/util/table_copier.rb:14:in `alter_table'
    /home/yahonda/git/activerecord-jdbc-adapter/lib/arjdbc/sqlite3/adapter.rb:508:in `change_column_default'
    test/cases/migration/columns_test.rb:272:in `test_change_column_default_with_from_and_to'

1 runs, 0 assertions, 0 failures, 1 errors, 0 skips
$
```
