### PR TITLE
Address `warning: Ambiguous first argument; make sure.`

### DIFF
--- a/test/db/mysql/simple_test.rb
+++ b/test/db/mysql/simple_test.rb
@@ -188,7 +188,7 @@ class MySQLSimpleTest < Test::Unit::TestCase
       config[:password] = MYSQL_CONFIG[:password]
       config[:database] = MYSQL_CONFIG[:database]
       with_connection(config) do |connection|
-        assert_match /^jdbc:mysql:\/\/:\d*\//, connection.config[:url]
+        assert_match(/^jdbc:mysql:\/\/:\d*\//, connection.config[:url])
       end
 #      # ActiveRecord::Base.connection.disconnect!
 #      host = [ MYSQL_CONFIG[:host] || 'localhost', '127.0.0.1' ] # fail-over


### PR DESCRIPTION
This pull request addresses the folloiwng warning.

```ruby
$ rake test_mysql
Using ActiveRecord::VERSION = 5.1.4
/home/yahonda/git/activerecord-jdbc-adapter/test/db/mysql/simple_test.rb:191:
warning: Ambiguous first argument; make sure.
```