### PR TITLE
Remove unnecessary `CHARSET=utf8 COLLATE=utf8_general_ci`

### DIFF
--- a/lib/arjdbc/mysql/adapter.rb
+++ b/lib/arjdbc/mysql/adapter.rb
@@ -83,9 +83,8 @@ module ActiveRecord
         exception.errno if exception.respond_to? :errno
       end
 
-      # FIXME: #833 This is wrong...it should not always pass utf8 and native adapter never does...
       def create_table(table_name, **options) #:nodoc:
-        super(table_name, options: 'ENGINE=InnoDB CHARSET=utf8 COLLATE=utf8_general_ci', **options)
+        super(table_name, options: "ENGINE=InnoDB", **options)
       end
 
       #--


### PR DESCRIPTION
from `create_table` method

Closes #833

These options are unnecessary as Rails `AbstractMysqlAdapter` does not specify them.

https://github.com/rails/rails/blob/5-1-stable/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb#L362-L364
```ruby
      def create_table(table_name, **options) #:nodoc:
        super(table_name, options: "ENGINE=InnoDB", **options)
      end
```
