### PR TITLE
Support view names with single quote

### DIFF
--- a/lib/arjdbc/postgresql/adapter.rb
+++ b/lib/arjdbc/postgresql/adapter.rb
@@ -549,7 +549,7 @@ module ArJdbc
                col_description(a.attrelid, a.attnum) AS comment
           FROM pg_attribute a
           LEFT JOIN pg_attrdef d ON a.attrelid = d.adrelid AND a.attnum = d.adnum
-         WHERE a.attrelid = '#{quote_table_name(table_name)}'::regclass
+         WHERE a.attrelid = #{quote(quote_table_name(table_name))}::regclass
            AND a.attnum > 0 AND NOT a.attisdropped
          ORDER BY a.attnum
       end_sql


### PR DESCRIPTION
Refer https://github.com/rails/rails/pull/26784

This pull request addresses these 3 errors:

```ruby
$ cd rails/activerecord
$ git checkout 5-1-stable
$ bundle install
$ ARCONN=jdbcpostgresql bin/test test/cases/view_test.rb
Using jdbcpostgresql
Run options: --seed 28409

# Running:

.E.E.E..............

Finished in 2.083744s, 9.5981 runs/s, 9.1182 assertions/s.

  1) Error:
ViewWithPrimaryKeyTest#test_column_definitions:
ActiveRecord::StatementInvalid: ActiveRecord::JDBCError: org.postgresql.util.PSQLException: ERROR: unterminated quoted identifier at or near ""'::regclass
           AND a.attnum > 0 AND NOT a.attisdropped
         ORDER BY a.attnum
"
  Position: 556:         SELECT a.attname, format_type(a.atttypid, a.atttypmod),
               pg_get_expr(d.adbin, d.adrelid), a.attnotnull, a.atttypid, a.atttypmod,
               (SELECT c.collname FROM pg_collation c, pg_type t
                 WHERE c.oid = a.attcollation AND t.oid = a.atttypid
                  AND a.attcollation <> t.typcollation),
               col_description(a.attrelid, a.attnum) AS comment
          FROM pg_attribute a
          LEFT JOIN pg_attrdef d ON a.attrelid = d.adrelid AND a.attnum = d.adnum
         WHERE a.attrelid = '"ebooks'"'::regclass
           AND a.attnum > 0 AND NOT a.attisdropped
         ORDER BY a.attnum

    arjdbc/jdbc/RubyJdbcConnection.java:551:in `execute'
    /home/yahonda/git/activerecord-jdbc-adapter/lib/arjdbc/abstract/database_statements.rb:33:in `block in execute'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:613:in `block in log'
    /home/yahonda/.rbenv/versions/jruby-9.1.14.0/lib/ruby/stdlib/monitor.rb:214:in `mon_synchronize'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:612:in `block in log'
    /home/yahonda/git/rails/activesupport/lib/active_support/notifications/instrumenter.rb:21:in `instrument'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:604:in `log'
    /home/yahonda/git/activerecord-jdbc-adapter/lib/arjdbc/abstract/database_statements.rb:33:in `execute'
    /home/yahonda/git/activerecord-jdbc-adapter/lib/arjdbc/abstract/database_statements.rb:12:in `exec_query'
    /home/yahonda/git/activerecord-jdbc-adapter/lib/arjdbc/postgresql/adapter.rb:776:in `exec_query'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:371:in `select'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:42:in `select_all'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb:97:in `select_all'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:66:in `select_rows'
    /home/yahonda/git/activerecord-jdbc-adapter/lib/arjdbc/postgresql/adapter.rb:543:in `column_definitions'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:167:in `columns'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/schema_cache.rb:67:in `columns'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/schema_cache.rb:73:in `columns_hash'
    /home/yahonda/git/rails/activerecord/lib/active_record/model_schema.rb:471:in `load_schema!'
    /home/yahonda/git/rails/activerecord/lib/active_record/attributes.rb:233:in `load_schema!'
    /home/yahonda/git/rails/activerecord/lib/active_record/attribute_decorators.rb:50:in `load_schema!'
    /home/yahonda/git/rails/activerecord/lib/active_record/model_schema.rb:464:in `block in load_schema'
    /home/yahonda/.rbenv/versions/jruby-9.1.14.0/lib/ruby/stdlib/monitor.rb:214:in `mon_synchronize'
    /home/yahonda/git/rails/activerecord/lib/active_record/model_schema.rb:461:in `load_schema'
    /home/yahonda/git/rails/activerecord/lib/active_record/model_schema.rb:348:in `columns'
    /home/yahonda/git/rails/activerecord/test/cases/view_test.rb:59:in `test_column_definitions'

Error:
ViewWithPrimaryKeyTest#test_column_definitions:
ActiveRecord::StatementInvalid: ActiveRecord::JDBCError: org.postgresql.util.PSQLException: ERROR: current transaction is aborted, commands ignored until end of transaction block: SELECT c.relname FROM pg_class c LEFT JOIN pg_namespace n ON n.oid = c.relnamespace WHERE n.nspname = ANY (current_schemas(false)) AND c.relname = 'ebooks''' AND c.relkind IN ('v','m')
    arjdbc/jdbc/RubyJdbcConnection.java:796:in `execute_query_raw'
    /home/yahonda/git/activerecord-jdbc-adapter/lib/arjdbc/postgresql/adapter.rb:387:in `block in query'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:613:in `block in log'
    /home/yahonda/.rbenv/versions/jruby-9.1.14.0/lib/ruby/stdlib/monitor.rb:214:in `mon_synchronize'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:612:in `block in log'
    /home/yahonda/git/rails/activesupport/lib/active_support/notifications/instrumenter.rb:21:in `instrument'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:604:in `log'
    /home/yahonda/git/activerecord-jdbc-adapter/lib/arjdbc/postgresql/adapter.rb:385:in `query'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:74:in `query_values'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb:74:in `view_exists?'
    /home/yahonda/git/rails/activerecord/test/cases/view_test.rb:95:in `drop_view'
    /home/yahonda/git/rails/activerecord/test/cases/view_test.rb:28:in `teardown'


  2) Error:
ViewWithPrimaryKeyTest#test_attributes:
ActiveRecord::StatementInvalid: ActiveRecord::JDBCError: org.postgresql.util.PSQLException: ERROR: unterminated quoted identifier at or near ""'::regclass
           AND a.attnum > 0 AND NOT a.attisdropped
         ORDER BY a.attnum
"
  Position: 556:         SELECT a.attname, format_type(a.atttypid, a.atttypmod),
               pg_get_expr(d.adbin, d.adrelid), a.attnotnull, a.atttypid, a.atttypmod,
               (SELECT c.collname FROM pg_collation c, pg_type t
                 WHERE c.oid = a.attcollation AND t.oid = a.atttypid
                  AND a.attcollation <> t.typcollation),
               col_description(a.attrelid, a.attnum) AS comment
          FROM pg_attribute a
          LEFT JOIN pg_attrdef d ON a.attrelid = d.adrelid AND a.attnum = d.adnum
         WHERE a.attrelid = '"ebooks'"'::regclass
           AND a.attnum > 0 AND NOT a.attisdropped
         ORDER BY a.attnum

    arjdbc/jdbc/RubyJdbcConnection.java:551:in `execute'
    /home/yahonda/git/activerecord-jdbc-adapter/lib/arjdbc/abstract/database_statements.rb:33:in `block in execute'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:613:in `block in log'
    /home/yahonda/.rbenv/versions/jruby-9.1.14.0/lib/ruby/stdlib/monitor.rb:214:in `mon_synchronize'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:612:in `block in log'
    /home/yahonda/git/rails/activesupport/lib/active_support/notifications/instrumenter.rb:21:in `instrument'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:604:in `log'
    /home/yahonda/git/activerecord-jdbc-adapter/lib/arjdbc/abstract/database_statements.rb:33:in `execute'
    /home/yahonda/git/activerecord-jdbc-adapter/lib/arjdbc/abstract/database_statements.rb:12:in `exec_query'
    /home/yahonda/git/activerecord-jdbc-adapter/lib/arjdbc/postgresql/adapter.rb:776:in `exec_query'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:371:in `select'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:42:in `select_all'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb:97:in `select_all'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:66:in `select_rows'
    /home/yahonda/git/activerecord-jdbc-adapter/lib/arjdbc/postgresql/adapter.rb:543:in `column_definitions'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:167:in `columns'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/schema_cache.rb:67:in `columns'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/schema_cache.rb:73:in `columns_hash'
    /home/yahonda/git/rails/activerecord/lib/active_record/model_schema.rb:471:in `load_schema!'
    /home/yahonda/git/rails/activerecord/lib/active_record/attributes.rb:233:in `load_schema!'
    /home/yahonda/git/rails/activerecord/lib/active_record/attribute_decorators.rb:50:in `load_schema!'
    /home/yahonda/git/rails/activerecord/lib/active_record/model_schema.rb:464:in `block in load_schema'
    /home/yahonda/.rbenv/versions/jruby-9.1.14.0/lib/ruby/stdlib/monitor.rb:214:in `mon_synchronize'
    /home/yahonda/git/rails/activerecord/lib/active_record/model_schema.rb:461:in `load_schema'
    /home/yahonda/git/rails/activerecord/lib/active_record/model_schema.rb:343:in `columns_hash'
    /home/yahonda/git/rails/activerecord/lib/active_record/querying.rb:41:in `find_by_sql'
    /home/yahonda/git/rails/activerecord/lib/active_record/relation.rb:678:in `exec_queries'
    /home/yahonda/git/rails/activerecord/lib/active_record/relation.rb:546:in `load'
    /home/yahonda/git/rails/activerecord/lib/active_record/relation.rb:255:in `records'
    /home/yahonda/git/rails/activerecord/lib/active_record/relation.rb:251:in `to_a'
    /home/yahonda/git/rails/activerecord/lib/active_record/relation/finder_methods.rb:536:in `find_nth_with_limit'
    /home/yahonda/git/rails/activerecord/lib/active_record/relation/finder_methods.rb:521:in `find_nth'
    /home/yahonda/git/rails/activerecord/lib/active_record/relation/finder_methods.rb:122:in `first'
    /home/yahonda/git/rails/activerecord/lib/active_record/querying.rb:3:in `first'
    /home/yahonda/git/rails/activerecord/test/cases/view_test.rb:64:in `test_attributes'

Error:
ViewWithPrimaryKeyTest#test_attributes:
ActiveRecord::StatementInvalid: ActiveRecord::JDBCError: org.postgresql.util.PSQLException: ERROR: current transaction is aborted, commands ignored until end of transaction block: SELECT c.relname FROM pg_class c LEFT JOIN pg_namespace n ON n.oid = c.relnamespace WHERE n.nspname = ANY (current_schemas(false)) AND c.relname = 'ebooks''' AND c.relkind IN ('v','m')
    arjdbc/jdbc/RubyJdbcConnection.java:796:in `execute_query_raw'
    /home/yahonda/git/activerecord-jdbc-adapter/lib/arjdbc/postgresql/adapter.rb:387:in `block in query'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:613:in `block in log'
    /home/yahonda/.rbenv/versions/jruby-9.1.14.0/lib/ruby/stdlib/monitor.rb:214:in `mon_synchronize'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:612:in `block in log'
    /home/yahonda/git/rails/activesupport/lib/active_support/notifications/instrumenter.rb:21:in `instrument'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:604:in `log'
    /home/yahonda/git/activerecord-jdbc-adapter/lib/arjdbc/postgresql/adapter.rb:385:in `query'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:74:in `query_values'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb:74:in `view_exists?'
    /home/yahonda/git/rails/activerecord/test/cases/view_test.rb:95:in `drop_view'
    /home/yahonda/git/rails/activerecord/test/cases/view_test.rb:28:in `teardown'


  3) Error:
ViewWithPrimaryKeyTest#test_reading:
ActiveRecord::StatementInvalid: ActiveRecord::JDBCError: org.postgresql.util.PSQLException: ERROR: unterminated quoted identifier at or near ""'::regclass
           AND a.attnum > 0 AND NOT a.attisdropped
         ORDER BY a.attnum
"
  Position: 556:         SELECT a.attname, format_type(a.atttypid, a.atttypmod),
               pg_get_expr(d.adbin, d.adrelid), a.attnotnull, a.atttypid, a.atttypmod,
               (SELECT c.collname FROM pg_collation c, pg_type t
                 WHERE c.oid = a.attcollation AND t.oid = a.atttypid
                  AND a.attcollation <> t.typcollation),
               col_description(a.attrelid, a.attnum) AS comment
          FROM pg_attribute a
          LEFT JOIN pg_attrdef d ON a.attrelid = d.adrelid AND a.attnum = d.adnum
         WHERE a.attrelid = '"ebooks'"'::regclass
           AND a.attnum > 0 AND NOT a.attisdropped
         ORDER BY a.attnum

    arjdbc/jdbc/RubyJdbcConnection.java:551:in `execute'
    /home/yahonda/git/activerecord-jdbc-adapter/lib/arjdbc/abstract/database_statements.rb:33:in `block in execute'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:613:in `block in log'
    /home/yahonda/.rbenv/versions/jruby-9.1.14.0/lib/ruby/stdlib/monitor.rb:214:in `mon_synchronize'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:612:in `block in log'
    /home/yahonda/git/rails/activesupport/lib/active_support/notifications/instrumenter.rb:21:in `instrument'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:604:in `log'
    /home/yahonda/git/activerecord-jdbc-adapter/lib/arjdbc/abstract/database_statements.rb:33:in `execute'
    /home/yahonda/git/activerecord-jdbc-adapter/lib/arjdbc/abstract/database_statements.rb:12:in `exec_query'
    /home/yahonda/git/activerecord-jdbc-adapter/lib/arjdbc/postgresql/adapter.rb:776:in `exec_query'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:371:in `select'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:42:in `select_all'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb:97:in `select_all'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:66:in `select_rows'
    /home/yahonda/git/activerecord-jdbc-adapter/lib/arjdbc/postgresql/adapter.rb:543:in `column_definitions'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:167:in `columns'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/schema_cache.rb:67:in `columns'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/schema_cache.rb:73:in `columns_hash'
    /home/yahonda/git/rails/activerecord/lib/active_record/model_schema.rb:471:in `load_schema!'
    /home/yahonda/git/rails/activerecord/lib/active_record/attributes.rb:233:in `load_schema!'
    /home/yahonda/git/rails/activerecord/lib/active_record/attribute_decorators.rb:50:in `load_schema!'
    /home/yahonda/git/rails/activerecord/lib/active_record/model_schema.rb:464:in `block in load_schema'
    /home/yahonda/.rbenv/versions/jruby-9.1.14.0/lib/ruby/stdlib/monitor.rb:214:in `mon_synchronize'
    /home/yahonda/git/rails/activerecord/lib/active_record/model_schema.rb:461:in `load_schema'
    /home/yahonda/git/rails/activerecord/lib/active_record/model_schema.rb:343:in `columns_hash'
    /home/yahonda/git/rails/activerecord/lib/active_record/querying.rb:41:in `find_by_sql'
    /home/yahonda/git/rails/activerecord/lib/active_record/relation.rb:678:in `exec_queries'
    /home/yahonda/git/rails/activerecord/lib/active_record/relation.rb:546:in `load'
    /home/yahonda/git/rails/activerecord/lib/active_record/relation.rb:255:in `records'
    /home/yahonda/git/rails/activerecord/lib/active_record/relation/delegation.rb:39:in `each'
    org/jruby/RubyEnumerable.java:830:in `map'
    /home/yahonda/git/rails/activerecord/test/cases/view_test.rb:33:in `test_reading'

Error:
ViewWithPrimaryKeyTest#test_reading:
ActiveRecord::StatementInvalid: ActiveRecord::JDBCError: org.postgresql.util.PSQLException: ERROR: current transaction is aborted, commands ignored until end of transaction block: SELECT c.relname FROM pg_class c LEFT JOIN pg_namespace n ON n.oid = c.relnamespace WHERE n.nspname = ANY (current_schemas(false)) AND c.relname = 'ebooks''' AND c.relkind IN ('v','m')
    arjdbc/jdbc/RubyJdbcConnection.java:796:in `execute_query_raw'
    /home/yahonda/git/activerecord-jdbc-adapter/lib/arjdbc/postgresql/adapter.rb:387:in `block in query'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:613:in `block in log'
    /home/yahonda/.rbenv/versions/jruby-9.1.14.0/lib/ruby/stdlib/monitor.rb:214:in `mon_synchronize'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:612:in `block in log'
    /home/yahonda/git/rails/activesupport/lib/active_support/notifications/instrumenter.rb:21:in `instrument'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:604:in `log'
    /home/yahonda/git/activerecord-jdbc-adapter/lib/arjdbc/postgresql/adapter.rb:385:in `query'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:74:in `query_values'
    /home/yahonda/git/rails/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb:74:in `view_exists?'
    /home/yahonda/git/rails/activerecord/test/cases/view_test.rb:95:in `drop_view'
    /home/yahonda/git/rails/activerecord/test/cases/view_test.rb:28:in `teardown'

20 runs, 19 assertions, 0 failures, 3 errors, 0 skips
$
```