### PR TITLE
Stop using alias_method_chain

### DIFF
--- a/lib/arjdbc/jdbc/base_ext.rb
+++ b/lib/arjdbc/jdbc/base_ext.rb
@@ -1,19 +1,12 @@
 module ActiveRecord
-  # ActiveRecord::Base extensions.
-  Base.class_eval do
-    class << self
-      # Allow adapters to provide their own {#reset_column_information} method.
-      # @note This only affects the current thread's connection.
-      def reset_column_information_with_arjdbc # :nodoc:
-        # invoke the adapter-specific reset_column_information method
-        connection.reset_column_information if connection.respond_to?(:reset_column_information)
-        reset_column_information_without_arjdbc
-      end
-      unless method_defined?("reset_column_information_without_arjdbc")
-        alias_method_chain :reset_column_information, :arjdbc
-      end
+  module ResetColumnInformationWithAdapter
+    def reset_column_information # :nodoc:
+      # invoke the adapter-specific reset_column_information method
+      connection.reset_column_information if connection.respond_to?(:reset_column_information)
+      super
     end
   end
+  Base.prepend(ResetColumnInformationWithAdapter)
 
   module ConnectionAdapters
     # Allows properly re-defining methods that may already be alias-chain-ed.


### PR DESCRIPTION
`alias_method_chain` has recently been removed from Rails (https://github.com/rails/rails/commit/7c848e6dd493ff236d33a0410a92f4c3e5cc3c7f).

ActiveRecord `master` will now raise because `NoMethodError`.

@enebo @kares 