### PR TITLE
Address "Directly inheriting from ActiveRecord::Migration is not supp…

### DIFF
--- a/test/change_column_test_methods.rb
+++ b/test/change_column_test_methods.rb
@@ -4,7 +4,7 @@ module ChangeColumnTestMethods
 
   class Person < ActiveRecord::Base; end
 
-  class CreatePeopleTable < ActiveRecord::Migration
+  class CreatePeopleTable < ActiveRecord::Migration[4.2]
     def self.up
       create_table(:people) { |t| t.string :name; t.integer :phone }
     end

--- a/test/db/mysql/nonstandard_primary_key_test.rb
+++ b/test/db/mysql/nonstandard_primary_key_test.rb
@@ -3,7 +3,7 @@ require 'db/mysql'
 
 class MysqlNonstandardPrimaryKeyTest < Test::Unit::TestCase
 
-  class Project < ActiveRecord::Migration
+  class Project < ActiveRecord::Migration[4.2]
     def self.up
       create_table :project, :primary_key => "project_id" do |t|
         t.string      :projectType, :limit => 31

--- a/test/db/mysql/schema_dump_test.rb
+++ b/test/db/mysql/schema_dump_test.rb
@@ -80,7 +80,7 @@ end
 
 class MysqlInfoTest < Test::Unit::TestCase
 
-  class DBSetup < ActiveRecord::Migration
+	class DBSetup < ActiveRecord::Migration[4.2]
 
     def self.up
       create_table :books do |t|

--- a/test/db/mysql/table_name_test.rb
+++ b/test/db/mysql/table_name_test.rb
@@ -22,7 +22,7 @@ class MySQLTableNameTest < Test::Unit::TestCase
     SerialMigration.down
   end
 
-  class SerialNumberMigration < ActiveRecord::Migration
+  class SerialNumberMigration < ActiveRecord::Migration[4.2]
     def self.up
       columns = [
         "serial BIGINT PRIMARY KEY",
@@ -49,7 +49,7 @@ class MySQLTableNameTest < Test::Unit::TestCase
     SerialNumber.columns
   end if ar_version('3.2')
 
-  class SerialMigration < ActiveRecord::Migration
+  class SerialMigration < ActiveRecord::Migration[4.2]
     def self.up
       columns = [
         "sid CHAR(36)", # PRIMARY KEY

--- a/test/db/postgresql/a_custom_primary_key_test.rb
+++ b/test/db/postgresql/a_custom_primary_key_test.rb
@@ -14,7 +14,7 @@ require 'db/postgres'
 #
 class PostgresACustomPrimaryKeyTest < Test::Unit::TestCase
 
-  class CreateUrls < ActiveRecord::Migration
+  class CreateUrls < ActiveRecord::Migration[4.2]
     def self.up
       create_table 'some_urls', :id => false do |t|
         t.string :uhash, :null => false

--- a/test/db/postgresql/information_schema_leak_test.rb
+++ b/test/db/postgresql/information_schema_leak_test.rb
@@ -3,7 +3,7 @@ require 'db/postgres'
 
 class PostgreSQLInformationSchemaLeakTest < Test::Unit::TestCase
 
-  class CreateISLSchema < ActiveRecord::Migration
+  class CreateISLSchema < ActiveRecord::Migration[4.2]
     def self.up
       execute "CREATE TABLE domains (id int, name varchar(16))"
     end

--- a/test/db/postgresql/native_types_test.rb
+++ b/test/db/postgresql/native_types_test.rb
@@ -11,7 +11,7 @@ class PostgreSQLNativeTypesTest < Test::Unit::TestCase
     PG_VERSION = 0
   end
 
-  class CustomersMigration < ActiveRecord::Migration
+  class CustomersMigration < ActiveRecord::Migration[4.2]
     def self.up
       execute "DROP SEQUENCE IF EXISTS seq_pk_customers"
       execute "CREATE SEQUENCE seq_pk_customers"

--- a/test/db/postgresql/schema_test.rb
+++ b/test/db/postgresql/schema_test.rb
@@ -37,7 +37,7 @@ class PostgresSchemaTest < Test::Unit::TestCase
 
   context "search path" do
 
-    class CreateSchema < ActiveRecord::Migration
+    class CreateSchema < ActiveRecord::Migration[4.2]
       def self.up
         execute "CREATE SCHEMA test"
         execute "CREATE TABLE test.people (id serial, name text)"

--- a/test/db/postgresql/table_name_test.rb
+++ b/test/db/postgresql/table_name_test.rb
@@ -23,7 +23,7 @@ class PostgreSQLTableNameTest < Test::Unit::TestCase
     SerialMigration.down
   end
 
-  class SerialNumberMigration < ActiveRecord::Migration
+  class SerialNumberMigration < ActiveRecord::Migration[4.2]
     def self.up
       columns = [
         "serial BIGINT PRIMARY KEY",
@@ -49,7 +49,7 @@ class PostgreSQLTableNameTest < Test::Unit::TestCase
     SerialNumber.columns
   end
 
-  class SerialMigration < ActiveRecord::Migration
+  class SerialMigration < ActiveRecord::Migration[4.2]
     def self.up
       columns = [
         "sid INTEGER", # PRIMARY KEY

--- a/test/models/add_not_null_column_to_table.rb
+++ b/test/models/add_not_null_column_to_table.rb
@@ -1,4 +1,4 @@
-class AddNotNullColumnToTable < ActiveRecord::Migration
+class AddNotNullColumnToTable < ActiveRecord::Migration[4.2]
   def self.up
     add_column :entries, :color, :string, :null => false, :default => "blue"
   end

--- a/test/models/binary.rb
+++ b/test/models/binary.rb
@@ -1,7 +1,7 @@
 class Binary < ActiveRecord::Base
 end
 
-class BinaryMigration < ActiveRecord::Migration
+class BinaryMigration < ActiveRecord::Migration[4.2]
 
   def self.up
     create_table :binaries, :force => true do |t|

--- a/test/models/custom_pk_name.rb
+++ b/test/models/custom_pk_name.rb
@@ -1,4 +1,4 @@
-class CreateCustomPkName < ActiveRecord::Migration
+class CreateCustomPkName < ActiveRecord::Migration[4.2]
   def self.up
     create_table :custom_pk_names, :force => true, :id => false do |t|
       t.primary_key :custom_id

--- a/test/models/data_types.rb
+++ b/test/models/data_types.rb
@@ -1,4 +1,4 @@
-class DbTypeMigration < ActiveRecord::Migration
+class DbTypeMigration < ActiveRecord::Migration[4.2]
   
   # Oracle/SQLServer supports precision up to 38
   @@big_decimal_precision = 38

--- a/test/models/entry.rb
+++ b/test/models/entry.rb
@@ -1,4 +1,4 @@
-class CreateEntries < ActiveRecord::Migration
+class CreateEntries < ActiveRecord::Migration[4.2]
   def self.up
     create_table "entries", :force => true do |t|
       t.column :title, :string, :limit => 100
@@ -23,7 +23,7 @@ class Entry < ActiveRecord::Base
   end
 end
 
-class CreateUsers < ActiveRecord::Migration
+class CreateUsers < ActiveRecord::Migration[4.2]
   def self.up
     create_table "users", :force => true do |t|
       t.column :login, :string, :limit => 100, :null => false

--- a/test/models/mixed_case.rb
+++ b/test/models/mixed_case.rb
@@ -1,5 +1,5 @@
 module Migration
-  class MixedCase < ActiveRecord::Migration
+  class MixedCase < ActiveRecord::Migration[4.2]
 
     def self.up
       create_table "mixed_cases" do |t|

--- a/test/models/reserved_word.rb
+++ b/test/models/reserved_word.rb
@@ -1,4 +1,4 @@
-class CreateReservedWords < ActiveRecord::Migration
+class CreateReservedWords < ActiveRecord::Migration[4.2]
   def self.up
     create_table "reserved_words", :force => true do |t|
       t.column :position, :integer

--- a/test/models/rights_and_roles.rb
+++ b/test/models/rights_and_roles.rb
@@ -1,4 +1,4 @@
-class CreateRightsAndRoles < ActiveRecord::Migration
+class CreateRightsAndRoles < ActiveRecord::Migration[4.2]
   def self.up
     create_table :role_assignments do |t| 
       t.column :role_id, :integer

--- a/test/models/string_id.rb
+++ b/test/models/string_id.rb
@@ -1,4 +1,4 @@
-class CreateStringIds < ActiveRecord::Migration
+class CreateStringIds < ActiveRecord::Migration[4.2]
   def self.up
     create_table "string_ids", :force => true, :id => false do |t|
       t.string :id, :null => false

--- a/test/models/thing.rb
+++ b/test/models/thing.rb
@@ -1,4 +1,4 @@
-class CreateThings < ActiveRecord::Migration
+class CreateThings < ActiveRecord::Migration[4.2]
   def self.up
     create_table :things, :id => false do |t|
       t.string :name

--- a/test/models/topic.rb
+++ b/test/models/topic.rb
@@ -6,7 +6,7 @@ class ImportantTopic < Topic
   serialize :important, Hash
 end
 
-class TopicMigration < ActiveRecord::Migration
+class TopicMigration < ActiveRecord::Migration[4.2]
 
   def self.up
     create_table :topics, :force => true do |t|

--- a/test/models/validates_uniqueness_of_string.rb
+++ b/test/models/validates_uniqueness_of_string.rb
@@ -1,4 +1,4 @@
-class CreateValidatesUniquenessOf < ActiveRecord::Migration
+class CreateValidatesUniquenessOf < ActiveRecord::Migration[4.2]
   def self.up
     create_table "validates_uniqueness_of", :force => true do |t|
       t.column :cs_string, :string

--- a/test/simple.rb
+++ b/test/simple.rb
@@ -730,7 +730,7 @@ module SimpleTestMethods
     assert_equal 'bar?', entry.content
   end
 
-  class ChangeEntriesTable < ActiveRecord::Migration
+  class ChangeEntriesTable < ActiveRecord::Migration[4.2]
     def self.up
       change_table :entries do |t|
         t.string :author


### PR DESCRIPTION
Address "Directly inheriting from ActiveRecord::Migration is not supported" 
Refer https://github.com/rails/rails/commit/249f71a22ab21c03915da5606a063d321f04d4d3

This pull request addresses these "StandardError: Directly inheriting from ActiveRecord::Migration is not supported." error at master branch which should support Rails 5.1

```ruby
$ rake test_sqlite3
Using ActiveRecord::VERSION = 5.1.4
StandardError: Directly inheriting from ActiveRecord::Migration is not supported. Please specify the Rails release the migration was written for:

  class AddNotNullColumnToTable < ActiveRecord::Migration[4.2]
                                                                                                                inherited at /home/ubuntu/.rbenv/versions/jruby-9.1.14.0/lib/ruby/gems/shared/gems/activerecord-5.1.4/lib/active_record/migration.rb:525
                                                                                                                   <main> at /home/ubuntu/activerecord-jdbc-adapter/test/models/add_not_null_column_to_table.rb:1
                                                                                                                  require at org/jruby/RubyKernel.java:955
                                                                                                         block in require at /home/ubuntu/.rbenv/versions/jruby-9.1.14.0/lib/ruby/gems/shared/gems/activesupport-5.1.4/lib/active_support/dependencies.rb:292
                                                                                                          load_dependency at /home/ubuntu/.rbenv/versions/jruby-9.1.14.0/lib/ruby/gems/shared/gems/activesupport-5.1.4/lib/active_support/dependencies.rb:258
                                                                                                                  require at /home/ubuntu/.rbenv/versions/jruby-9.1.14.0/lib/ruby/gems/shared/gems/activesupport-5.1.4/lib/active_support/dependencies.rb:292
                                                                                                                   <main> at /home/ubuntu/activerecord-jdbc-adapter/test/jdbc_common.rb:1
                                                                                                                  require at org/jruby/RubyKernel.java:955
                                                                                                         block in require at /home/ubuntu/.rbenv/versions/jruby-9.1.14.0/lib/ruby/gems/shared/gems/activesupport-5.1.4/lib/active_support/dependencies.rb:292
                                                                                                          load_dependency at /home/ubuntu/.rbenv/versions/jruby-9.1.14.0/lib/ruby/gems/shared/gems/activesupport-5.1.4/lib/active_support/dependencies.rb:258
                                                                                                                  require at /home/ubuntu/.rbenv/versions/jruby-9.1.14.0/lib/ruby/gems/shared/gems/activesupport-5.1.4/lib/active_support/dependencies.rb:292
                                                                                                                   <main> at /home/ubuntu/activerecord-jdbc-adapter/test/jdbc_common.rb:8
                                                                                                                  require at org/jruby/RubyKernel.java:955
                                                                                                         block in require at /home/ubuntu/.rbenv/versions/jruby-9.1.14.0/lib/ruby/gems/shared/gems/activesupport-5.1.4/lib/active_support/dependencies.rb:292
                                                                                                          load_dependency at /home/ubuntu/.rbenv/versions/jruby-9.1.14.0/lib/ruby/gems/shared/gems/activesupport-5.1.4/lib/active_support/dependencies.rb:258
                                                                                                                  require at /home/ubuntu/.rbenv/versions/jruby-9.1.14.0/lib/ruby/gems/shared/gems/activesupport-5.1.4/lib/active_support/dependencies.rb:292
  block in /home/ubuntu/.rbenv/versions/jruby-9.1.14.0/lib/ruby/gems/shared/gems/rake-12.3.0/lib/rake/rake_test_loader.rb at /home/ubuntu/.rbenv/versions/jruby-9.1.14.0/lib/ruby/gems/shared/gems/rake-12.3.0/lib/rake/rake_test_loader.rb:17
                                                                                                                   select at org/jruby/RubyArray.java:2565
                                                                                                                   <main> at /home/ubuntu/.rbenv/versions/jruby-9.1.14.0/lib/ruby/gems/shared/gems/rake-12.3.0/lib/rake/rake_test_loader.rb:5
rake aborted!
Command failed with status (1)

Tasks: TOP => test_sqlite3
(See full trace by running task with --trace)
$
```

