### PR TITLE
Postgres rails 5.0.4 fixes

### DIFF
--- a/lib/arjdbc/postgresql/adapter.rb
+++ b/lib/arjdbc/postgresql/adapter.rb
@@ -973,9 +973,11 @@ module ArJdbc
     def translate_exception(exception, message)
       case exception.message
       when /duplicate key value violates unique constraint/
-        ::ActiveRecord::RecordNotUnique.new(message, exception)
+        ::ActiveRecord::RecordNotUnique.new(message)
       when /violates foreign key constraint/
-        ::ActiveRecord::InvalidForeignKey.new(message, exception)
+        ::ActiveRecord::InvalidForeignKey.new(message)
+      when /value too long/
+        ::ActiveRecord::ValueTooLong.new(message)
       else
         super
       end

--- a/lib/arjdbc/postgresql/base/pgconn.rb
+++ b/lib/arjdbc/postgresql/base/pgconn.rb
@@ -1,6 +1,5 @@
 module PG
-  class Connection # emulate PGconn#unescape_bytea due #652
-    # NOTE: on pg gem ... PGconn = (class) PG::Connection
+  class Connection # emulate PG::Connection#unescape_bytea due #652
     def self.unescape_bytea(escaped)
       ArJdbc::PostgreSQL.unescape_bytea(escaped)
     end

--- a/lib/arjdbc/postgresql/base/pgconn.rb
+++ b/lib/arjdbc/postgresql/base/pgconn.rb
@@ -1,5 +1,5 @@
-module ActiveRecord::ConnectionAdapters::PostgreSQL::OID
-  class PGconn # emulate PGconn#unescape_bytea due #652
+module PG
+  class Connection # emulate PGconn#unescape_bytea due #652
     # NOTE: on pg gem ... PGconn = (class) PG::Connection
     def self.unescape_bytea(escaped)
       ArJdbc::PostgreSQL.unescape_bytea(escaped)

--- a/src/java/arjdbc/jdbc/RubyJdbcConnection.java
+++ b/src/java/arjdbc/jdbc/RubyJdbcConnection.java
@@ -1791,7 +1791,7 @@ public class RubyJdbcConnection extends RubyObject {
     protected static IRubyObject typeCastFromDatabase(final ThreadContext context,
         final IRubyObject adapter, final RubySymbol typeName, final RubyString value) {
         final IRubyObject type = adapter.callMethod(context, "lookup_cast_type", typeName);
-        return type.callMethod(context, "type_cast_from_database", value);
+        return type.callMethod(context, "deserialize", value);
     }
 
     protected IRubyObject dateToRuby(final ThreadContext context,


### PR DESCRIPTION
In ActiveRecord 5.0.3 or 5.0.4 they updated `PGConn` references to be `PG::Connection` since `PGConn` was deprecated.

Should I also include the compiled jar file for the adapter with the pr or should that not be in the repo?