### PR TITLE
Address `sun.security.validator.ValidatorException:`

### DIFF
--- a/lib/arjdbc/mysql/connection_methods.rb
+++ b/lib/arjdbc/mysql/connection_methods.rb
@@ -68,6 +68,7 @@ ArJdbc::ConnectionMethods.module_eval do
       # According to MySQL 5.5.45+, 5.6.26+ and 5.7.6+ requirements SSL connection
       # must be established by default if explicit option isn't set :
       properties['useSSL'] ||= false
+      properties['trustServerCertificate'] ||= true
     end
     if socket = config[:socket]
       properties['localSocket'] ||= socket if mariadb_driver


### PR DESCRIPTION
This pull request addresses #845 

```ruby
$ rake test_mysql
Using ActiveRecord::VERSION = 5.1.4
ActiveRecord::JDBCError: java.sql.SQLNonTransientConnectionException:
Could not connect to localhost:3306:
sun.security.validator.ValidatorException: PKIX path building failed:
sun.security.provider.certpath.SunCertPathBuilderException: unable to
find valid certification path to requested target
```

Refer [Using TLS/SSL with MariaDB Connector/J](https://mariadb.com/kb/en/library/using-tlsssl-with-mariadb-connectorj/)

