### PR TITLE
Postgres adapter cleanup

### DIFF
--- a/lib/arjdbc/jdbc/adapter.rb
+++ b/lib/arjdbc/jdbc/adapter.rb
@@ -298,13 +298,6 @@ module ActiveRecord
         @connection.disconnect!
       end
 
-      # @note Used on AR 2.3 and 3.0
-      # @override
-      def insert_sql(sql, name = nil, pk = nil, id_value = nil, sequence_name = nil)
-        id = execute(sql, name)
-        id_value || id
-      end
-
       def columns(table_name, name = nil)
         @connection.columns(table_name.to_s)
       end


### PR DESCRIPTION
Updated the adapter to use more of ActiveRecord's logic. Most of the changes in here are just deleting methods that are now coming from `ActiveRecord::ConnectionAdapters::PostgreSQL::DatabaseStatements`