### PR TITLE
get rails tests to run (on CI)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,6 +60,6 @@ matrix:
         mariadb: '10.1'
       env: DB=mariadb PREPARED_STATEMENTS=true
     # Rails test-suite :
-    - env: DB=mysql2     TEST_PREFIX="rails:" AR_VERSION="5-0-stable"
-    - env: DB=postgresql TEST_PREFIX="rails:" AR_VERSION="5-0-stable"
-    - env: DB=sqlite3    TEST_PREFIX="rails:" AR_VERSION="5-0-stable"
+    - env: DB=mysql2     TEST_PREFIX="rails:" AR_VERSION="v5.0.6"
+    - env: DB=postgresql TEST_PREFIX="rails:" AR_VERSION="v5.0.6"
+    - env: DB=sqlite3    TEST_PREFIX="rails:" AR_VERSION="v5.0.6"

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,10 @@ language: ruby
 sudo: false
 bundler_args: --without development
 script: bundle exec rake $TEST_PREFIXtest_$DB
+before_install:
+  - unset _JAVA_OPTIONS
 before_script:
-  - export JRUBY_OPTS="--server $JRUBY_OPTS" # -Xcompile.invokedynamic=false
+  - export JRUBY_OPTS="--server -Xms64M -Xmx1024M $JRUBY_OPTS" # -Xcompile.invokedynamic=false
   #- mvn prepare-package # compiles ext generates: lib/arjdbc/jdbc/adapter_java.jar
   - mysql --version || true # to see if we're using MySQL or MariaDB
   - '[ "$DB" == "postgresql" ] && rake db:postgresql || true'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,33 @@
 language: ruby
 sudo: false
 bundler_args: --without development
-script: bundle exec rake $TEST_PREFIXtest_$DB
+script: bundle exec rake ${TEST_PREFIX}test_$DB
 before_install:
   - unset _JAVA_OPTIONS
 before_script:
   - export JRUBY_OPTS="--server -Xms64M -Xmx1024M $JRUBY_OPTS" # -Xcompile.invokedynamic=false
   #- mvn prepare-package # compiles ext generates: lib/arjdbc/jdbc/adapter_java.jar
   - mysql --version || true # to see if we're using MySQL or MariaDB
-  - '[ "$DB" == "postgresql" ] && rake db:postgresql || true'
-  - '[ "$DB" == "mysql2" ] && rake db:mysql || true'
-  - '[ "$DB" == "mariadb" ] && rake db:mysql || true'
+  - '[ "$DB" == "postgresql" ] && [ "$TEST_PREFIX" == "" ] && rake db:postgresql || true'
+  - '[ "$DB" == "mysql2" ] && [ "$TEST_PREFIX" == "" ] && rake db:mysql || true'
+  - '[ "$DB" == "mariadb" ] && [ "$TEST_PREFIX" == "" ] && rake db:mysql || true'
   - '[ "$DB" == "jdbc" ] && rake db:mysql || true'
   - '[ "$DB" == "jndi" ] && rake db:mysql || true'
-
+  # rails:test setups :
+  - |
+    [ "$DB" == "mysql2" ] && [ "$TEST_PREFIX" == "rails:" ] && \
+    mysql -e "CREATE USER rails@localhost;" && \
+    mysql -e "grant all privileges on activerecord_unittest.* to rails@localhost;" && \
+    mysql -e "grant all privileges on activerecord_unittest2.* to rails@localhost;" && \
+    mysql -e "grant all privileges on inexistent_activerecord_unittest.* to rails@localhost;" && \
+    mysql -e "CREATE DATABASE activerecord_unittest;" && \
+    mysql -e "CREATE DATABASE activerecord_unittest2;" \
+    || true
+  - |
+    [ "$DB" == "postgresql" ] && [ "$TEST_PREFIX" == "rails:" ] && \
+    psql  -c "create database activerecord_unittest;" -U postgres && \
+    psql  -c "create database activerecord_unittest2;" -U postgres \
+    || true
 rvm:
   - jruby-9.1.14.0
 jdk:
@@ -46,6 +60,6 @@ matrix:
         mariadb: '10.1'
       env: DB=mariadb PREPARED_STATEMENTS=true
     # Rails test-suite :
-    - env: DB=mysql2     TEST_PREFIX=rails: AR_VERSION=5-0-stable
-    - env: DB=postgresql TEST_PREFIX=rails: AR_VERSION=5-0-stable
-    - env: DB=sqlite3    TEST_PREFIX=rails: AR_VERSION=5-0-stable
+    - env: DB=mysql2     TEST_PREFIX="rails:" AR_VERSION="5-0-stable"
+    - env: DB=postgresql TEST_PREFIX="rails:" AR_VERSION="5-0-stable"
+    - env: DB=sqlite3    TEST_PREFIX="rails:" AR_VERSION="5-0-stable"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,13 @@
 language: ruby
 sudo: false
 bundler_args: --without development
-script: bundle exec rake test_$DB
+script: bundle exec rake $TEST_PREFIXtest_$DB
 before_script:
   - export JRUBY_OPTS="--server $JRUBY_OPTS" # -Xcompile.invokedynamic=false
   #- mvn prepare-package # compiles ext generates: lib/arjdbc/jdbc/adapter_java.jar
   - mysql --version || true # to see if we're using MySQL or MariaDB
   - '[ "$DB" == "postgresql" ] && rake db:postgresql || true'
-  - '[ "$DB" == "mysql" ] && rake db:mysql || true'
+  - '[ "$DB" == "mysql2" ] && rake db:mysql || true'
   - '[ "$DB" == "mariadb" ] && rake db:mysql || true'
   - '[ "$DB" == "jdbc" ] && rake db:mysql || true'
   - '[ "$DB" == "jndi" ] && rake db:mysql || true'
@@ -17,8 +17,8 @@ rvm:
 jdk:
   - openjdk8
 env:
-  - DB=mysql PREPARED_STATEMENTS=false
-  - DB=mysql PREPARED_STATEMENTS=true
+  - DB=mysql2 PREPARED_STATEMENTS=false
+  - DB=mysql2 PREPARED_STATEMENTS=true
   - DB=postgresql PREPARED_STATEMENTS=false INSERT_RETURNING=false
   - DB=postgresql PREPARED_STATEMENTS=false INSERT_RETURNING=true
   - DB=postgresql PREPARED_STATEMENTS=true
@@ -43,3 +43,7 @@ matrix:
     - addons:
         mariadb: '10.1'
       env: DB=mariadb PREPARED_STATEMENTS=true
+    # Rails test-suite :
+    - env: DB=mysql2     TEST_PREFIX=rails: AR_VERSION=5-0-stable
+    - env: DB=postgresql TEST_PREFIX=rails: AR_VERSION=5-0-stable
+    - env: DB=sqlite3    TEST_PREFIX=rails: AR_VERSION=5-0-stable

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,17 @@
 language: ruby
 sudo: false
 bundler_args: --without development
-script:
-  - bundle exec rake test_$DB
+script: bundle exec rake test_$DB
 before_script:
   - export JRUBY_OPTS="--server $JRUBY_OPTS" # -Xcompile.invokedynamic=false
-  - mysql --version # to see if we're using MySQL or MariaDB
+  #- mvn prepare-package # compiles ext generates: lib/arjdbc/jdbc/adapter_java.jar
+  - mysql --version || true # to see if we're using MySQL or MariaDB
+  - '[ "$DB" == "postgresql" ] && rake db:postgresql || true'
+  - '[ "$DB" == "mysql" ] && rake db:mysql || true'
+  - '[ "$DB" == "mariadb" ] && rake db:mysql || true'
+  - '[ "$DB" == "jdbc" ] && rake db:mysql || true'
+  - '[ "$DB" == "jndi" ] && rake db:mysql || true'
+
 rvm:
   - jruby-9.1.14.0
 jdk:
@@ -26,12 +32,14 @@ branches:
     - master
     - /.*-stable$/
     - /^test-.*/
+    - /maintenance|support/
+    - /.*dev$/
 matrix:
   include:
     # testing against MariaDB
     - addons:
         mariadb: '10.0'
-      env: JRUBY_OPTS="$JRUBY_OPTS" DB=mariadb PREPARED_STATEMENTS=false
+      env: DB=mariadb PREPARED_STATEMENTS=false
     - addons:
-        mariadb: '10.0'
-      env: JRUBY_OPTS="$JRUBY_OPTS" DB=mariadb PREPARED_STATEMENTS=true
+        mariadb: '10.1'
+      env: DB=mariadb PREPARED_STATEMENTS=true

--- a/Gemfile
+++ b/Gemfile
@@ -11,36 +11,38 @@ if version = ENV['AR_VERSION']
     gem 'activerecord', version, require: nil
   end
 else
-  gem 'activerecord', '~> 5.0.6', require: false
+  gemspec name: 'activerecord-jdbc-adapter' # gem 'activerecord' declared in .gemspec
 end
 
-#gem 'thread_safe', require: nil # "optional" - we can roll without it
-gem 'rake', require: nil
+gem 'rake', '>= 11.1', require: nil
 
 group :test do
-  gem 'minitest', '< 5.3.4'
   gem 'test-unit', '~> 2.5.4'
   gem 'test-unit-context', '>= 0.4.0'
-  gem 'mocha', '~> 1.2', require: nil
+  gem 'mocha', '~> 1.2', require: false # Rails has '~> 0.14'
 
-  gem 'simplecov', require: nil
-  gem 'bcrypt-ruby', '~> 3.0.0', require: nil
-  #gem 'trinidad_dbpool', require: nil
+  gem 'bcrypt', '~> 3.1.11', require: false
+end
+
+group :rails do
+  group :test do
+    # FIX: Our test suite isn't ready to run in random order yet.
+    gem 'minitest', '< 5.3.4'
+
+    gem 'benchmark-ips'
+  end
+
+  #gem 'erubis', require: nil
+  # NOTE: due rails/activerecord/test/cases/connection_management_test.rb (AR 5.0)
+  #gem 'actionpack', require: nil
 end
 
 group :development do
   gem 'ruby-debug', require: nil # if ENV['DEBUG']
   group :doc do
     gem 'yard', require: nil
-    gem 'yard-method-overrides', git: 'https://github.com/kares/yard-method-overrides.git', require: nil
     gem 'kramdown', require: nil
   end
-end
-
-group :rails do
-  gem 'erubis', require: nil
-  # NOTE: due rails/activerecord/test/cases/connection_management_test.rb (AR 5.0)
-  gem 'actionpack', require: nil
 end
 
 group :test do
@@ -49,11 +51,12 @@ group :test do
     gem 'jdbc-sqlite3', sqlite_version, require: nil, platform: :jruby
   end
 
-  gem 'mysql2', '< 0.4', require: nil, platform: :mri
-  gem 'pg', require: nil, platform: :mri
-  gem 'sqlite3', require: nil, platform: :mri
-  group :mssql do
-    gem 'tiny_tds', require: nil, platform: :mri
-    gem 'activerecord-sqlserver-adapter', require: nil, platform: :mri
-  end
+  gem 'mysql2', '>= 0.4.4', require: nil, platform: :mri
+  gem 'pg', '>= 0.18.0', require: nil, platform: :mri
+  gem 'sqlite3', '~> 1.3.6', require: nil, platform: :mri
+
+  # group :mssql do
+  #   gem 'tiny_tds', require: nil, platform: :mri
+  #   gem 'activerecord-sqlserver-adapter', require: nil, platform: :mri
+  # end
 end

--- a/Gemfile
+++ b/Gemfile
@@ -33,8 +33,8 @@ end
 gem 'rake', '>= 11.1', require: nil
 
 group :test do
-  gem 'test-unit', '~> 2.5.4'
-  gem 'test-unit-context', '>= 0.4.0'
+  gem 'test-unit', '~> 2.5.4', require: nil
+  gem 'test-unit-context', '>= 0.4.0', require: nil
   gem 'mocha', '~> 1.2', require: false # Rails has '~> 0.14'
 
   gem 'bcrypt', '~> 3.1.11', require: false
@@ -44,14 +44,14 @@ group :rails do
   group :test do
     # FIX: Our test suite isn't ready to run in random order yet.
     gem 'minitest', '< 5.3.4', require: nil
-    gem 'minitest-colorize', require: nil
+    gem 'minitest-rg', require: nil
 
     gem 'benchmark-ips', require: nil
   end
 
   gem 'erubis', require: nil # "~> 2.7.0"
-  # NOTE: due rails/activerecord/test/cases/connection_management_test.rb (AR 5.0)
-  #gem 'actionpack', require: nil
+  # NOTE: due rails/activerecord/test/cases/connection_management_test.rb
+  gem 'rack', require: nil
 end
 
 group :development do

--- a/Gemfile
+++ b/Gemfile
@@ -49,7 +49,7 @@ group :rails do
     gem 'benchmark-ips', require: nil
   end
 
-  #gem 'erubis', require: nil
+  gem 'erubis', require: nil # "~> 2.7.0"
   # NOTE: due rails/activerecord/test/cases/connection_management_test.rb (AR 5.0)
   #gem 'actionpack', require: nil
 end

--- a/Gemfile
+++ b/Gemfile
@@ -27,9 +27,10 @@ end
 group :rails do
   group :test do
     # FIX: Our test suite isn't ready to run in random order yet.
-    gem 'minitest', '< 5.3.4'
+    gem 'minitest', '< 5.3.4', require: nil
+    gem 'minitest-colorize', require: nil
 
-    gem 'benchmark-ips'
+    gem 'benchmark-ips', require: nil
   end
 
   #gem 'erubis', require: nil

--- a/Gemfile
+++ b/Gemfile
@@ -1,12 +1,28 @@
 source "https://rubygems.org"
 
-if version = ENV['AR_VERSION']
-  if version.index('/') && ::File.exist?(version)
-    gem 'activerecord', path: version
+if version = ( ENV['AR_VERSION'] || ENV['RAILS'] )
+  if version.eql?('false')
+    # NO gem declaration (Rails test -> manipulating LOAD_PATH)
+  elsif version.index('/') && ::File.exist?(version)
+    if Dir.entries(version).include?('activerecord') # Rails directory
+      gem 'activerecord', require: false, path: ::File.join(version, 'activerecord')
+      gem 'activemodel', require: false, path: ::File.join(version, 'activemodel')
+      gem 'activesupport', require: false, path: ::File.join(version, 'activesupport')
+    else
+      gem 'activerecord', path: version
+    end
   elsif version =~ /^[0-9abcdef]+$/
-    gem 'activerecord', github: 'rails/rails', ref: version
+    git 'https://github.com/rails/rails.git', ref: version do
+      gem 'activerecord', require: false
+      gem 'activemodel', require: false
+      gem 'activesupport', require: false
+    end
   elsif version.index('.').nil?
-    gem 'activerecord', github: 'rails/rails', branch: version
+    git 'https://github.com/rails/rails.git', branch: version do
+      gem 'activerecord', require: false
+      gem 'activemodel', require: false
+      gem 'activesupport', require: false
+    end
   else
     gem 'activerecord', version, require: nil
   end

--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ if version = ( ENV['AR_VERSION'] || ENV['RAILS'] )
     else
       gem 'activerecord', path: version
     end
-  elsif version =~ /^[0-9abcdef]+$/
+  elsif version =~ /^[0-9abcdef]+$/ || version.start_with?('v')
     git 'https://github.com/rails/rails.git', ref: version do
       gem 'activerecord', require: false
       gem 'activemodel', require: false

--- a/rakelib/02-test.rake
+++ b/rakelib/02-test.rake
@@ -1,4 +1,3 @@
-require File.expand_path('../../test/shared_helper', __FILE__)
 
 test_tasks = [ 'test_mysql', 'test_sqlite3', 'test_postgresql_with_hint' ]
 if defined?(JRUBY_VERSION)
@@ -10,6 +9,7 @@ desc "Run \"most\" available test_xxx tasks"
 task :test => test_tasks
 
 task 'test_postgresql_with_hint' do
+  require File.expand_path('../../test/shared_helper', __FILE__)
   if PostgresHelper.have_postgres?(false)
     Rake::Task['test_postgresql'].invoke
   else
@@ -21,15 +21,18 @@ Rake::TestTask.class_eval { attr_reader :test_files }
 
 def test_task_for(adapter, options = {})
   desc = options[:desc] || options[:comment] ||
-    "Run tests against #{options[:database_name] || adapter}"
+      "Run tests against #{options[:database_name] || adapter}"
   adapter = adapter.to_s.downcase
   driver = adapter if ( driver = options[:driver] ).nil?
   prereqs = options[:prereqs] || []
+  unless prereqs.frozen?
+    prereqs = [ prereqs ].flatten; # prereqs << 'test_appraisal_hint'
+  end
   name = options[:name] || "test_#{adapter}"
   test_task = Rake::TestTask.new(name => prereqs) do |test_task|
     files = options[:files] || begin
       FileList["test/#{adapter}*_test.rb"] +
-        FileList["test/db/#{adapter}/**/*_test.rb"]
+          FileList["test/db/#{adapter}/**/*_test.rb"]
     end
     test_task.test_files = files
     test_task.libs = []
@@ -63,14 +66,14 @@ test_task_for :Derby, :desc => 'Run tests against (embedded) DerbyDB'
 test_task_for :H2, :desc => 'Run tests against H2 database engine'
 test_task_for :HSQLDB, :desc => 'Run tests against HyperSQL (Java) database'
 test_task_for :MSSQL, :driver => :jtds, :database_name => 'MS-SQL (SQLServer)'
-test_task_for :MySQL, :prereqs => 'db:mysql'
-test_task_for :PostgreSQL, :driver => 'postgres', :prereqs => 'db:postgresql'
+test_task_for :MySQL #, :prereqs => 'db:mysql'
+test_task_for :PostgreSQL, :driver => ENV['JDBC_POSTGRES_VERSION'] || 'postgres' #, :prereqs => 'db:postgresql'
 task :test_postgres => :test_postgresql # alias
 test_task_for :SQLite3, :driver => ENV['JDBC_SQLITE_VERSION']
 task :test_sqlite => :test_sqlite3 # alias
 test_task_for :Firebird
 
-test_task_for :MariaDB, :prereqs => 'db:mysql', :files => FileList["test/db/mysql/*_test.rb"]
+test_task_for :MariaDB, :files => FileList["test/db/mysql/*_test.rb"] #, :prereqs => 'db:mysql'
 
 # ensure driver for these DBs is on your class-path
 [ :Oracle, :DB2, :Informix, :CacheDB ].each do |adapter|
@@ -80,29 +83,59 @@ end
 #test_task_for :MSSQL, :name => 'test_sqlserver', :driver => nil, :database_name => 'MS-SQL using SQLJDBC'
 
 test_task_for :AS400, :desc => "Run tests against AS400 (DB2) (ensure driver is on class-path)",
-  :files => FileList["test/db2*_test.rb"] + FileList["test/db/db2/*_test.rb"]
+              :files => FileList["test/db2*_test.rb"] + FileList["test/db/db2/*_test.rb"]
+
+#task :test_jdbc => [ :test_jdbc_mysql, :test_jdbc_derby ] if defined?(JRUBY_VERSION)
 
 test_task_for 'JDBC', :desc => 'Run tests against plain JDBC adapter (uses MySQL and Derby)',
-  :prereqs => 'db:mysql', :files => FileList['test/*jdbc_*test.rb'] do |test_task|
+              :prereqs => [ 'db:mysql' ], :files => FileList['test/*jdbc_*test.rb'] do |test_task|
   test_task.libs << 'jdbc-mysql/lib' << 'jdbc-derby/lib'
 end
 
-test_task_for 'JNDI', :desc => 'Run tests against a JNDI connection (uses Derby)',
-  :prereqs => 'tomcat-jndi:check',
-  :files => FileList['test/*jndi_*test.rb'] do |test_task|
+task :test_jndi => [ :test_jndi_mysql, :test_jndi_derby ] if defined?(JRUBY_VERSION)
+
+jndi_classpath = []
+jndi_classpath << 'test/jars/tomcat-juli.jar'
+jndi_classpath << 'test/jars/tomcat-catalina.jar'
+
+jndi_classpath.each do |jar_path|
+  file(jar_path) { Rake::Task['tomcat-jndi:download'].invoke }
+end
+
+get_jndi_classpath_opt = lambda do
+  cp = jndi_classpath.map do |jar_path|
+    File.expand_path("../#{jar_path}", File.dirname(__FILE__))
+  end
+  "-J-cp \"#{cp.join(windows? ? ';' : ':')}\""
+end
+
+def windows?; require 'rbconfig'; RbConfig::CONFIG['host_os'] =~ /mswin|msys|mingw/ end
+
+test_task_for 'JNDI_Derby', :desc => 'Run tests against a Derby JNDI connection',
+              :prereqs => jndi_classpath,
+              :files => FileList['test/*jndi_derby*test.rb'] do |test_task|
   test_task.libs << 'jdbc-derby/lib'
+  test_task.ruby_opts << get_jndi_classpath_opt.call
+  #test_task.verbose = true
+end
+
+test_task_for 'JNDI_MySQL', :desc => 'Run tests against a MySQL JNDI connection',
+              :prereqs => [ 'db:mysql' ] + jndi_classpath,
+              :files => FileList['test/*jndi_mysql*test.rb'] do |test_task|
+  test_task.libs << 'jdbc-mysql/lib'
+  test_task.ruby_opts << get_jndi_classpath_opt.call
 end
 
 test_task_for :MySQL, :name => 'test_jdbc_mysql',
-  :prereqs => 'db:mysql', :database_name => 'MySQL (using adapter: jdbc)' do |test_task|
+              :prereqs => 'db:mysql', :database_name => 'MySQL (using adapter: jdbc)' do |test_task|
   test_task.ruby_opts << '-rdb/jdbc_mysql' # replaces require 'db/mysql'
 end
 test_task_for :PostgreSQL, :name => 'test_jdbc_postgresql', :driver => 'postgres',
-  :prereqs => 'db:postgresql', :database_name => 'PostgreSQL (using adapter: jdbc)' do |test_task|
+              :prereqs => 'db:postgresql', :database_name => 'PostgreSQL (using adapter: jdbc)' do |test_task|
   test_task.ruby_opts << '-rdb/jdbc_postgres' # replaces require 'db/postgres'
 end
 
-# TODO Sybase testing is currently broken, please fix it if you're on Sybase :
+# NOTE: Sybase testing is currently broken, please fix it if you're on Sybase :
 #test_task_for :Sybase, :desc => "Run tests against Sybase (using jTDS driver)"
 #task :test_sybase_jtds => :test_sybase # alias
 #test_task_for :Sybase, :name => 'sybase_jconnect',

--- a/rakelib/02-test.rake
+++ b/rakelib/02-test.rake
@@ -67,6 +67,7 @@ test_task_for :H2, :desc => 'Run tests against H2 database engine'
 test_task_for :HSQLDB, :desc => 'Run tests against HyperSQL (Java) database'
 test_task_for :MSSQL, :driver => :jtds, :database_name => 'MS-SQL (SQLServer)'
 test_task_for :MySQL #, :prereqs => 'db:mysql'
+task :test_mysql2 => :test_mysql
 test_task_for :PostgreSQL, :driver => ENV['JDBC_POSTGRES_VERSION'] || 'postgres' #, :prereqs => 'db:postgresql'
 task :test_postgres => :test_postgresql # alias
 test_task_for :SQLite3, :driver => ENV['JDBC_SQLITE_VERSION']

--- a/rakelib/rails.rake
+++ b/rakelib/rails.rake
@@ -18,6 +18,7 @@ namespace :rails do
       env['BUNDLE_GEMFILE'] = ENV['BUNDLE_GEMFILE'] || File.join(root_dir, 'Gemfile') # use AR-JDBC's with Rails tests
 
       driver = "jdbc-#{adapter =~ /postgres/i ? 'postgres' : adapter}"
+      adapter = 'mysql2' if adapter.eql?('mysql')
 
       libs = [
           File.join(root_dir, 'lib'),
@@ -53,6 +54,7 @@ namespace :rails do
         end
       end
     end
+    task :test_mysql2 => :test_mysql
 
     FileUtils.module_eval do
 

--- a/rakelib/rails.rake
+++ b/rakelib/rails.rake
@@ -20,6 +20,7 @@ namespace :rails do
       env['ARCONFIG'] = File.join(root_dir, 'test/rails', 'config.yml')
       env['ARCONN'] = adapter
       env['BUNDLE_GEMFILE'] = ENV['BUNDLE_GEMFILE'] || File.join(root_dir, 'Gemfile') # use AR-JDBC's with Rails tests
+      env['EXCLUDE_DIR'] = File.join(root_dir, 'test/rails/excludes') # minitest-excludes
 
       libs = [
           File.join(root_dir, 'lib'),

--- a/rakelib/rails.rake
+++ b/rakelib/rails.rake
@@ -12,13 +12,14 @@ namespace :rails do
               " try setting a local repository path e.g. export RAILS=`pwd`/../rails && bundle install"
       end
 
+      driver = "jdbc-#{adapter =~ /postgres/i ? 'postgres' : adapter}"
+      adapter = 'mysql2' if adapter.eql?('mysql')
+
       root_dir = File.expand_path('..', File.dirname(__FILE__))
       env = {}
       env['ARCONFIG'] = File.join(root_dir, 'test/rails', 'config.yml')
+      env['ARCONN'] = adapter
       env['BUNDLE_GEMFILE'] = ENV['BUNDLE_GEMFILE'] || File.join(root_dir, 'Gemfile') # use AR-JDBC's with Rails tests
-
-      driver = "jdbc-#{adapter =~ /postgres/i ? 'postgres' : adapter}"
-      adapter = 'mysql2' if adapter.eql?('mysql')
 
       libs = [
           File.join(root_dir, 'lib'),

--- a/rakelib/rails.rake
+++ b/rakelib/rails.rake
@@ -20,7 +20,7 @@ namespace :rails do
       env['ARCONFIG'] = File.join(root_dir, 'test/rails', 'config.yml')
       env['ARCONN'] = adapter
       env['BUNDLE_GEMFILE'] = ENV['BUNDLE_GEMFILE'] || File.join(root_dir, 'Gemfile') # use AR-JDBC's with Rails tests
-      env['EXCLUDE_DIR'] = File.join(root_dir, 'test/rails/excludes') # minitest-excludes
+      env['EXCLUDE_DIR'] = File.join(root_dir, 'test/rails/excludes', adapter) # minitest-excludes
 
       libs = [
           File.join(root_dir, 'lib'),

--- a/rakelib/rails.rake
+++ b/rakelib/rails.rake
@@ -1,7 +1,87 @@
-DEFAULT_RAILS_DIR = File.join('..', 'rails')
-DEFAULT_ADAPTERS = %w(MySQL SQLite3 Postgres)
-
 namespace :rails do
+
+  %w(MySQL SQLite3 PostgreSQL).each do |adapter|
+
+    desc "Run Rails ActiveRecord tests with #{adapter} (JDBC)"
+    task "test_#{adapter = adapter.downcase}" do
+      puts "Use TESTOPTS=\"--verbose\" to pass --verbose to runners." if ARGV.include? '--verbose'
+
+      require 'active_record/version'; ar_path = Gem.loaded_specs['activerecord'].full_gem_path
+      unless File.exist? ar_test_dir = File.join(ar_path, 'test')
+        raise "can not directly load Rails tests;" +
+              " try setting a local repository path e.g. export RAILS=`pwd`/../rails && bundle install"
+      end
+
+      root_dir = File.expand_path('..', File.dirname(__FILE__))
+      env = {}
+      env['ARCONFIG'] = File.join(root_dir, 'test/rails', 'config.yml')
+      env['BUNDLE_GEMFILE'] = ENV['BUNDLE_GEMFILE'] || File.join(root_dir, 'Gemfile') # use AR-JDBC's with Rails tests
+
+      driver = "jdbc-#{adapter =~ /postgres/i ? 'postgres' : adapter}"
+
+      libs = [
+          File.join(root_dir, 'lib'),
+          File.join(root_dir, driver, 'lib'),
+          File.join(root_dir, 'test/rails'),
+          ar_test_dir
+      ]
+
+      test_files_finder = lambda do
+        Dir.chdir(ar_path) do # taken from Rails' *activerecord/Rakefile* :
+          ( Dir.glob("test/cases/**/*_test.rb").reject { |x| x =~ /\/adapters\// } +
+            Dir.glob("test/cases/adapters/#{adapter}/**/*_test.rb") )
+        end
+      end
+
+      task_stub = Class.new(Rake::TestTask) { def define; end }.new # no-op define
+      test_loader_code = task_stub.run_code # :rake test-loader
+
+      ruby_opts_string = "-I\"#{libs.join(File::PATH_SEPARATOR)}\""
+      ruby_opts_string += " -C \"#{ar_path}\""
+      ruby_opts_string += " -rbundler/setup"
+      file_list_string = ENV["TEST"] ? FileList[ ENV["TEST"] ] : test_files_finder.call
+      file_list_string = file_list_string.map { |fn| "\"#{fn}\"" }.join(' ')
+      # test_loader_code = "-e \"ARGV.each{|f| require f}\"" # :direct
+      option_list = ( ENV["TESTOPTS"] || ENV["TESTOPT"] || ENV["TEST_OPTS"] || '' )
+
+      args = "#{ruby_opts_string} #{test_loader_code} #{file_list_string} #{option_list}"
+      env_sh env, "#{FileUtils::RUBY} #{args}" do |ok, status|
+        if !ok && status.respond_to?(:signaled?) && status.signaled?
+          raise SignalException.new(status.termsig)
+        elsif !ok
+          fail "Command failed with status (#{status.exitstatus})"
+        end
+      end
+    end
+
+    FileUtils.module_eval do
+
+      def env_sh(env, *cmd, &block)
+        options = (Hash === cmd.last) ? cmd.pop : {}
+        shell_runner = block_given? ? block : create_shell_runner(cmd)
+        set_verbose_option(options)
+        options[:noop] ||= Rake::FileUtilsExt.nowrite_flag
+        Rake.rake_check_options options, :noop, :verbose
+
+        cmd = env.map { |k,v| "#{k}=\"#{v}\"" }.join(' ') + ' ' + cmd.join(' ')
+        Rake.rake_output_message cmd if options[:verbose]
+
+        unless options[:noop]
+          res = Kernel.system(cmd)
+          status = $?
+          status = Rake::PseudoStatus.new(1) if !res && status.nil?
+          shell_runner.call(res, status)
+        end
+      end
+
+      def env_system(env, cmd)
+        Kernel.system(env.map { |k,v| "#{k}=\"#{v}\"" }.join(' ') + ' ' + cmd)
+      end
+
+    end
+
+  end
+
   namespace :test do
     task :all do
       driver = ENV['DRIVER'] || ENV['ADAPTER']
@@ -16,17 +96,15 @@ namespace :rails do
       end
     end
 
-    DEFAULT_ADAPTERS.each do |adapter|
-      desc "Run Rails ActiveRecord tests with #{adapter} (JDBC)"
+    %w(MySQL SQLite3 Postgres).each do |adapter|
       task adapter.downcase do
         ENV['ADAPTER'] = adapter
         Rake::Task['rails:test:all'].invoke
       end
 
       namespace adapter.downcase do
-        desc "Runs Rails ActiveRecord base_test.rb with #{adapter}"
         task "base_test" do
-          ENV['TEST'] ||= "test/cases/base_test.rb"
+          ENV['TEST'] ||= 'test/cases/base_test.rb'
           ENV['ADAPTER'] = adapter
           Rake::Task['rails:test:all'].invoke
         end
@@ -40,12 +118,12 @@ namespace :rails do
     end
 
     def _rails_dir
-      rails_dir = ENV['RAILS'] || DEFAULT_RAILS_DIR
+      rails_dir = ENV['RAILS'] || File.join('..', 'rails')
       unless File.directory? rails_dir
-        raise "can't find RAILS source '#{rails_dir}' (maybe set ENV['RAILS'])"
+        raise "can't find RAILS source at '#{rails_dir}' (maybe set ENV['RAILS'])"
       end
       rails_dir = File.join(rails_dir, '..') if rails_dir =~ /activerecord$/
-      rails_dir
+      File.expand_path(rails_dir)
     end
 
     def _ruby_lib(rails_dir, driver)
@@ -54,8 +132,7 @@ namespace :rails do
       if driver =~ /postgres/i
         adapter, driver = 'postgresql', 'postgres'
       else
-        adapter = driver.downcase
-        driver = adapter
+        adapter, driver = driver.downcase, adapter
       end
 
       [File.join(ar_jdbc_dir, 'lib'),
@@ -76,5 +153,6 @@ namespace :rails do
         "test_jdbc#{name.downcase}"
       end
     end
+
   end
 end

--- a/test/db/postgresql/schema_test.rb
+++ b/test/db/postgresql/schema_test.rb
@@ -32,7 +32,7 @@ class PostgresSchemaTest < Test::Unit::TestCase
   end
 
   def test_schema_search_path
-    assert_equal "\"$user\", public", connection.schema_search_path
+    assert_equal "\"$user\",public", connection.schema_search_path
   end
 
   context "search path" do

--- a/test/rails/config.yml
+++ b/test/rails/config.yml
@@ -1,4 +1,4 @@
-default_connection: jdbcsqlite3
+default_connection: sqlite3
 
 with_manual_interventions: false
 
@@ -61,11 +61,11 @@ connections:
 
   mysql2:
     arunit:
-      username: rails
+      username: <%= ENV['MY_USER'] || 'rails' %>
       encoding: utf8
       collation: utf8_unicode_ci
     arunit2:
-      username: rails
+      username: <%= ENV['MY_USER'] || 'rails' %>
       encoding: utf8
 
   oracle:
@@ -84,17 +84,15 @@ connections:
 
   postgresql:
     arunit:
-      adapter: jdbcpostgresql
       insert_returning: <%= ENV['INSERT_RETURNING'] %>
       prepared_statements: <%= ENV['PREPARED_STATEMENTS'] %>
-      username: <%= ENV['user'] || 'rails' %>
+      username: <%= ENV['PGUSER'] || ENV['user'] || 'rails' %>
       properties:
         prepareThreshold: <%= ENV['PREPARE_THRESHOLD'] || 1 %>
     arunit2:
-      adapter: jdbcpostgresql
       insert_returning: <%= ENV['INSERT_RETURNING'] %>
       prepared_statements: <%= ENV['PREPARED_STATEMENTS'] %>
-      username: <%= ENV['user'] || 'rails' %>
+      username: <%= ENV['PGUSER'] || ENV['user'] || 'rails' %>
       properties:
         prepareThreshold: <%= ENV['PREPARE_THRESHOLD'] || 1 %>
 

--- a/test/rails/config.yml
+++ b/test/rails/config.yml
@@ -64,9 +64,15 @@ connections:
       username: <%= ENV['MY_USER'] || 'rails' %>
       encoding: utf8
       collation: utf8_unicode_ci
+      <%- if ENV['PREPARED_STATEMENTS'] -%>
+      prepared_statements: <%= ENV['PREPARED_STATEMENTS'] %> # false by default for Mysql2Adapter
+      <%- end -%>
     arunit2:
       username: <%= ENV['MY_USER'] || 'rails' %>
       encoding: utf8
+      <%- if ENV['PREPARED_STATEMENTS'] -%>
+      prepared_statements: <%= ENV['PREPARED_STATEMENTS'] %> # false by default for Mysql2Adapter
+      <%- end -%>
 
   oracle:
      arunit:

--- a/test/rails/excludes/mysql2/Mysql2ConnectionTest.rb
+++ b/test/rails/excludes/mysql2/Mysql2ConnectionTest.rb
@@ -1,0 +1,3 @@
+exclude :test_passing_arbitary_flags_to_adapter, 'no support for arbitrary flags such as Mysql2::Client::COMPRESS'
+exclude :test_passing_flags_by_array_to_adapter, 'no support for passing flags: ... not supported by JDBC adapter'
+exclude :test_quote_after_disconnect, 'AR-JDBC does not rely on driver to do quoting - thus wont raise an error'


### PR DESCRIPTION
previous tasks are left in ... `rake rails:test:sqlite3` still works

... new syntax is `rake rails:test_sqlite3` - uses AR-JDBC's dependencies, also faster to boot up.