### PR TITLE
Travis: Update JRuby to 9.1.13.0 and 1.7.27

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_script:
 before_install:
   - ((jruby -v | grep 1.8.7) && jruby --1.9 -S gem update --system 2.1.11) || true
 rvm:
-  - jruby-1.7.24
+  - jruby-1.7.26
 jdk:
   - openjdk7
 gemfile:
@@ -47,217 +47,217 @@ branches:
 matrix:
   allow_failures:
     # yet another BC timestamp issue: <Wed, 31 Dec -0001 22:58:59 +0000> expected but was <Fri, 02 Jan 0000 22:58:59 +0000>
-    - rvm: jruby-9.0.5.0
+    - rvm: jruby-9.1.6.0
       gemfile: gemfiles/rails41.gemfile
       env: JRUBY_OPTS="$JRUBY_OPTS" DB=postgresql
       jdk: oraclejdk7
     # ``/system call symlink regression (since JRuby 1.7.19)
     # + (postgres) database_tasks got updated on 4.2 : https://github.com/rails/rails/commit/07f8a96aa14b642a86
-    - rvm: jruby-1.7.24
+    - rvm: jruby-1.7.26
       gemfile: gemfiles/rails42.gemfile
       env: JRUBY_OPTS="--1.9 $JRUBY_OPTS" DB=postgresql PREPARED_STATEMENTS=false INSERT_RETURNING=true
-    - rvm: jruby-1.7.24
+    - rvm: jruby-1.7.26
       gemfile: gemfiles/rails42.gemfile
       env: JRUBY_OPTS="--1.9 $JRUBY_OPTS" DB=postgresql PREPARED_STATEMENTS=true
-    - rvm: jruby-1.7.24
+    - rvm: jruby-1.7.26
       gemfile: gemfiles/rails42.gemfile
       env: JRUBY_OPTS="--1.9 $JRUBY_OPTS" DB=postgresql PREPARED_STATEMENTS=true INSERT_RETURNING=true
-    - rvm: jruby-1.7.24
+    - rvm: jruby-1.7.26
       gemfile: gemfiles/rails42.gemfile
       env: JRUBY_OPTS="$JRUBY_OPTS" DB=postgresql
   include:
     # testing against MariaDB
     - addons:
         mariadb: '5.5'
-      rvm: jruby-1.7.24
+      rvm: jruby-1.7.26
       gemfile: gemfiles/rails32.gemfile
       env: JRUBY_OPTS="$JRUBY_OPTS" DB=mysql
       jdk: openjdk6
     - addons:
         mariadb: '10.0'
-      rvm: jruby-1.7.24
+      rvm: jruby-1.7.26
       gemfile: gemfiles/rails40.gemfile
       env: JRUBY_OPTS="$JRUBY_OPTS" DB=mariadb
       jdk: openjdk7
     - addons:
         mariadb: '10.0'
-      rvm: jruby-1.7.24
+      rvm: jruby-1.7.26
       gemfile: gemfiles/rails41.gemfile
       env: JRUBY_OPTS="$JRUBY_OPTS" DB=mariadb PREPARED_STATEMENTS=true
       jdk: oraclejdk8
       # include some tests on JDK 6 :
-    - rvm: jruby-1.7.24
+    - rvm: jruby-1.7.26
       gemfile: gemfiles/rails42.gemfile
       env: JRUBY_OPTS="$JRUBY_OPTS" DB=mysql
       jdk: openjdk6
-    - rvm: jruby-1.7.24
+    - rvm: jruby-1.7.26
       gemfile: gemfiles/rails42.gemfile
       env: JRUBY_OPTS="$JRUBY_OPTS" DB=postgresql
       jdk: openjdk6
-    - rvm: jruby-1.7.24
+    - rvm: jruby-1.7.26
       gemfile: gemfiles/rails42.gemfile
       env: JRUBY_OPTS="$JRUBY_OPTS" DB=sqlite3
       jdk: openjdk6
-    - rvm: jruby-1.7.24
+    - rvm: jruby-1.7.26
       gemfile: gemfiles/rails42.gemfile
       env: JRUBY_OPTS="$JRUBY_OPTS" DB=derby
       jdk: openjdk6
-    - rvm: jruby-1.7.24
+    - rvm: jruby-1.7.26
       gemfile: gemfiles/rails42.gemfile
       env: JRUBY_OPTS="$JRUBY_OPTS" DB=h2
       jdk: openjdk6
-    - rvm: jruby-1.7.24
+    - rvm: jruby-1.7.26
       gemfile: gemfiles/rails42.gemfile
       env: JRUBY_OPTS="$JRUBY_OPTS" DB=hsqldb
       jdk: openjdk6
       # include testing with JRuby 9K (4.2) :
-    - rvm: jruby-9.0.5.0
+    - rvm: jruby-9.1.6.0
       gemfile: gemfiles/rails42.gemfile
       env: JRUBY_OPTS="$JRUBY_OPTS" DB=mysql PREPARED_STATEMENTS=true
       jdk: oraclejdk7
-    - rvm: jruby-9.0.5.0
+    - rvm: jruby-9.1.6.0
       gemfile: gemfiles/rails42.gemfile
       env: JRUBY_OPTS="$JRUBY_OPTS" DB=postgresql PREPARED_STATEMENTS=true
       jdk: oraclejdk7
-    - rvm: jruby-9.0.5.0
+    - rvm: jruby-9.1.6.0
       gemfile: gemfiles/rails42.gemfile
       env: JRUBY_OPTS="$JRUBY_OPTS" DB=sqlite3
       jdk: oraclejdk7
-    - rvm: jruby-9.0.5.0
+    - rvm: jruby-9.1.6.0
       gemfile: gemfiles/rails42.gemfile
       env: JRUBY_OPTS="$JRUBY_OPTS" DB=mysql
       jdk: oraclejdk8
-    - rvm: jruby-9.0.5.0
+    - rvm: jruby-9.1.6.0
       gemfile: gemfiles/rails42.gemfile
       env: JRUBY_OPTS="$JRUBY_OPTS" DB=postgresql
       jdk: oraclejdk8
-    - rvm: jruby-9.0.5.0
+    - rvm: jruby-9.1.6.0
       gemfile: gemfiles/rails42.gemfile
       env: JRUBY_OPTS="$JRUBY_OPTS" DB=sqlite3
       jdk: oraclejdk8
-    - rvm: jruby-9.0.5.0
+    - rvm: jruby-9.1.6.0
       gemfile: gemfiles/rails42.gemfile
       env: JRUBY_OPTS="$JRUBY_OPTS" DB=derby
       jdk: oraclejdk8
-    - rvm: jruby-9.0.5.0
+    - rvm: jruby-9.1.6.0
       gemfile: gemfiles/rails42.gemfile
       env: JRUBY_OPTS="$JRUBY_OPTS" DB=h2
       jdk: oraclejdk8
-    - rvm: jruby-9.0.5.0
+    - rvm: jruby-9.1.6.0
       gemfile: gemfiles/rails42.gemfile
       env: JRUBY_OPTS="$JRUBY_OPTS" DB=hsqldb
       jdk: oraclejdk8
       # include testing with JRuby 9K (4.1) :
-    - rvm: jruby-9.0.5.0
+    - rvm: jruby-9.1.6.0
       gemfile: gemfiles/rails41.gemfile
       env: JRUBY_OPTS="$JRUBY_OPTS" DB=mysql PREPARED_STATEMENTS=true
       jdk: oraclejdk8
-    - rvm: jruby-9.0.5.0
+    - rvm: jruby-9.1.6.0
       gemfile: gemfiles/rails41.gemfile
       env: JRUBY_OPTS="$JRUBY_OPTS" DB=postgresql PREPARED_STATEMENTS=true
       jdk: oraclejdk8
-    - rvm: jruby-9.0.5.0
+    - rvm: jruby-9.1.6.0
       gemfile: gemfiles/rails41.gemfile
       env: JRUBY_OPTS="$JRUBY_OPTS" DB=sqlite3
       jdk: oraclejdk8
-    - rvm: jruby-9.0.5.0
+    - rvm: jruby-9.1.6.0
       gemfile: gemfiles/rails41.gemfile
       env: JRUBY_OPTS="$JRUBY_OPTS" DB=mysql
       jdk: oraclejdk7
-    - rvm: jruby-9.0.5.0
+    - rvm: jruby-9.1.6.0
       gemfile: gemfiles/rails41.gemfile
       env: JRUBY_OPTS="$JRUBY_OPTS" DB=postgresql
       jdk: oraclejdk7
-    - rvm: jruby-9.0.5.0
+    - rvm: jruby-9.1.6.0
       gemfile: gemfiles/rails41.gemfile
       env: JRUBY_OPTS="$JRUBY_OPTS" DB=sqlite3
       jdk: oraclejdk8
-    - rvm: jruby-9.0.5.0
+    - rvm: jruby-9.1.6.0
       gemfile: gemfiles/rails41.gemfile
       env: JRUBY_OPTS="$JRUBY_OPTS" DB=derby
       jdk: oraclejdk7
-    - rvm: jruby-9.0.5.0
+    - rvm: jruby-9.1.6.0
       gemfile: gemfiles/rails41.gemfile
       env: JRUBY_OPTS="$JRUBY_OPTS" DB=h2
       jdk: oraclejdk7
-    - rvm: jruby-9.0.5.0
+    - rvm: jruby-9.1.6.0
       gemfile: gemfiles/rails41.gemfile
       env: JRUBY_OPTS="$JRUBY_OPTS" DB=hsqldb
       jdk: oraclejdk8
   exclude:
     # Rails 4 prefers Ruby 2.0 (or at least >= 1.9.3) :
-    - rvm: jruby-1.7.24
+    - rvm: jruby-1.7.26
       gemfile: gemfiles/rails40.gemfile
       env: JRUBY_OPTS="--1.8 $JRUBY_OPTS" DB=mysql
-    - rvm: jruby-1.7.24
+    - rvm: jruby-1.7.26
       gemfile: gemfiles/rails40.gemfile
       env: JRUBY_OPTS="--1.8 $JRUBY_OPTS" DB=postgresql
-    - rvm: jruby-1.7.24
+    - rvm: jruby-1.7.26
       gemfile: gemfiles/rails40.gemfile
       env: JRUBY_OPTS="--1.8 $JRUBY_OPTS" DB=sqlite3
-    - rvm: jruby-1.7.24
+    - rvm: jruby-1.7.26
       gemfile: gemfiles/rails40.gemfile
       env: JRUBY_OPTS="--1.8 $JRUBY_OPTS" DB=derby
-    - rvm: jruby-1.7.24
+    - rvm: jruby-1.7.26
       gemfile: gemfiles/rails40.gemfile
       env: JRUBY_OPTS="--1.8 $JRUBY_OPTS" DB=h2
-    - rvm: jruby-1.7.24
+    - rvm: jruby-1.7.26
       gemfile: gemfiles/rails40.gemfile
       env: JRUBY_OPTS="--1.8 $JRUBY_OPTS" DB=hsqldb
-    - rvm: jruby-1.7.24
+    - rvm: jruby-1.7.26
       gemfile: gemfiles/rails40.gemfile
       env: JRUBY_OPTS="--1.8 $JRUBY_OPTS" DB=jndi
-    - rvm: jruby-1.7.24
+    - rvm: jruby-1.7.26
       gemfile: gemfiles/rails40.gemfile
       env: JRUBY_OPTS="--1.8 $JRUBY_OPTS" DB=jdbc
     # Rails 4.1 does not support Ruby 1.8 :
-    - rvm: jruby-1.7.24
+    - rvm: jruby-1.7.26
       gemfile: gemfiles/rails41.gemfile
       env: JRUBY_OPTS="--1.8 $JRUBY_OPTS" DB=mysql
-    - rvm: jruby-1.7.24
+    - rvm: jruby-1.7.26
       gemfile: gemfiles/rails41.gemfile
       env: JRUBY_OPTS="--1.8 $JRUBY_OPTS" DB=postgresql
-    - rvm: jruby-1.7.24
+    - rvm: jruby-1.7.26
       gemfile: gemfiles/rails41.gemfile
       env: JRUBY_OPTS="--1.8 $JRUBY_OPTS" DB=sqlite3
-    - rvm: jruby-1.7.24
+    - rvm: jruby-1.7.26
       gemfile: gemfiles/rails41.gemfile
       env: JRUBY_OPTS="--1.8 $JRUBY_OPTS" DB=derby
-    - rvm: jruby-1.7.24
+    - rvm: jruby-1.7.26
       gemfile: gemfiles/rails41.gemfile
       env: JRUBY_OPTS="--1.8 $JRUBY_OPTS" DB=h2
-    - rvm: jruby-1.7.24
+    - rvm: jruby-1.7.26
       gemfile: gemfiles/rails41.gemfile
       env: JRUBY_OPTS="--1.8 $JRUBY_OPTS" DB=hsqldb
-    - rvm: jruby-1.7.24
+    - rvm: jruby-1.7.26
       gemfile: gemfiles/rails41.gemfile
       env: JRUBY_OPTS="--1.8 $JRUBY_OPTS" DB=jndi
-    - rvm: jruby-1.7.24
+    - rvm: jruby-1.7.26
       gemfile: gemfiles/rails41.gemfile
       env: JRUBY_OPTS="--1.8 $JRUBY_OPTS" DB=jdbc
     # Rails 4.2 will not support Ruby 1.8 :
-    - rvm: jruby-1.7.24
+    - rvm: jruby-1.7.26
       gemfile: gemfiles/rails42.gemfile
       env: JRUBY_OPTS="--1.8 $JRUBY_OPTS" DB=mysql
-    - rvm: jruby-1.7.24
+    - rvm: jruby-1.7.26
       gemfile: gemfiles/rails42.gemfile
       env: JRUBY_OPTS="--1.8 $JRUBY_OPTS" DB=postgresql
-    - rvm: jruby-1.7.24
+    - rvm: jruby-1.7.26
       gemfile: gemfiles/rails42.gemfile
       env: JRUBY_OPTS="--1.8 $JRUBY_OPTS" DB=sqlite3
-    - rvm: jruby-1.7.24
+    - rvm: jruby-1.7.26
       gemfile: gemfiles/rails42.gemfile
       env: JRUBY_OPTS="--1.8 $JRUBY_OPTS" DB=derby
-    - rvm: jruby-1.7.24
+    - rvm: jruby-1.7.26
       gemfile: gemfiles/rails42.gemfile
       env: JRUBY_OPTS="--1.8 $JRUBY_OPTS" DB=h2
-    - rvm: jruby-1.7.24
+    - rvm: jruby-1.7.26
       gemfile: gemfiles/rails42.gemfile
       env: JRUBY_OPTS="--1.8 $JRUBY_OPTS" DB=hsqldb
-    - rvm: jruby-1.7.24
+    - rvm: jruby-1.7.26
       gemfile: gemfiles/rails42.gemfile
       env: JRUBY_OPTS="--1.8 $JRUBY_OPTS" DB=jndi
-    - rvm: jruby-1.7.24
+    - rvm: jruby-1.7.26
       gemfile: gemfiles/rails42.gemfile
       env: JRUBY_OPTS="--1.8 $JRUBY_OPTS" DB=jdbc
     ## JRuby 9K :
@@ -396,19 +396,19 @@ matrix:
     - rvm: jruby-head
       gemfile: gemfiles/rails41.gemfile
       env: JRUBY_OPTS="--1.8 $JRUBY_OPTS" DB=sqlite3
-    - rvm: jruby-1.7.24
+    - rvm: jruby-1.7.26
       gemfile: gemfiles/rails41.gemfile
       env: JRUBY_OPTS="--1.8 $JRUBY_OPTS" DB=derby
-    - rvm: jruby-1.7.24
+    - rvm: jruby-1.7.26
       gemfile: gemfiles/rails41.gemfile
       env: JRUBY_OPTS="--1.8 $JRUBY_OPTS" DB=h2
-    - rvm: jruby-1.7.24
+    - rvm: jruby-1.7.26
       gemfile: gemfiles/rails41.gemfile
       env: JRUBY_OPTS="--1.8 $JRUBY_OPTS" DB=hsqldb
-    - rvm: jruby-1.7.24
+    - rvm: jruby-1.7.26
       gemfile: gemfiles/rails41.gemfile
       env: JRUBY_OPTS="--1.8 $JRUBY_OPTS" DB=jndi
-    - rvm: jruby-1.7.24
+    - rvm: jruby-1.7.26
       gemfile: gemfiles/rails41.gemfile
       env: JRUBY_OPTS="--1.8 $JRUBY_OPTS" DB=jdbc
     # Rails 4.2 (JRuby 9K) :
@@ -436,3 +436,4 @@ matrix:
     - rvm: jruby-head
       gemfile: gemfiles/rails42.gemfile
       env: JRUBY_OPTS="--1.8 $JRUBY_OPTS" DB=jdbc
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_script:
 before_install:
   - ((jruby -v | grep 1.8.7) && jruby --1.9 -S gem update --system 2.1.11) || true
 rvm:
-  - jruby-1.7.26
+  - jruby-1.7.27
 jdk:
   - openjdk7
 gemfile:
@@ -47,217 +47,217 @@ branches:
 matrix:
   allow_failures:
     # yet another BC timestamp issue: <Wed, 31 Dec -0001 22:58:59 +0000> expected but was <Fri, 02 Jan 0000 22:58:59 +0000>
-    - rvm: jruby-9.1.7.0
+    - rvm: jruby-9.1.13.0
       gemfile: gemfiles/rails41.gemfile
       env: JRUBY_OPTS="$JRUBY_OPTS" DB=postgresql
       jdk: oraclejdk7
     # ``/system call symlink regression (since JRuby 1.7.19)
     # + (postgres) database_tasks got updated on 4.2 : https://github.com/rails/rails/commit/07f8a96aa14b642a86
-    - rvm: jruby-1.7.26
+    - rvm: jruby-1.7.27
       gemfile: gemfiles/rails42.gemfile
       env: JRUBY_OPTS="--1.9 $JRUBY_OPTS" DB=postgresql PREPARED_STATEMENTS=false INSERT_RETURNING=true
-    - rvm: jruby-1.7.26
+    - rvm: jruby-1.7.27
       gemfile: gemfiles/rails42.gemfile
       env: JRUBY_OPTS="--1.9 $JRUBY_OPTS" DB=postgresql PREPARED_STATEMENTS=true
-    - rvm: jruby-1.7.26
+    - rvm: jruby-1.7.27
       gemfile: gemfiles/rails42.gemfile
       env: JRUBY_OPTS="--1.9 $JRUBY_OPTS" DB=postgresql PREPARED_STATEMENTS=true INSERT_RETURNING=true
-    - rvm: jruby-1.7.26
+    - rvm: jruby-1.7.27
       gemfile: gemfiles/rails42.gemfile
       env: JRUBY_OPTS="$JRUBY_OPTS" DB=postgresql
   include:
     # testing against MariaDB
     - addons:
         mariadb: '5.5'
-      rvm: jruby-1.7.26
+      rvm: jruby-1.7.27
       gemfile: gemfiles/rails32.gemfile
       env: JRUBY_OPTS="$JRUBY_OPTS" DB=mysql
       jdk: openjdk6
     - addons:
         mariadb: '10.0'
-      rvm: jruby-1.7.26
+      rvm: jruby-1.7.27
       gemfile: gemfiles/rails40.gemfile
       env: JRUBY_OPTS="$JRUBY_OPTS" DB=mariadb
       jdk: openjdk7
     - addons:
         mariadb: '10.0'
-      rvm: jruby-1.7.26
+      rvm: jruby-1.7.27
       gemfile: gemfiles/rails41.gemfile
       env: JRUBY_OPTS="$JRUBY_OPTS" DB=mariadb PREPARED_STATEMENTS=true
       jdk: oraclejdk8
       # include some tests on JDK 6 :
-    - rvm: jruby-1.7.26
+    - rvm: jruby-1.7.27
       gemfile: gemfiles/rails42.gemfile
       env: JRUBY_OPTS="$JRUBY_OPTS" DB=mysql
       jdk: openjdk6
-    - rvm: jruby-1.7.26
+    - rvm: jruby-1.7.27
       gemfile: gemfiles/rails42.gemfile
       env: JRUBY_OPTS="$JRUBY_OPTS" DB=postgresql
       jdk: openjdk6
-    - rvm: jruby-1.7.26
+    - rvm: jruby-1.7.27
       gemfile: gemfiles/rails42.gemfile
       env: JRUBY_OPTS="$JRUBY_OPTS" DB=sqlite3
       jdk: openjdk6
-    - rvm: jruby-1.7.26
+    - rvm: jruby-1.7.27
       gemfile: gemfiles/rails42.gemfile
       env: JRUBY_OPTS="$JRUBY_OPTS" DB=derby
       jdk: openjdk6
-    - rvm: jruby-1.7.26
+    - rvm: jruby-1.7.27
       gemfile: gemfiles/rails42.gemfile
       env: JRUBY_OPTS="$JRUBY_OPTS" DB=h2
       jdk: openjdk6
-    - rvm: jruby-1.7.26
+    - rvm: jruby-1.7.27
       gemfile: gemfiles/rails42.gemfile
       env: JRUBY_OPTS="$JRUBY_OPTS" DB=hsqldb
       jdk: openjdk6
       # include testing with JRuby 9K (4.2) :
-    - rvm: jruby-9.1.7.0
+    - rvm: jruby-9.1.13.0
       gemfile: gemfiles/rails42.gemfile
       env: JRUBY_OPTS="$JRUBY_OPTS" DB=mysql PREPARED_STATEMENTS=true
       jdk: oraclejdk7
-    - rvm: jruby-9.1.7.0
+    - rvm: jruby-9.1.13.0
       gemfile: gemfiles/rails42.gemfile
       env: JRUBY_OPTS="$JRUBY_OPTS" DB=postgresql PREPARED_STATEMENTS=true
       jdk: oraclejdk7
-    - rvm: jruby-9.1.7.0
+    - rvm: jruby-9.1.13.0
       gemfile: gemfiles/rails42.gemfile
       env: JRUBY_OPTS="$JRUBY_OPTS" DB=sqlite3
       jdk: oraclejdk7
-    - rvm: jruby-9.1.7.0
+    - rvm: jruby-9.1.13.0
       gemfile: gemfiles/rails42.gemfile
       env: JRUBY_OPTS="$JRUBY_OPTS" DB=mysql
       jdk: oraclejdk8
-    - rvm: jruby-9.1.7.0
+    - rvm: jruby-9.1.13.0
       gemfile: gemfiles/rails42.gemfile
       env: JRUBY_OPTS="$JRUBY_OPTS" DB=postgresql
       jdk: oraclejdk8
-    - rvm: jruby-9.1.7.0
+    - rvm: jruby-9.1.13.0
       gemfile: gemfiles/rails42.gemfile
       env: JRUBY_OPTS="$JRUBY_OPTS" DB=sqlite3
       jdk: oraclejdk8
-    - rvm: jruby-9.1.7.0
+    - rvm: jruby-9.1.13.0
       gemfile: gemfiles/rails42.gemfile
       env: JRUBY_OPTS="$JRUBY_OPTS" DB=derby
       jdk: oraclejdk8
-    - rvm: jruby-9.1.7.0
+    - rvm: jruby-9.1.13.0
       gemfile: gemfiles/rails42.gemfile
       env: JRUBY_OPTS="$JRUBY_OPTS" DB=h2
       jdk: oraclejdk8
-    - rvm: jruby-9.1.7.0
+    - rvm: jruby-9.1.13.0
       gemfile: gemfiles/rails42.gemfile
       env: JRUBY_OPTS="$JRUBY_OPTS" DB=hsqldb
       jdk: oraclejdk8
       # include testing with JRuby 9K (4.1) :
-    - rvm: jruby-9.1.7.0
+    - rvm: jruby-9.1.13.0
       gemfile: gemfiles/rails41.gemfile
       env: JRUBY_OPTS="$JRUBY_OPTS" DB=mysql PREPARED_STATEMENTS=true
       jdk: oraclejdk8
-    - rvm: jruby-9.1.7.0
+    - rvm: jruby-9.1.13.0
       gemfile: gemfiles/rails41.gemfile
       env: JRUBY_OPTS="$JRUBY_OPTS" DB=postgresql PREPARED_STATEMENTS=true
       jdk: oraclejdk8
-    - rvm: jruby-9.1.7.0
+    - rvm: jruby-9.1.13.0
       gemfile: gemfiles/rails41.gemfile
       env: JRUBY_OPTS="$JRUBY_OPTS" DB=sqlite3
       jdk: oraclejdk8
-    - rvm: jruby-9.1.7.0
+    - rvm: jruby-9.1.13.0
       gemfile: gemfiles/rails41.gemfile
       env: JRUBY_OPTS="$JRUBY_OPTS" DB=mysql
       jdk: oraclejdk7
-    - rvm: jruby-9.1.7.0
+    - rvm: jruby-9.1.13.0
       gemfile: gemfiles/rails41.gemfile
       env: JRUBY_OPTS="$JRUBY_OPTS" DB=postgresql
       jdk: oraclejdk7
-    - rvm: jruby-9.1.7.0
+    - rvm: jruby-9.1.13.0
       gemfile: gemfiles/rails41.gemfile
       env: JRUBY_OPTS="$JRUBY_OPTS" DB=sqlite3
       jdk: oraclejdk8
-    - rvm: jruby-9.1.7.0
+    - rvm: jruby-9.1.13.0
       gemfile: gemfiles/rails41.gemfile
       env: JRUBY_OPTS="$JRUBY_OPTS" DB=derby
       jdk: oraclejdk7
-    - rvm: jruby-9.1.7.0
+    - rvm: jruby-9.1.13.0
       gemfile: gemfiles/rails41.gemfile
       env: JRUBY_OPTS="$JRUBY_OPTS" DB=h2
       jdk: oraclejdk7
-    - rvm: jruby-9.1.7.0
+    - rvm: jruby-9.1.13.0
       gemfile: gemfiles/rails41.gemfile
       env: JRUBY_OPTS="$JRUBY_OPTS" DB=hsqldb
       jdk: oraclejdk8
   exclude:
     # Rails 4 prefers Ruby 2.0 (or at least >= 1.9.3) :
-    - rvm: jruby-1.7.26
+    - rvm: jruby-1.7.27
       gemfile: gemfiles/rails40.gemfile
       env: JRUBY_OPTS="--1.8 $JRUBY_OPTS" DB=mysql
-    - rvm: jruby-1.7.26
+    - rvm: jruby-1.7.27
       gemfile: gemfiles/rails40.gemfile
       env: JRUBY_OPTS="--1.8 $JRUBY_OPTS" DB=postgresql
-    - rvm: jruby-1.7.26
+    - rvm: jruby-1.7.27
       gemfile: gemfiles/rails40.gemfile
       env: JRUBY_OPTS="--1.8 $JRUBY_OPTS" DB=sqlite3
-    - rvm: jruby-1.7.26
+    - rvm: jruby-1.7.27
       gemfile: gemfiles/rails40.gemfile
       env: JRUBY_OPTS="--1.8 $JRUBY_OPTS" DB=derby
-    - rvm: jruby-1.7.26
+    - rvm: jruby-1.7.27
       gemfile: gemfiles/rails40.gemfile
       env: JRUBY_OPTS="--1.8 $JRUBY_OPTS" DB=h2
-    - rvm: jruby-1.7.26
+    - rvm: jruby-1.7.27
       gemfile: gemfiles/rails40.gemfile
       env: JRUBY_OPTS="--1.8 $JRUBY_OPTS" DB=hsqldb
-    - rvm: jruby-1.7.26
+    - rvm: jruby-1.7.27
       gemfile: gemfiles/rails40.gemfile
       env: JRUBY_OPTS="--1.8 $JRUBY_OPTS" DB=jndi
-    - rvm: jruby-1.7.26
+    - rvm: jruby-1.7.27
       gemfile: gemfiles/rails40.gemfile
       env: JRUBY_OPTS="--1.8 $JRUBY_OPTS" DB=jdbc
     # Rails 4.1 does not support Ruby 1.8 :
-    - rvm: jruby-1.7.26
+    - rvm: jruby-1.7.27
       gemfile: gemfiles/rails41.gemfile
       env: JRUBY_OPTS="--1.8 $JRUBY_OPTS" DB=mysql
-    - rvm: jruby-1.7.26
+    - rvm: jruby-1.7.27
       gemfile: gemfiles/rails41.gemfile
       env: JRUBY_OPTS="--1.8 $JRUBY_OPTS" DB=postgresql
-    - rvm: jruby-1.7.26
+    - rvm: jruby-1.7.27
       gemfile: gemfiles/rails41.gemfile
       env: JRUBY_OPTS="--1.8 $JRUBY_OPTS" DB=sqlite3
-    - rvm: jruby-1.7.26
+    - rvm: jruby-1.7.27
       gemfile: gemfiles/rails41.gemfile
       env: JRUBY_OPTS="--1.8 $JRUBY_OPTS" DB=derby
-    - rvm: jruby-1.7.26
+    - rvm: jruby-1.7.27
       gemfile: gemfiles/rails41.gemfile
       env: JRUBY_OPTS="--1.8 $JRUBY_OPTS" DB=h2
-    - rvm: jruby-1.7.26
+    - rvm: jruby-1.7.27
       gemfile: gemfiles/rails41.gemfile
       env: JRUBY_OPTS="--1.8 $JRUBY_OPTS" DB=hsqldb
-    - rvm: jruby-1.7.26
+    - rvm: jruby-1.7.27
       gemfile: gemfiles/rails41.gemfile
       env: JRUBY_OPTS="--1.8 $JRUBY_OPTS" DB=jndi
-    - rvm: jruby-1.7.26
+    - rvm: jruby-1.7.27
       gemfile: gemfiles/rails41.gemfile
       env: JRUBY_OPTS="--1.8 $JRUBY_OPTS" DB=jdbc
     # Rails 4.2 will not support Ruby 1.8 :
-    - rvm: jruby-1.7.26
+    - rvm: jruby-1.7.27
       gemfile: gemfiles/rails42.gemfile
       env: JRUBY_OPTS="--1.8 $JRUBY_OPTS" DB=mysql
-    - rvm: jruby-1.7.26
+    - rvm: jruby-1.7.27
       gemfile: gemfiles/rails42.gemfile
       env: JRUBY_OPTS="--1.8 $JRUBY_OPTS" DB=postgresql
-    - rvm: jruby-1.7.26
+    - rvm: jruby-1.7.27
       gemfile: gemfiles/rails42.gemfile
       env: JRUBY_OPTS="--1.8 $JRUBY_OPTS" DB=sqlite3
-    - rvm: jruby-1.7.26
+    - rvm: jruby-1.7.27
       gemfile: gemfiles/rails42.gemfile
       env: JRUBY_OPTS="--1.8 $JRUBY_OPTS" DB=derby
-    - rvm: jruby-1.7.26
+    - rvm: jruby-1.7.27
       gemfile: gemfiles/rails42.gemfile
       env: JRUBY_OPTS="--1.8 $JRUBY_OPTS" DB=h2
-    - rvm: jruby-1.7.26
+    - rvm: jruby-1.7.27
       gemfile: gemfiles/rails42.gemfile
       env: JRUBY_OPTS="--1.8 $JRUBY_OPTS" DB=hsqldb
-    - rvm: jruby-1.7.26
+    - rvm: jruby-1.7.27
       gemfile: gemfiles/rails42.gemfile
       env: JRUBY_OPTS="--1.8 $JRUBY_OPTS" DB=jndi
-    - rvm: jruby-1.7.26
+    - rvm: jruby-1.7.27
       gemfile: gemfiles/rails42.gemfile
       env: JRUBY_OPTS="--1.8 $JRUBY_OPTS" DB=jdbc
     ## JRuby 9K :
@@ -396,19 +396,19 @@ matrix:
     - rvm: jruby-head
       gemfile: gemfiles/rails41.gemfile
       env: JRUBY_OPTS="--1.8 $JRUBY_OPTS" DB=sqlite3
-    - rvm: jruby-1.7.26
+    - rvm: jruby-1.7.27
       gemfile: gemfiles/rails41.gemfile
       env: JRUBY_OPTS="--1.8 $JRUBY_OPTS" DB=derby
-    - rvm: jruby-1.7.26
+    - rvm: jruby-1.7.27
       gemfile: gemfiles/rails41.gemfile
       env: JRUBY_OPTS="--1.8 $JRUBY_OPTS" DB=h2
-    - rvm: jruby-1.7.26
+    - rvm: jruby-1.7.27
       gemfile: gemfiles/rails41.gemfile
       env: JRUBY_OPTS="--1.8 $JRUBY_OPTS" DB=hsqldb
-    - rvm: jruby-1.7.26
+    - rvm: jruby-1.7.27
       gemfile: gemfiles/rails41.gemfile
       env: JRUBY_OPTS="--1.8 $JRUBY_OPTS" DB=jndi
-    - rvm: jruby-1.7.26
+    - rvm: jruby-1.7.27
       gemfile: gemfiles/rails41.gemfile
       env: JRUBY_OPTS="--1.8 $JRUBY_OPTS" DB=jdbc
     # Rails 4.2 (JRuby 9K) :
@@ -436,4 +436,3 @@ matrix:
     - rvm: jruby-head
       gemfile: gemfiles/rails42.gemfile
       env: JRUBY_OPTS="--1.8 $JRUBY_OPTS" DB=jdbc
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ branches:
 matrix:
   allow_failures:
     # yet another BC timestamp issue: <Wed, 31 Dec -0001 22:58:59 +0000> expected but was <Fri, 02 Jan 0000 22:58:59 +0000>
-    - rvm: jruby-9.1.6.0
+    - rvm: jruby-9.1.7.0
       gemfile: gemfiles/rails41.gemfile
       env: JRUBY_OPTS="$JRUBY_OPTS" DB=postgresql
       jdk: oraclejdk7
@@ -111,76 +111,76 @@ matrix:
       env: JRUBY_OPTS="$JRUBY_OPTS" DB=hsqldb
       jdk: openjdk6
       # include testing with JRuby 9K (4.2) :
-    - rvm: jruby-9.1.6.0
+    - rvm: jruby-9.1.7.0
       gemfile: gemfiles/rails42.gemfile
       env: JRUBY_OPTS="$JRUBY_OPTS" DB=mysql PREPARED_STATEMENTS=true
       jdk: oraclejdk7
-    - rvm: jruby-9.1.6.0
+    - rvm: jruby-9.1.7.0
       gemfile: gemfiles/rails42.gemfile
       env: JRUBY_OPTS="$JRUBY_OPTS" DB=postgresql PREPARED_STATEMENTS=true
       jdk: oraclejdk7
-    - rvm: jruby-9.1.6.0
+    - rvm: jruby-9.1.7.0
       gemfile: gemfiles/rails42.gemfile
       env: JRUBY_OPTS="$JRUBY_OPTS" DB=sqlite3
       jdk: oraclejdk7
-    - rvm: jruby-9.1.6.0
+    - rvm: jruby-9.1.7.0
       gemfile: gemfiles/rails42.gemfile
       env: JRUBY_OPTS="$JRUBY_OPTS" DB=mysql
       jdk: oraclejdk8
-    - rvm: jruby-9.1.6.0
+    - rvm: jruby-9.1.7.0
       gemfile: gemfiles/rails42.gemfile
       env: JRUBY_OPTS="$JRUBY_OPTS" DB=postgresql
       jdk: oraclejdk8
-    - rvm: jruby-9.1.6.0
+    - rvm: jruby-9.1.7.0
       gemfile: gemfiles/rails42.gemfile
       env: JRUBY_OPTS="$JRUBY_OPTS" DB=sqlite3
       jdk: oraclejdk8
-    - rvm: jruby-9.1.6.0
+    - rvm: jruby-9.1.7.0
       gemfile: gemfiles/rails42.gemfile
       env: JRUBY_OPTS="$JRUBY_OPTS" DB=derby
       jdk: oraclejdk8
-    - rvm: jruby-9.1.6.0
+    - rvm: jruby-9.1.7.0
       gemfile: gemfiles/rails42.gemfile
       env: JRUBY_OPTS="$JRUBY_OPTS" DB=h2
       jdk: oraclejdk8
-    - rvm: jruby-9.1.6.0
+    - rvm: jruby-9.1.7.0
       gemfile: gemfiles/rails42.gemfile
       env: JRUBY_OPTS="$JRUBY_OPTS" DB=hsqldb
       jdk: oraclejdk8
       # include testing with JRuby 9K (4.1) :
-    - rvm: jruby-9.1.6.0
+    - rvm: jruby-9.1.7.0
       gemfile: gemfiles/rails41.gemfile
       env: JRUBY_OPTS="$JRUBY_OPTS" DB=mysql PREPARED_STATEMENTS=true
       jdk: oraclejdk8
-    - rvm: jruby-9.1.6.0
+    - rvm: jruby-9.1.7.0
       gemfile: gemfiles/rails41.gemfile
       env: JRUBY_OPTS="$JRUBY_OPTS" DB=postgresql PREPARED_STATEMENTS=true
       jdk: oraclejdk8
-    - rvm: jruby-9.1.6.0
+    - rvm: jruby-9.1.7.0
       gemfile: gemfiles/rails41.gemfile
       env: JRUBY_OPTS="$JRUBY_OPTS" DB=sqlite3
       jdk: oraclejdk8
-    - rvm: jruby-9.1.6.0
+    - rvm: jruby-9.1.7.0
       gemfile: gemfiles/rails41.gemfile
       env: JRUBY_OPTS="$JRUBY_OPTS" DB=mysql
       jdk: oraclejdk7
-    - rvm: jruby-9.1.6.0
+    - rvm: jruby-9.1.7.0
       gemfile: gemfiles/rails41.gemfile
       env: JRUBY_OPTS="$JRUBY_OPTS" DB=postgresql
       jdk: oraclejdk7
-    - rvm: jruby-9.1.6.0
+    - rvm: jruby-9.1.7.0
       gemfile: gemfiles/rails41.gemfile
       env: JRUBY_OPTS="$JRUBY_OPTS" DB=sqlite3
       jdk: oraclejdk8
-    - rvm: jruby-9.1.6.0
+    - rvm: jruby-9.1.7.0
       gemfile: gemfiles/rails41.gemfile
       env: JRUBY_OPTS="$JRUBY_OPTS" DB=derby
       jdk: oraclejdk7
-    - rvm: jruby-9.1.6.0
+    - rvm: jruby-9.1.7.0
       gemfile: gemfiles/rails41.gemfile
       env: JRUBY_OPTS="$JRUBY_OPTS" DB=h2
       jdk: oraclejdk7
-    - rvm: jruby-9.1.6.0
+    - rvm: jruby-9.1.7.0
       gemfile: gemfiles/rails41.gemfile
       env: JRUBY_OPTS="$JRUBY_OPTS" DB=hsqldb
       jdk: oraclejdk8


### PR DESCRIPTION
This PR for rails-5 branch is about removing JRuby 1.7 builds and upping JRuby 9K version numbers to ~9.1.6.0~ 9.1.13.0 (latest stable).

Rails 5 does not support Ruby 1.9, so there's no point in building against it.