### PR TITLE
Remove duplicate method definition

### DIFF
--- a/lib/arjdbc/postgresql/adapter.rb
+++ b/lib/arjdbc/postgresql/adapter.rb
@@ -290,12 +290,6 @@ module ArJdbc
       end
     end
 
-    def max_identifier_length
-      @max_identifier_length ||= query_value("SHOW max_identifier_length", "SCHEMA").to_i
-    end
-    alias table_alias_length max_identifier_length
-    alias index_name_length max_identifier_length
-
     def index_algorithms
       { :concurrently => 'CONCURRENTLY' }
     end


### PR DESCRIPTION
The pull request is an attempt to remove the duplicate method definition `max_identifier_length`