### PR TITLE
Fix transaction isolation tests for Rails 5

### DIFF
--- a/src/java/arjdbc/jdbc/RubyJdbcConnection.java
+++ b/src/java/arjdbc/jdbc/RubyJdbcConnection.java
@@ -225,12 +225,10 @@ public class RubyJdbcConnection extends RubyObject {
 
     protected IRubyObject beginTransaction(final ThreadContext context, final Connection connection,
         final IRubyObject isolation) throws SQLException {
-
-        connection.setAutoCommit(false);
-
         if ( isolation != null ) {
             setTransactionIsolation(context, connection, isolation);
         }
+        if ( connection.getAutoCommit() ) connection.setAutoCommit(false);
         return context.nil;
     }
 
@@ -276,7 +274,7 @@ public class RubyJdbcConnection extends RubyObject {
                 try {
                     connection.rollback();
                     resetSavepoints(context); // if any
-                    return context.getRuntime().newBoolean(true);
+                    return context.runtime.getTrue();
                 } finally {
                     connection.setAutoCommit(true);
                 }

--- a/src/java/arjdbc/jdbc/RubyJdbcConnection.java
+++ b/src/java/arjdbc/jdbc/RubyJdbcConnection.java
@@ -197,21 +197,12 @@ public class RubyJdbcConnection extends RubyObject {
         });
     }
 
-    @JRubyMethod(name = {"begin", "transaction"}) // optional isolation argument for AR-4.0
+    @JRubyMethod(name = {"begin", "transaction"}, required = 1) // optional isolation argument for AR-4.0
     public IRubyObject begin(final ThreadContext context, final IRubyObject isolation) {
         try { // handleException == false so we can handle setTXIsolation
             return withConnection(context, false, new Callable<IRubyObject>() {
                 public IRubyObject call(final Connection connection) throws SQLException {
-                    try {
-                        if (!isolation.isNil()) {
-                            connection.setTransactionIsolation(mapTransactionIsolationLevel(isolation));
-                        }
-                        return context.getRuntime().getNil();
-                    } catch (SQLException e) {
-                        RubyClass txError = ActiveRecord(context).getClass("TransactionIsolationError");
-                        if (txError != null) throw wrapException(context, txError, e);
-                        throw e; // let it roll - will be wrapped into a JDBCError (non 4.0)
-                    }
+                    return beginTransaction(context, connection, isolation.isNil() ? null : isolation);
                 }
             });
         } catch (SQLException e) {
@@ -224,13 +215,35 @@ public class RubyJdbcConnection extends RubyObject {
         try { // handleException == false so we can handle setTXIsolation
             return withConnection(context, false, new Callable<IRubyObject>() {
                 public IRubyObject call(final Connection connection) throws SQLException {
-                    connection.setAutoCommit(false);
-
-                    return context.getRuntime().getNil();
+                    return beginTransaction(context, connection, null);
                 }
             });
         } catch (SQLException e) {
             return handleException(context, e);
+        }
+    }
+
+    protected IRubyObject beginTransaction(final ThreadContext context, final Connection connection,
+        final IRubyObject isolation) throws SQLException {
+
+        connection.setAutoCommit(false);
+
+        if ( isolation != null ) {
+            setTransactionIsolation(context, connection, isolation);
+        }
+        return context.nil;
+    }
+
+    protected final void setTransactionIsolation(final ThreadContext context, final Connection connection,
+        final IRubyObject isolation) throws SQLException {
+        final int level = mapTransactionIsolationLevel(isolation);
+        try {
+            connection.setTransactionIsolation(level);
+        }
+        catch (SQLException e) {
+            RubyClass txError = ActiveRecord(context).getClass("TransactionIsolationError");
+            if ( txError != null ) throw wrapException(context, txError, e);
+            throw e; // let it roll - will be wrapped into a JDBCError (non 4.0)
         }
     }
 


### PR DESCRIPTION
This just cherry picks some commits from the master branch so that the tests will be passing on the rails-5 branch.