### PR TITLE
Fix some ActiveRecord primary key tests for postgres adapter

### DIFF
--- a/lib/arjdbc/jdbc/adapter.rb
+++ b/lib/arjdbc/jdbc/adapter.rb
@@ -580,11 +580,6 @@ module ActiveRecord
       end
 
       # @override
-      def primary_key(table)
-        primary_keys(table).first
-      end
-
-      # @override
       def primary_keys(table)
         @connection.primary_keys(table)
       end

--- a/lib/arjdbc/postgresql/adapter.rb
+++ b/lib/arjdbc/postgresql/adapter.rb
@@ -411,19 +411,6 @@ module ArJdbc
       nil
     end
 
-    def primary_key(table)
-      result = select(<<-end_sql, 'SCHEMA').first
-        SELECT attr.attname
-        FROM pg_attribute attr
-        INNER JOIN pg_constraint cons ON attr.attrelid = cons.conrelid AND attr.attnum = any(cons.conkey)
-        WHERE cons.contype = 'p' AND cons.conrelid = '#{quote_table_name(table)}'::regclass
-      end_sql
-
-      result && result['attname']
-      # pk_and_sequence = pk_and_sequence_for(table)
-      # pk_and_sequence && pk_and_sequence.first
-    end
-
     def insert(sql, name = nil, pk = nil, id_value = nil, sequence_name = nil, binds = [])
       sql = to_sql(sql, binds)
       unless pk


### PR DESCRIPTION
Removed some logic that was overwriting ActiveRecord's built in primary key handling and breaking some tests. The logic that was being overwritten was:

```
def primary_key(table_name)
  pk = primary_keys(table_name)
  pk = pk.first unless pk.size > 1
  pk
end
```

This change makes it so that composite keys will be returned instead of being hidden and ActiveRecord will emit a warning about composite keys not being supported. This fixes the tests in the ActiveRecord test suite that specifically test that the warning is emitted.