### PR TITLE
 Restore `minitest-excludes` feature

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,7 +43,7 @@ end
 group :rails do
   group :test do
     # FIX: Our test suite isn't ready to run in random order yet.
-    gem 'minitest', '< 5.3.4', require: nil
+    gem 'minitest', '< 5.3.4'
     # FIX: Update to 2.0.1 or higher once this gem is released
     gem 'minitest-excludes', git: 'https://github.com/enebo/minitest-excludes'
     gem 'minitest-rg', require: nil

--- a/Gemfile
+++ b/Gemfile
@@ -45,6 +45,7 @@ group :rails do
     # FIX: Our test suite isn't ready to run in random order yet.
     gem 'minitest', '< 5.3.4', require: nil
     # FIX: Update to 2.0.1 or higher once this gem is released
+    gem 'minitest-excludes', git: 'https://github.com/enebo/minitest-excludes'
     gem 'minitest-rg', require: nil
 
     gem 'benchmark-ips', require: nil

--- a/rakelib/rails.rake
+++ b/rakelib/rails.rake
@@ -42,6 +42,7 @@ namespace :rails do
       ruby_opts_string = "-I\"#{libs.join(File::PATH_SEPARATOR)}\""
       ruby_opts_string += " -C \"#{ar_path}\""
       ruby_opts_string += " -rbundler/setup"
+      ruby_opts_string += " -rminitest/excludes"
       file_list_string = ENV["TEST"] ? FileList[ ENV["TEST"] ] : test_files_finder.call
       file_list_string = file_list_string.map { |fn| "\"#{fn}\"" }.join(' ')
       # test_loader_code = "-e \"ARGV.each{|f| require f}\"" # :direct


### PR DESCRIPTION
This pull request addresses #852 and restore `minitest-excludes` feature. 
Somehow in my environment, it needs to remove ` require: nil` for `mintest`