### PR TITLE
Address ` warning: Ambiguous first argument; make sure.`

### DIFF
--- a/test/db/mysql/rake_test.rb
+++ b/test/db/mysql/rake_test.rb
@@ -86,7 +86,7 @@ class MySQLRakeTest < Test::Unit::TestCase
       Rake::Task["db:structure:dump"].invoke
 
       assert File.exists?(structure_sql)
-      assert_match /CREATE TABLE `users`/, File.read(structure_sql)
+      assert_match(/CREATE TABLE `users`/, File.read(structure_sql))
 
       # db:structure:load
       drop_rake_test_database(:silence)
@@ -112,7 +112,7 @@ class MySQLRakeTest < Test::Unit::TestCase
 
   test 'rake db:collation' do
     create_rake_test_database
-    expect_rake_output /utf8_.*?_ci/
+    expect_rake_output (/utf8_.*?_ci/)
     Rake::Task["db:collation"].invoke
   end
 


### PR DESCRIPTION
This pull request suppresses these two warnings.

```ruby
$ rake test_mysql
... snip ...
Using ActiveRecord::VERSION = 5.1.4
/home/ubuntu/activerecord-jdbc-adapter/test/db/mysql/rake_test.rb:89: warning: Ambiguous first argument; make sure.
/home/ubuntu/activerecord-jdbc-adapter/test/db/mysql/rake_test.rb:115: warning: Ambiguous first argument; make sure.
```
