### PR TITLE
Error PostgreSQL::ColumnDefinition

### DIFF
--- a/lib/arjdbc/jdbc.rb
+++ b/lib/arjdbc/jdbc.rb
@@ -3,9 +3,9 @@ require 'active_support/deprecation'
 module ArJdbc
 
   # @private
-  AR40 = ::ActiveRecord::VERSION::MAJOR > 3
+  AR40 = ::ActiveRecord::VERSION::MAJOR > 3 && ::ActiveRecord::VERSION::STRING < '4.2'
   # @private
-  AR42 = ::ActiveRecord::VERSION::STRING >= '4.2'
+  AR42 = ::ActiveRecord::VERSION::STRING >= '4.2' && ::ActiveRecord::VERSION::MAJOR < 5
   # @private
   AR50 = ::ActiveRecord::VERSION::MAJOR > 4
 


### PR DESCRIPTION
This solve the error in rails 5.1: 
Bundler::GemRequireError: There was an error while trying to load the gem 'activerecord-jdbcpostgresql-adapter'.
Gem Load Error is: uninitialized constant ActiveRecord::ConnectionAdapters::PostgreSQL::ColumnDefinition