### PR TITLE
Use `ActiveRecord::SchemaMigration.table_name`

### DIFF
--- a/test/rake_test_support.rb
+++ b/test/rake_test_support.rb
@@ -119,7 +119,7 @@ module RakeTestSupport
   # (Test) Helpers :
 
   def create_schema_migrations_table(connection = ActiveRecord::Base.connection)
-    schema_migration = ActiveRecord::Migrator.schema_migrations_table_name
+    schema_migration = ActiveRecord::SchemaMigration.table_name
     return if connection.data_source_exists?(schema_migration)
     connection.create_table(schema_migration, :id => false) do |t|
       t.column :version, :string, :null => false


### PR DESCRIPTION
since `ActiveRecord::Migrator.schema_migrations_table_name`
will be deprecated in 5.2.

Refer https://github.com/rails/rails/pull/28293

This pull request suppresses the following deprecation warning.

```ruby
$ rake test_postgresql
... snip ...
Dropped database 'test_rake_db'
.DEPRECATION WARNING: schema_migrations_table_name is deprecated and will be removed from Rails 5.2 (called from create_schema_migrations_table at /home/ubuntu/activerecord-jdbc-adapter/test/rake_test_support.rb:122)
```