### PR TITLE
Fix `change_column` to drop default with `null: false`

### DIFF
--- a/lib/arjdbc/sqlite3/adapter.rb
+++ b/lib/arjdbc/sqlite3/adapter.rb
@@ -356,11 +356,10 @@ module ArJdbc
 
     def change_column(table_name, column_name, type, options = {}) #:nodoc:
       alter_table(table_name) do |definition|
-        include_default = options_include_default?(options)
         definition[column_name].instance_eval do
           self.type    = type
           self.limit   = options[:limit] if options.include?(:limit)
-          self.default = options[:default] if include_default
+          self.default = options[:default] if options.include?(:default)
           self.null    = options[:null] if options.include?(:null)
           self.precision = options[:precision] if options.include?(:precision)
           self.scale   = options[:scale] if options.include?(:scale)


### PR DESCRIPTION
Refer https://github.com/rails/rails/commit/c92757fb68f

This pull request addresses the following failure.

```ruby
$ cd rails/activerecord
$ git checkout 5-1-stable
$ bundle
$ bin/test test/cases/migration/columns_test.rb:234
Using jdbcsqlite3
Run options: --seed 4959

# Running:

F

Finished in 0.281328s, 3.5546 runs/s, 7.1091 assertions/s.

  1) Failure:
ActiveRecord::Migration::ColumnsTest#test_change_column_to_drop_default_with_null_false [/home/yahonda/git/rails/activerecord/test/cases/migration/columns_test.rb:234]:
Expected true to be nil or false

1 runs, 2 assertions, 1 failures, 0 errors, 0 skips
$
```
