### PR TITLE
Let `supports_transaction_isolation?` have the same method signature

### DIFF
--- a/lib/arjdbc/abstract/transaction_support.rb
+++ b/lib/arjdbc/abstract/transaction_support.rb
@@ -13,15 +13,8 @@ module ArJdbc
         @connection.supports_savepoints?
       end
 
-      # Does this adapter support setting the isolation level for a transaction?
-      # Unlike 'plain' `ActiveRecord` we allow checking for concrete transaction
-      # isolation level support by the database.
-      # @param level optional to check if we support a specific isolation level
-      # @since 1.3.0
-      # @extension added optional level parameter
-      def supports_transaction_isolation?(level = nil)
-        return false unless level
-        @connection.supports_transaction_isolation?(level)
+      def supports_transaction_isolation?
+        @connection.supports_transaction_isolation?
       end
 
       ########################## Transaction Interface ##########################

--- a/lib/arjdbc/mysql/adapter.rb
+++ b/lib/arjdbc/mysql/adapter.rb
@@ -54,6 +54,10 @@ module ActiveRecord
         true
       end
 
+      def supports_transaction_isolation?
+        true
+      end
+
       # HELPER METHODS ===========================================
 
       # Reloading the type map in abstract/statement_cache.rb blows up postgres

--- a/lib/arjdbc/postgresql/adapter.rb
+++ b/lib/arjdbc/postgresql/adapter.rb
@@ -242,7 +242,7 @@ module ArJdbc
 
     def supports_savepoints?; true end
 
-    def supports_transaction_isolation?(level = nil); true end
+    def supports_transaction_isolation?; true end
 
     def supports_views?; true end
 

--- a/lib/arjdbc/sqlite3/adapter.rb
+++ b/lib/arjdbc/sqlite3/adapter.rb
@@ -671,6 +671,10 @@ module ActiveRecord::ConnectionAdapters
     include ArJdbc::Abstract::StatementCache
     include ArJdbc::Abstract::TransactionSupport
 
+    def supports_transaction_isolation?
+      false
+    end
+
     def begin_isolated_db_transaction(isolation)
       raise ActiveRecord::TransactionIsolationError, 'adapter does not support setting transaction isolation'
     end

--- a/test/transaction_test_methods.rb
+++ b/test/transaction_test_methods.rb
@@ -34,16 +34,6 @@ module TransactionTestMethods
 
   def setup_failed?; @setup_failed ||= false end
 
-  def test_supports_transaction_isolation
-    unless ActiveRecord::Base.connection.supports_transaction_isolation?
-      omit("transaction isolation not supported")
-    end
-    assert ActiveRecord::Base.connection.supports_transaction_isolation?(:read_uncommitted)
-    assert ActiveRecord::Base.connection.supports_transaction_isolation?(:read_committed)
-    assert ActiveRecord::Base.connection.supports_transaction_isolation?(:repeatable_read)
-    assert ActiveRecord::Base.connection.supports_transaction_isolation?(:serializable)
-  end
-
   def test_transaction_isolation_read_uncommitted
     # It is impossible to properly test read uncommitted. The SQL standard only
     # specifies what must not happen at a certain level, not what must happen. At


### PR DESCRIPTION
Let `supports_transaction_isolation?` have the same method signature with Active Record

This pull request the following failure.

```ruby
$ cd rails/activerecord
$ git checkout 5-1-stable
$ bundle install
$ ARCONN=jdbcmysql bin/test test/cases/transaction_isolation_test.rb:11
Using jdbcmysql
Run options: --seed 8415

F

Finished in 0.069170s, 14.4571 runs/s, 14.4571 assertions/s.

  1) Failure:
TransactionIsolationUnsupportedTest#test_setting_the_isolation_level_raises_an_error
[/home/yahonda/git/rails/activerecord/test/cases/transaction_isolation_test.rb:11]:
ActiveRecord::TransactionIsolationError expected but nothing was raised.

1 runs, 1 assertions, 1 failures, 0 errors, 0 skips
$
```

It also removes `test_supports_transaction_isolation` test expecting
`supports_transaction_isolation?` method have `level` argument, which is
not compatible with Active Record implementation.

Note: I am not clear how to handle Java implmentation for this method.

https://github.com/jruby/activerecord-jdbc-adapter/blob/b381039e78aed38ecb36e1ca8afbf137cc882865/src/java/arjdbc/jdbc/RubyJdbcConnection.java#L178-L198