### PR TITLE
[mssql] automatically remove identity columns from AR generated UPDATE

### DIFF
--- a/lib/arjdbc/mssql/adapter.rb
+++ b/lib/arjdbc/mssql/adapter.rb
@@ -35,6 +35,7 @@ module ArJdbc
     require 'arjdbc/mssql/column'
     require 'arjdbc/mssql/explain_support'
     require 'arjdbc/mssql/types' if AR42
+    require 'arjdbc/mssql/attributes_for_update'
 
     include LimitHelpers
     include Utils

--- a/lib/arjdbc/mssql/attributes_for_update.rb
+++ b/lib/arjdbc/mssql/attributes_for_update.rb
@@ -1,0 +1,22 @@
+module ActiveRecord
+  module ConnectionAdapters
+    module SQLServer
+      module CoreExt
+        module AttributeMethods
+
+
+          private
+
+          def attributes_for_update(attribute_names)
+            super.reject do |name|
+              column = self.class.columns_hash[name]
+              column && column.respond_to?(:identity?) && column.identity?
+            end
+          end
+
+        end
+      end
+    end
+  end
+end
+ActiveRecord::Base.send :include, ActiveRecord::ConnectionAdapters::SQLServer::CoreExt::AttributeMethods

--- a/test/db/mssql/remove_identity_columns_from_update.rb
+++ b/test/db/mssql/remove_identity_columns_from_update.rb
@@ -1,0 +1,37 @@
+require 'test_helper'
+require 'db/mssql'
+
+class MSSQLRemoveIdentityColumnsFromUpdateTest < Test::Unit::TestCase
+
+  class TestTable < ActiveRecord::Base; end
+
+  def self.startup
+    ActiveRecord::Base.connection.execute "CREATE TABLE test_tables ( [ID Number] int IDENTITY PRIMARY KEY, [My Name] VARCHAR(60) NULL )"
+  end
+
+  def self.shutdown
+    ActiveRecord::Base.connection.execute "DROP TABLE test_tables" rescue nil
+  end
+
+  test 'identity column is removed from update statement' do
+    record = TestTable.create! 'My Name' => 'Hello!'
+    assert_not_nil record['ID Number']
+    record.reload
+    assert_equal 'Hello!', record['My Name']
+
+    # ActiveRecord will happily create SQL with an identity column in the 
+    # SET fields of an UPDATE statement, which causes MSSQL to blow up 
+    # with 'Cannot update identity column" error. 
+    #
+    # Test that we are removing the identity column on update
+
+    if ar_version('4.0')
+      assert_equal true, record.update('My Name': 'Bob', id: 99999)
+    end
+
+    #
+    # Maybe a valid test for older rails versions
+    # assert_equal true, record.update_attribute(:id, 99999)
+  end
+
+end

--- a/test/db/mssql/simple_test.rb
+++ b/test/db/mssql/simple_test.rb
@@ -197,25 +197,9 @@ class MSSQLSimpleTest < Test::Unit::TestCase
     # readonly_attribute? and not pk_attribute?(name) as well ...
     # other adapters such as MySQL simply accept/ignore similar UPDATE as valid
     #
-    return super unless ar_version('4.0')
-    begin
-      ro_attrs = User.readonly_attributes.dup
-      User.readonly_attributes << 'id'
-      super
-    ensure
-      User.readonly_attributes.replace(ro_attrs)
-    end
   end
 
   def test_partial_update_with_updated_on
-    return super unless ar_version('4.0')
-    begin
-      ro_attrs = User.readonly_attributes.dup
-      User.readonly_attributes << 'id'
-      super
-    ensure
-      User.readonly_attributes.replace(ro_attrs)
-    end
   end
 
 


### PR DESCRIPTION
Tested this in branch 1-3-stable, with jruby 9.1.12.0 and rails 4.0, 4.1 and 4.2

