### PR TITLE
Delete minitest-excludes from Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,7 +45,6 @@ group :rails do
     # FIX: Our test suite isn't ready to run in random order yet.
     gem 'minitest', '< 5.3.4', require: nil
     # FIX: Update to 2.0.1 or higher once this gem is released
-    gem 'minitest-excludes', git: 'https://github.com/enebo/minitest-excludes'
     gem 'minitest-rg', require: nil
 
     gem 'benchmark-ips', require: nil


### PR DESCRIPTION
Delete minitest-excludes from Gemfile to address `warning: loading in progress, circular require considered harmful`

Even with [minitest excluded for now since it is broken on travis
](https://github.com/jruby/activerecord-jdbc-adapter/commit/eccdf007ff118734d4888d0197eb86f6f60d9bc5 ) it is getting this warning below https://travis-ci.org/jruby/activerecord-jdbc-adapter/jobs/309757276 

```ruby
/home/travis/.rvm/gems/jruby-9.1.14.0/gems/activesupport-5.1.4/lib/active_support/dependencies.rb:292: warning: loading in progress, circular require considered harmful - /home/travis/.rvm/gems/jruby-9.1.14.0/gems/minitest-5.3.3/lib/minitest/test.rb
```

Refer #852