### PR TITLE
Increment index when counting octal escapes

### DIFF
--- a/src/java/arjdbc/postgresql/ByteaUtils.java
+++ b/src/java/arjdbc/postgresql/ByteaUtils.java
@@ -89,6 +89,7 @@ abstract class ByteaUtils {
                     }
                     else {
                         correctSize -= 3;
+  						i += 2;
                     }
                 }
             }


### PR DESCRIPTION
This is to avoid arrayIndexOutOfBoundsException in the main unescape loop.  It only happens when unescaping non-escaped content.