### PR TITLE
Minitest excludes require nil

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,7 +43,7 @@ end
 group :rails do
   group :test do
     # FIX: Our test suite isn't ready to run in random order yet.
-    gem 'minitest', '< 5.3.4'
+    gem 'minitest', '< 5.3.4', require: nil
     # FIX: Update to 2.0.1 or higher once this gem is released
     gem 'minitest-excludes', git: 'https://github.com/enebo/minitest-excludes'
     gem 'minitest-rg', require: nil

--- a/Gemfile
+++ b/Gemfile
@@ -45,7 +45,7 @@ group :rails do
     # FIX: Our test suite isn't ready to run in random order yet.
     gem 'minitest', '< 5.3.4', require: nil
     # FIX: Update to 2.0.1 or higher once this gem is released
-    gem 'minitest-excludes', git: 'https://github.com/enebo/minitest-excludes'
+    gem 'minitest-excludes', git: 'https://github.com/enebo/minitest-excludes', require: nil
     gem 'minitest-rg', require: nil
 
     gem 'benchmark-ips', require: nil


### PR DESCRIPTION
Follow up #854 and based on the comment https://github.com/jruby/activerecord-jdbc-adapter/issues/852#issuecomment-348529100