### PR TITLE
Execute `configure_connection` to enable foreign keys at sqlite3 adapter

### DIFF
--- a/lib/arjdbc/sqlite3/adapter.rb
+++ b/lib/arjdbc/sqlite3/adapter.rb
@@ -78,6 +78,8 @@ module ArJdbc
 
       @active     = nil
       @statements = StatementPool.new(self.class.type_cast_config_to_integer(config[:statement_limit]))
+
+      configure_connection
     end
 
     def supports_ddl_transactions?


### PR DESCRIPTION
Refer https://github.com/rails/rails/pull/27701

This pull request addresses these two failures:

#### Steps to reproduce:
```
$ cd rails/activerecord
$ git checkout 5-1-stable
$ bundle install
$ ARCONN=jdbcsqlite3 bin/test test/cases/adapter_test.rb -n /test_foreign_key_violations/
```

### Actual result without this commit:
```ruby
$ ARCONN=jdbcsqlite3 bin/test test/cases/adapter_test.rb -n /test_foreign_key_violations/
Using jdbcsqlite3
Run options: -n /test_foreign_key_violations/ --seed 41207

# Running:

FF

Finished in 0.080637s, 24.8025 runs/s, 24.8025 assertions/s.

  1) Failure:
ActiveRecord::AdapterForeignKeyTest#test_foreign_key_violations_are_translated_to_specific_exception [/home/yahonda/git/rails/activerecord/test/cases/adapter_test.rb:288]:
ActiveRecord::InvalidForeignKey expected but nothing was raised.


  2) Failure:
ActiveRecord::AdapterForeignKeyTest#test_foreign_key_violations_are_translated_to_specific_exception_with_validate_false [/home/yahonda/git/rails/activerecord/test/cases/adapter_test.rb:278]:
ActiveRecord::InvalidForeignKey expected but nothing was raised.

2 runs, 2 assertions, 2 failures, 0 errors, 0 skips
$
```

Since the current `initialize` method does not call `configure_connection`  `disable_referential_integrity` method executes `PRAGMA foreign_keys = 0` at the end. which means foreign keys are disabled.


