### PR TITLE
Pass column types for postgres results

### DIFF
--- a/src/java/arjdbc/jdbc/RubyJdbcConnection.java
+++ b/src/java/arjdbc/jdbc/RubyJdbcConnection.java
@@ -3644,7 +3644,7 @@ public class RubyJdbcConnection extends RubyObject {
         return Result.newInstance(context, columnsToArray(context, columns), rows, Block.NULL_BLOCK); // Result.new
     }
 
-    private static RubyArray columnsToArray(ThreadContext context, ColumnData[] columns) {
+    protected static RubyArray columnsToArray(ThreadContext context, ColumnData[] columns) {
         final IRubyObject[] cols = new IRubyObject[columns.length];
 
         for ( int i = 0; i < columns.length; i++ ) cols[i] = columns[i].getName(context);
@@ -3752,6 +3752,7 @@ public class RubyJdbcConnection extends RubyObject {
         public final int type;
 
         private final String label;
+        private IRubyObject rubyType = null;
 
         @Deprecated
         public ColumnData(RubyString name, int type, int idx) {
@@ -3768,6 +3769,11 @@ public class RubyJdbcConnection extends RubyObject {
             this.index = idx;
         }
 
+        public ColumnData(String label, int type, int idx, IRubyObject rubyType) {
+            this(label, type, idx);
+            this.rubyType = rubyType;
+        }
+
         // NOTE: meant temporary for others to update from accesing name
         ColumnData(ThreadContext context, String label, int type, int idx) {
             this(label, type, idx);
@@ -3778,9 +3784,13 @@ public class RubyJdbcConnection extends RubyObject {
             return label;
         }
 
-        RubyString getName(final ThreadContext context) {
+        public RubyString getName(final ThreadContext context) {
             if ( name != null ) return name;
             return name = cachedString(context, label);
+        }
+
+        public IRubyObject getRubyType() {
+            return rubyType;
         }
 
         @Override
@@ -3790,7 +3800,7 @@ public class RubyJdbcConnection extends RubyObject {
 
     }
 
-    private ColumnData[] setupColumns(
+    protected ColumnData[] setupColumns(
             final ThreadContext context,
             final Connection connection,
             final ResultSetMetaData resultMetaData,

--- a/src/java/arjdbc/postgresql/PgResultSetMetaDataWrapper.java
+++ b/src/java/arjdbc/postgresql/PgResultSetMetaDataWrapper.java
@@ -1,0 +1,22 @@
+/*
+ * A class to loosen restrictions on the PgResultSetMetaData class
+ */
+package org.postgresql.jdbc;
+
+import java.sql.SQLException;
+import org.postgresql.core.BaseConnection;
+import org.postgresql.core.Field;
+import org.postgresql.jdbc.PgResultSetMetaData;
+
+public class PgResultSetMetaDataWrapper {
+
+    private final PgResultSetMetaData metaData;
+
+    public PgResultSetMetaDataWrapper(PgResultSetMetaData metaData) {
+        this.metaData = metaData;
+    }
+
+    public Field getField(int i) throws SQLException {
+        return this.metaData.getField(i);
+    }
+}


### PR DESCRIPTION
This makes it so we will fetch the column types from the adapter to populate the `ActiveRecord::Result` object if we have access to them. It's a bit of a chicken/egg situation since we need to get the types from the cache but need to query to get types into the cache, so there may be a better work around than I currently have in place.

This fixes a couple of tests and sets us up to potentially fix a few others. I think it should also be applied to other adapters at some point. If this is ok, I'll see about getting it into master as well so it can be in the 51.0 release.

I created `PgResultSetMetaDataWrapper` because the `getField` method is protected in the `PgResultSetMetaData` object and it was the only way I could figure to work around it. If there is a better option please let me know.