### PR TITLE
Support SSL options via environment vars

### DIFF
--- a/lib/arjdbc/postgresql/connection_methods.rb
+++ b/lib/arjdbc/postgresql/connection_methods.rb
@@ -31,7 +31,7 @@ ArJdbc::ConnectionMethods.module_eval do
     end
     sslmode = config.key?(:sslmode) ? config[:sslmode] : config[:requiressl]
     # NOTE: makes not much sense since this needs some JVM options :
-    # sslmode = ENV['PGSSLMODE'] || ENV['PGREQUIRESSL'] if sslmode.nil?
+    sslmode = ENV['PGSSLMODE'] || ENV['PGREQUIRESSL'] if sslmode.nil?
     unless sslmode.nil? # PG :sslmode - disable|allow|prefer|require
       # JRuby/JVM needs to be started with :
       #  -Djavax.net.ssl.trustStore=mystore -Djavax.net.ssl.trustStorePassword=...

--- a/lib/arjdbc/postgresql/connection_methods.rb
+++ b/lib/arjdbc/postgresql/connection_methods.rb
@@ -37,7 +37,10 @@ ArJdbc::ConnectionMethods.module_eval do
       #  -Djavax.net.ssl.trustStore=mystore -Djavax.net.ssl.trustStorePassword=...
       # or a non-validating connection might be used (for testing) :
       #  :sslfactory = 'org.postgresql.ssl.NonValidatingFactory'
-      properties['ssl'] ||= 'true' if sslmode == true || sslmode.to_s == 'require'
+      if sslmode == true || sslmode.to_s == 'require'
+        properties['sslfactory'] ||= 'org.postgresql.ssl.NonValidatingFactory' 
+        properties['ssl'] ||= 'true' 
+      end
     end
     properties['tcpKeepAlive'] ||= config[:keepalives] if config.key?(:keepalives)
     properties['kerberosServerName'] ||= config[:krbsrvname] if config[:krbsrvname]


### PR DESCRIPTION
Perhaps this isn't the most well developed code, but it became a giant sticking point for me while on Heroku.

I worked with Heroku Support for a period of three hours, and neither of us could figure out how to get `activerecord-jdbc-adapter` to support SSL in a Rails 3.2 app (note Rails 3.2 does not support ENV(...) in database.yml).

My only recourse was this patch that made the library aware of environment vars.

Did I miss something?