### PR TITLE
[test] tune/more rails tests - leave PG config to its defaults

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,6 +61,9 @@ matrix:
         mariadb: '10.1'
       env: DB=mariadb PREPARED_STATEMENTS=true
     # Rails test-suite :
-    - env: DB=mysql2     TEST_PREFIX="rails:" AR_VERSION="v5.0.6"
-    - env: DB=postgresql TEST_PREFIX="rails:" AR_VERSION="v5.0.6"
+    - env: DB=mysql2     TEST_PREFIX="rails:" AR_VERSION="v5.0.6" # PS off by default
+    - env: DB=mysql2     TEST_PREFIX="rails:" AR_VERSION="v5.0.6" PREPARED_STATEMENTS=true
+    - env: DB=postgresql TEST_PREFIX="rails:" AR_VERSION="v5.0.6" # PS on by default
+    - env: DB=postgresql TEST_PREFIX="rails:" AR_VERSION="v5.0.6" PREPARED_STATEMENTS=false
+    - env: DB=postgresql TEST_PREFIX="rails:" AR_VERSION="v5.0.6" INSERT_RETURNIG=false
     - env: DB=sqlite3    TEST_PREFIX="rails:" AR_VERSION="v5.0.6"

--- a/test/rails/config.yml
+++ b/test/rails/config.yml
@@ -71,23 +71,25 @@ connections:
       prepared_statements: <%= ENV['PREPARED_STATEMENTS'] || 'false' %>
 
   postgresql:
-    arunit:
-      insert_returning: <%= ENV['INSERT_RETURNING'] %>
-      prepared_statements: <%= ENV['PREPARED_STATEMENTS'] %>
+    _setup: &_setup
+      <% if ENV.key?('INSERT_RETURNING') -%>
+      insert_returning: <%= ENV['INSERT_RETURNING'] %> # really should leave it off to no key if not set
+      <% end -%>
+      <% if ENV.key?('PREPARED_STATEMENTS') -%>
+      insert_returning: <%= ENV['PREPARED_STATEMENTS'] %> # should leave it off to its default if not set
+      <% end -%>
       username: <%= ENV['PGUSER'] || ENV['user'] || 'rails' %>
       properties:
+        # Postgres' JDBC driver does not prepare statements until executed 5 times by default, let's lower:
         prepareThreshold: <%= ENV['PREPARE_THRESHOLD'] || 1 %>
         # to not print (lengthy) traces from driver such as :
         #   SEVERE: Connection error: org.postgresql.util.PSQLException: FATAL: database "xxx" does not exist
         #loggerLevel: OFF # Broken in 42.1.4 thus let's do it manually :
         <% java.util.logging.Logger.getLogger("org.postgresql").setLevel(java.util.logging.Level::OFF) %>
+    arunit:
+      <<: *_setup
     arunit2:
-      insert_returning: <%= ENV['INSERT_RETURNING'] %>
-      prepared_statements: <%= ENV['PREPARED_STATEMENTS'] %>
-      username: <%= ENV['PGUSER'] || ENV['user'] || 'rails' %>
-      properties:
-        prepareThreshold: <%= ENV['PREPARE_THRESHOLD'] || 1 %>
-        #loggerLevel: OFF # Broken in 42.1.4
+      <<: *_setup
 
   sqlite3:
     arunit:


### PR DESCRIPTION
... seems that by doing so there's much more failures with Postgres' (rails tests) than currently

but I believe this is the test setup we should be going towards - explicitly not having a setup such as : 
```
production:
  insert_returning: ""
  prepared_statements: ""
```

maybe there's just one issue underneath the failures (check the rails:test_postgresql target on CI - the one without any ENV vars) otherwise it would mean the adapter is still not much in shape