### PR TITLE
Added long varchar to type converter for legacy sybase DB

### DIFF
--- a/lib/arjdbc/jdbc/type_converter.rb
+++ b/lib/arjdbc/jdbc/type_converter.rb
@@ -34,6 +34,7 @@ module ActiveRecord
         :text        => [ lambda {|r| TEXT_TYPES.include?(r['data_type'].to_i)},
                           lambda {|r| r['type_name'] =~ /^text$/i},     # For Informix
                           lambda {|r| r['type_name'] =~ /sub_type 1$/i}, # For FireBird
+                          lambda {|r| r['type_name'] =~ /^long varchar$/i}, # Legacy Sybase/SqlAnywhere
                           lambda {|r| r['type_name'] =~ /^(text|clob)$/i},
                           lambda {|r| r['type_name'] =~ /^character large object$/i},
                           lambda {|r| r['sql_data_type'] == 2005}],


### PR DESCRIPTION
We are using a legacy Sybase DB and we have the long varchar type in use.
The "text" data type presented on line 35 is an alias for that type in Sybase, but for legacy codebases
the long varchar will probably be in use as it happens for us.
