### PR TITLE
Build adapter jar when installing from source

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -227,7 +227,7 @@ if defined? JRUBY_VERSION
       driver_jars
     end
 
-    if ENV['RUBYARCHDIR'] || ENV['BUILD_EXT_MAVEN'] == 'true'
+    if ENV['BUILD_EXT_MAVEN'] == 'true'
       driver_jars = get_driver_jars_maven.call
     else
       driver_jars = get_driver_jars_local.call

--- a/activerecord-jdbc-adapter.gemspec
+++ b/activerecord-jdbc-adapter.gemspec
@@ -37,5 +37,7 @@ Gem::Specification.new do |gem|
   #gem.add_development_dependency 'mocha', '~> 0.13.1'
 
   gem.rdoc_options = ["--main", "README.md", "-SHN", "-f", "darkfish"]
+
+  gem.extensions << 'Rakefile' if File.exist?('.git')
 end
 


### PR DESCRIPTION
Since the  `adapter_java.jar` file is no longer committed to the repository (which is good), developers wanting to use ARJDBC from source need to build the jar before using the gem.

To make this easier we can add this build step as an optional java extension in the gemspec.

There was a check on RUBYARCHDIR in the Rake task for the adapter jar which used to be set by the build script.  This is not set anymore, so I removed the check.

I am not aware of any tests for this toolchain.  Feel free to suggest where I could add some.
