### PR TITLE
Comparing timestamps with a string causes Comparable#== deprecation warning

### DIFF
--- a/lib/arjdbc/db2/column.rb
+++ b/lib/arjdbc/db2/column.rb
@@ -47,7 +47,7 @@ module ArJdbc
 
       # @override
       def type_cast(value)
-        return nil if value.nil? || value == 'NULL' || value =~ /^\s*NULL\s*$/i
+        return nil if value.nil? || value.to_s == 'NULL' || value =~ /^\s*NULL\s*$/i
         case type
         when :string    then value
         when :integer   then value.respond_to?(:to_i) ? value.to_i : (value ? 1 : 0)


### PR DESCRIPTION
calling the `to_s` on value before comparing it clears the warning

Ruby version: jruby 9.0.5.0 (2.2.3)
AR version: 4.1.15