### PR TITLE
fix schema config for Oracle application users

### DIFF
--- a/lib/arjdbc/oracle/adapter.rb
+++ b/lib/arjdbc/oracle/adapter.rb
@@ -921,9 +921,13 @@ module ArJdbc
     # default schema owner
     def schema_owner(force = true)
       unless defined? @schema_owner
-        username = config[:username] ? config[:username].to_s : nil
-        username = jdbc_connection.meta_data.user_name if force && username.nil?
-        @schema_owner = username.nil? ? nil : username.upcase
+        if !config[:schema].nil?
+          @schema_owner = config[:schema].upcase
+        else
+          username = config[:username] ? config[:username].to_s : nil
+          username = jdbc_connection.meta_data.user_name if force && username.nil?
+          @schema_owner = username.nil? ? nil : username.upcase
+        end
       end
       @schema_owner
     end


### PR DESCRIPTION
Oracle application users are currently broken in 1.3.x, the SELECT that tries to determine the proper sequences and primary key uses a nil owner and fails. This is a quick fix that will set the schema_owner to the schema name if set.