### PR TITLE
Avoid map! on result object.

### DIFF
--- a/lib/arjdbc/mysql/adapter.rb
+++ b/lib/arjdbc/mysql/adapter.rb
@@ -397,7 +397,7 @@ module ArJdbc
       columns = execute(sql, name || 'SCHEMA')
       strict = strict_mode?
       pass_cast_type = respond_to?(:lookup_cast_type)
-      columns.map! do |field|
+      columns.map do |field|
         sql_type = field['Type']
         null = field['Null'] == "YES"
         if pass_cast_type
@@ -407,7 +407,6 @@ module ArJdbc
           jdbc_column_class.new(field['Field'], field['Default'], sql_type, null, field['Collation'], strict, field['Extra'])
         end
       end
-      columns
     end
 
     if defined? ::ActiveRecord::ConnectionAdapters::AbstractAdapter::SchemaCreation


### PR DESCRIPTION
I tried the MySQL adaptor on rails 5 and I got the following error.
```
NoMethodError: undefined method `name' for #<Hash:0x6da646b8>
           block in columns_hash at /Users/sgnr/.gem/jruby/2.3.1/gems/activerecord-5.0.0.1/lib/active_record/connection_adapters/schema_cache.rb:63
```

The cause of this seems to be `ArJdbc::MySQL#column` that call `map!`, but `map!` has [a surprising behaviour on `ActiveRecord::Result`](https://github.com/rails/rails/blob/6cd65861e93250159b19eac5b990a100f566e0ff/activerecord/lib/active_record/result.rb#L60): it just ends up invoking `map`. I guess that code never returned an array of column, but the caller was fine with an array of hashes?
