### PR TITLE
Scope PG namespace

### DIFF
--- a/lib/arjdbc/postgresql/base/array_decoder.rb
+++ b/lib/arjdbc/postgresql/base/array_decoder.rb
@@ -1,24 +1,26 @@
 # This implements a basic decoder to work around ActiveRecord's dependence on the pg gem
-module PG
-  module TextDecoder
+module ActiveRecord::ConnectionAdapters::PostgreSQL::OID
+  class Array < ActiveModel::Type::Value
+    module PG
+      module TextDecoder
+        class Array
+          # Loads pg_array_parser if available. String parsing can be
+          # performed quicker by a native extension, which will not create
+          # a large amount of Ruby objects that will need to be garbage
+          # collected. pg_array_parser has a C and Java extension
+          begin
+            require 'pg_array_parser'
+            include PgArrayParser
+          rescue LoadError
+            require_relative 'array_parser'
+            include ActiveRecord::ConnectionAdapters::PostgreSQL::ArrayParser
+          end
 
-    class Array
-      # Loads pg_array_parser if available. String parsing can be
-      # performed quicker by a native extension, which will not create
-      # a large amount of Ruby objects that will need to be garbage
-      # collected. pg_array_parser has a C and Java extension
-      begin
-        require 'pg_array_parser'
-        include PgArrayParser
-      rescue LoadError
-        require_relative 'array_parser'
-        include ActiveRecord::ConnectionAdapters::PostgreSQL::ArrayParser
+          def initialize(name:, delimiter:); end
+
+          alias_method :decode, :parse_pg_array
+        end
       end
-
-      def initialize(name:, delimiter:); end
-
-      alias_method :decode, :parse_pg_array
     end
-
   end
 end

--- a/lib/arjdbc/postgresql/base/array_encoder.rb
+++ b/lib/arjdbc/postgresql/base/array_encoder.rb
@@ -1,21 +1,25 @@
 # This implements a basic encoder to work around ActiveRecord's dependence on the pg gem
-module PG
-  module TextEncoder
-    class Array
+module ActiveRecord::ConnectionAdapters::PostgreSQL::OID
+  class Array < ActiveModel::Type::Value
+    module PG
+      module TextEncoder
+        class Array
 
-      def initialize(name:, delimiter:)
-        @type = if name == 'string[]'.freeze
-                  'text'
-                else
-                  base_type = name.chomp('[]'.freeze).to_sym
-                  ActiveRecord::Base.connection.native_database_types[base_type][:name]
-                end
+          def initialize(name:, delimiter:)
+            @type = if name == 'string[]'.freeze
+                      'text'.freeze
+                    else
+                      base_type = name.chomp('[]'.freeze).to_sym
+                      ActiveRecord::Base.connection.native_database_types[base_type][:name]
+                    end
+          end
+
+          def encode(values)
+            ActiveRecord::Base.connection.jdbc_connection.create_array_of(@type, values.to_java).to_s
+          end
+
+        end
       end
-
-      def encode(values)
-        ActiveRecord::Base.connection.jdbc_connection.create_array_of(@type, values.to_java).to_s
-      end
-
     end
   end
 end

--- a/lib/arjdbc/postgresql/base/pgconn.rb
+++ b/lib/arjdbc/postgresql/base/pgconn.rb
@@ -1,7 +1,11 @@
-module PG
-  class Connection # emulate PG::Connection#unescape_bytea due #652
-    def self.unescape_bytea(escaped)
-      ArJdbc::PostgreSQL.unescape_bytea(escaped)
+module ActiveRecord::ConnectionAdapters::PostgreSQL::OID
+  class Bytea < ActiveModel::Type::Binary
+    module PG
+      class Connection # emulate PG::Connection#unescape_bytea due #652
+        def self.unescape_bytea(escaped)
+          ArJdbc::PostgreSQL.unescape_bytea(escaped)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
This makes it so that the PG modules/classes that we are emulating will be scoped to where they are referenced so that it doesn't look like the pg gem is loaded for others that may be checking `defined? PG`. This addresses concerns raised in: https://github.com/jruby/activerecord-jdbc-adapter/pull/804#discussion_r128342423