### PR TITLE
Fixing static references to JRuby runtime state

### DIFF
--- a/src/java/arjdbc/jdbc/JdbcResult.java
+++ b/src/java/arjdbc/jdbc/JdbcResult.java
@@ -64,7 +64,7 @@ public class JdbcResult extends RubyObject {
         for (int i = 1; i <= columnCount; i++) { // metadata is one-based
             // This appears to not be used by Postgres, MySQL, or SQLite so leaving it off for now
             //name = caseConvertIdentifierForRails(connection, name);
-            columnNames[i - 1] = RubyJdbcConnection.STRING_CACHE.get(context, resultMetaData.getColumnLabel(i));
+            columnNames[i - 1] = RubyJdbcConnection.cachedString(context, resultMetaData.getColumnLabel(i));
             columnTypes[i - 1] = resultMetaData.getColumnType(i);
         }
     }

--- a/src/java/arjdbc/jdbc/RubyJdbcConnection.java
+++ b/src/java/arjdbc/jdbc/RubyJdbcConnection.java
@@ -119,6 +119,7 @@ public class RubyJdbcConnection extends RubyObject {
 
     private static final String[] TABLE_TYPE = new String[] { "TABLE" };
     private static final String[] TABLE_TYPES = new String[] { "TABLE", "VIEW", "SYNONYM" };
+    private static final String ARJDBC_STRING_CACHE = "arjdbc_string_cache";
 
     private ConnectionFactory connectionFactory;
     private IRubyObject config;
@@ -3760,11 +3761,14 @@ public class RubyJdbcConnection extends RubyObject {
         return attribute.callMethod(context, "value_for_database");
     }
 
-    // FIXME: This should not be static and will be exposed via api in connection as instance method.
-    public static final StringCache STRING_CACHE = new StringCache();
-
     protected static RubyString cachedString(final ThreadContext context, final String str) {
-        return STRING_CACHE.get(context, str);
+        RubyModule arJdbc = context.runtime.getModule("ArJdbc");
+        StringCache stringCache = (StringCache) arJdbc.getInternalVariable(ARJDBC_STRING_CACHE);
+        if (stringCache == null) {
+            stringCache = new StringCache();
+            arJdbc.setInternalVariable(ARJDBC_STRING_CACHE, stringCache);
+        }
+        return stringCache.get(context, str);
     }
 
     protected static final class ColumnData {


### PR DESCRIPTION
This PR fixes the following two items:

* StringCache is now stored as an internal variable of ArJdbc mod.
* Loaded drivers cache is stored as an internal variable, I believe on ArJdbc, but unsure what "self" is in this context.

I request review from @enebo @kares @rdubya.

Specific concerns:

* Internal variables use instance variable logic, so they're a bit more overhead than a simple hash map.
* Obviously I have to look up ArJdbc module in the StringCache case. Both cases probably should store in same place using same mechanism but the loaded drivers cache has access to a "self" on which the load operation was called.

Unfixed at push time: RubyJdbcConnection has a static IRubyObject defaultConfig used for some JNDI logic. I was not clear what this field is or how to remove it. First instinct is to put it into the ARJDBC top-level module as an internal variable.

Related is the neighboring connectionFactory, which may hold runtime state.