### PR TITLE
Misc postgres test fixes

### DIFF
--- a/lib/arjdbc/postgresql/connection_methods.rb
+++ b/lib/arjdbc/postgresql/connection_methods.rb
@@ -43,6 +43,12 @@ ArJdbc::ConnectionMethods.module_eval do
     properties['kerberosServerName'] ||= config[:krbsrvname] if config[:krbsrvname]
 
     jdbc_connection(config)
+  rescue ActiveRecord::JDBCError => e
+    if e.message.include?('does not exist')
+      raise ActiveRecord::NoDatabaseError, e.message
+    else
+      raise
+    end
   end
   alias_method :jdbcpostgresql_connection, :postgresql_connection
 end

--- a/lib/arjdbc/tasks/db2_database_tasks.rb
+++ b/lib/arjdbc/tasks/db2_database_tasks.rb
@@ -82,9 +82,9 @@ module ArJdbc
           ensure
             pk_rs.close
           end
-          primary_keys.each do |name, cols|
+          primary_keys.each do |constraint_name, cols|
             dump << "ALTER TABLE #{connection.quote_table_name(table_name)}\n"
-            dump << "  ADD CONSTRAINT #{name}\n"
+            dump << "  ADD CONSTRAINT #{constraint_name}\n"
             dump << "    PRIMARY KEY (#{cols.join(', ')});\n\n"
           end
         end

--- a/test/db/postgresql/rake_test.rb
+++ b/test/db/postgresql/rake_test.rb
@@ -18,13 +18,13 @@ class PostgresRakeTest < Test::Unit::TestCase
     Rake::Task["db:create"].invoke
     if PSQL_EXE
       output = psql("-d template1 -c '\\\l'")
-      assert_match /#{db_name}/m, output
+      assert_match(/#{db_name}/m, output)
     end
 
     Rake::Task["db:drop"].invoke
     if PSQL_EXE
       output = psql("-d template1 -c '\\\l'")
-      assert_no_match /#{db_name}/m, output
+      assert_no_match(/#{db_name}/m, output)
     end
   end
 
@@ -86,7 +86,7 @@ class PostgresRakeTest < Test::Unit::TestCase
       Rake::Task["db:structure:dump"].invoke
 
       assert File.exists?(structure_sql)
-      assert_match /CREATE TABLE users/, File.read(structure_sql)
+      assert_match(/CREATE TABLE users/, File.read(structure_sql))
 
       # db:structure:load
       drop_rake_test_database(:silence)
@@ -112,7 +112,7 @@ class PostgresRakeTest < Test::Unit::TestCase
 
   test 'rake db:collation' do
     create_rake_test_database
-    expect_rake_output /\w*?\.UTF-8/ # en_US.UTF-8
+    expect_rake_output(/\w*?\.UTF-8/) # en_US.UTF-8
     Rake::Task["db:collation"].invoke
   end
 

--- a/test/db/postgresql/schema_test.rb
+++ b/test/db/postgresql/schema_test.rb
@@ -10,7 +10,7 @@ class PostgresSchemaTest < Test::Unit::TestCase
     ensure
       connection.drop_schema "test_schema3"
     end
-  end if ar_version('4.0') # create_schema/drop_schema added in AR 4.0
+  end
 
   def test_raise_create_schema_with_existing_schema
     begin
@@ -24,7 +24,7 @@ class PostgresSchemaTest < Test::Unit::TestCase
       # "DROP SCHEMA #{schema_name} CASCADE"
       connection.drop_schema "test_schema3"
     end
-  end if ar_version('4.0') # create_schema/drop_schema added in AR 4.0
+  end
 
   def test_drop_schema
     begin
@@ -33,11 +33,11 @@ class PostgresSchemaTest < Test::Unit::TestCase
       connection.drop_schema "test_schema3"
     end
     assert ! connection.schema_names.include?("test_schema3")
-  end if ar_version('4.0') # create_schema/drop_schema added in AR 4.0
+  end
 
   def test_collation
     assert_equal 'en_US.UTF-8', connection.collation
-  end if ar_version('4.0') # collation added in AR 4.0
+  end
 
   def test_encoding
     assert_equal 'UTF8', connection.encoding
@@ -45,7 +45,7 @@ class PostgresSchemaTest < Test::Unit::TestCase
 
   def test_ctype
     assert connection.ctype
-  end if ar_version('4.0') # ctype added in AR 4.0
+  end
 
   def test_current_database
     assert_not_nil connection.current_database
@@ -65,10 +65,10 @@ class PostgresSchemaTest < Test::Unit::TestCase
 
   def test_schema_names
     assert_equal [ "public" ], connection.schema_names
-  end if ar_version('4.0') # schema_names added in AR 4.0
+  end
 
   def test_schema_search_path
-    assert_equal "\"$user\",public", connection.schema_search_path
+    assert_equal "\"$user\", public", connection.schema_search_path
   end
 
   context "search path" do
@@ -101,16 +101,6 @@ class PostgresSchemaTest < Test::Unit::TestCase
     def test_columns
       assert_equal(%w{id name}, Person.column_names)
     end
-
-    def test_find_right
-      assert_not_nil Person.find_by_name("Alex")
-    end if ActiveRecord::VERSION::MAJOR < 4
-
-    def test_find_wrong
-      assert_raise NoMethodError do
-        Person.find_by_wrongname("Alex")
-      end
-    end if ActiveRecord::VERSION::MAJOR < 4
 
     def test_column_information
       assert_include Person.columns.map(&:name), "name"

--- a/test/db/postgresql/types_test.rb
+++ b/test/db/postgresql/types_test.rb
@@ -396,7 +396,7 @@ _SQL
 
   def test_money_values
     assert_equal 567.89, @first_money.wealth
-    assert_equal -567.89, @second_money.wealth
+    assert_equal(-567.89, @second_money.wealth)
   end
 
   def test_create_tstzrange


### PR DESCRIPTION
Most of the changes in this PR are cleaning up warnings and removing conditional tests.

Some tests that were fixed:

- ltree tests were updated so they will run if possible instead of always being omitted
- An ActiveRecord::NoDatabaseError is now thrown when attempting to connect to a DB that doesn't exist, this fixes one of the rake tests and matches core ActiveRecord functionality
- the schema_search_path test was updated because now there are spaces between schemas in the path