### PR TITLE
Gemfile: kares/yard-method-overrides over HTTPS

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,7 @@ group :development do
   gem 'ruby-debug', :require => nil # if ENV['DEBUG']
   group :doc do
     gem 'yard', :require => nil
-    gem 'yard-method-overrides', :github => 'kares/yard-method-overrides', :require => nil
+    gem 'yard-method-overrides', :git => 'https://github.com/kares/yard-method-overrides.git', :require => nil
     gem 'kramdown', :require => nil
   end
 end


### PR DESCRIPTION
This PR makes bundle install not output a warning.