### PR TITLE
Solution error: Gem Load ColumnDefinition for version 5.1

### DIFF
--- a/lib/arjdbc/jdbc.rb
+++ b/lib/arjdbc/jdbc.rb
@@ -3,9 +3,9 @@ require 'active_support/deprecation'
 module ArJdbc
 
   # @private
-  AR40 = ::ActiveRecord::VERSION::MAJOR > 3
+  AR40 = ::ActiveRecord::VERSION::MAJOR > 3 && ::ActiveRecord::VERSION::STRING < '4.2'
   # @private
-  AR42 = ::ActiveRecord::VERSION::STRING >= '4.2'
+  AR42 = ::ActiveRecord::VERSION::STRING >= '4.2' && ::ActiveRecord::VERSION::MAJOR < 5
   # @private
   AR50 = ::ActiveRecord::VERSION::MAJOR > 4
 


### PR DESCRIPTION
The propose is to solution this error: Gem Load Error is: uninitialized constant ActiveRecord::ConnectionAdapters::PostgreSQL::ColumnDefinition

This allowed to pass `uninitialized constant ActiveRecord::ConnectionAdapters::PostgreSQL::ColumnDefinition` error on Rails 5.1. However, some more work seems required in my case. I am now experiencing the following issue using this patch :

```
NoMethodError (undefined method `cast' for "character varying":String):

vendor/cache/activerecord-jdbc-adapter-6dbb2441c0db/lib/arjdbc/jdbc/column.rb:30:in `initialize'
```