### PR TITLE
[test, postgres, sqlite] Fix explain with binds

### DIFF
--- a/lib/arjdbc/postgresql/adapter.rb
+++ b/lib/arjdbc/postgresql/adapter.rb
@@ -339,8 +339,8 @@ module ArJdbc
     end
 
     def explain(arel, binds = [])
-      sql = "EXPLAIN #{to_sql(arel, binds)}"
-      ActiveRecord::ConnectionAdapters::PostgreSQL::ExplainPrettyPrinter.new.pp(exec_query(sql, 'EXPLAIN', binds))
+      sql, binds = to_sql_and_binds(arel, binds)
+      ActiveRecord::ConnectionAdapters::PostgreSQL::ExplainPrettyPrinter.new.pp(exec_query("EXPLAIN #{sql}", 'EXPLAIN', binds))
     end
 
     # @note Only for "better" AR 4.0 compatibility.

--- a/test/explain_support_test_methods.rb
+++ b/test/explain_support_test_methods.rb
@@ -1,3 +1,5 @@
+require 'test_helper'
+
 module ExplainSupportTestMethods
 
   PRINT_EXPLAIN_OUTPUT = get_system_property('explain.support.output')
@@ -16,25 +18,18 @@ module ExplainSupportTestMethods
     assert_instance_of String, pp
   end
 
+  def test_explain_with_arel
+    arel, binds = create_explain_arel
+
+    pp = ActiveRecord::Base.connection.explain(arel, [])
+    puts "\n", pp if PRINT_EXPLAIN_OUTPUT
+    assert_instance_of String, pp
+  end
+
   def test_explain_with_binds
-    create_explain_data
+    arel, binds = create_explain_arel
 
-    # "SELECT * FROM entries JOIN users on entries.user_id = users.id WHERE entries.rating > ? LIMIT 1"
-    arel = Arel::SelectManager.new Entry.arel_engine
-    arel.project Arel.star
-    arel.from arel_table = Entry.arel_table
-    arel.join(User.arel_table).on(arel_table[:user_id].eq User.arel_table[:id])
-    arel.where arel_table[:rating].gt arel_bind_param
-    arel.take arel_bind_param
-
-    attr_name = arel_table[:rating].name
-
-    binds = [
-        ActiveRecord::Relation::QueryAttribute.new(attr_name, 0, Entry.type_for_attribute(attr_name)),
-        ActiveRecord::Attribute.with_cast_value('LIMIT', 1, ActiveModel::Type::Value.new)
-    ]
-
-    pp = ActiveRecord::Base.connection.explain(arel, binds)
+    pp = ActiveRecord::Base.connection.explain(arel.to_sql, binds)
     puts "\n", pp if PRINT_EXPLAIN_OUTPUT
     assert_instance_of String, pp
   end
@@ -51,4 +46,25 @@ module ExplainSupportTestMethods
     Entry.create :title => 'title_4', :content => 'content', :rating => 0, :user_id => user_1.id
   end
 
+  def create_explain_arel
+    create_explain_data
+
+    arel_table = Entry.arel_table
+    attr_name = arel_table[:rating].name
+
+    binds = [
+        ActiveRecord::Relation::QueryAttribute.new(attr_name, 0, Entry.type_for_attribute(attr_name)),
+        ActiveModel::Attribute.with_cast_value('LIMIT', 1, ActiveModel::Type::Value.new)
+    ]
+
+    # "SELECT * FROM entries JOIN users on entries.user_id = users.id WHERE entries.rating > ? LIMIT 1"
+    arel = Arel::SelectManager.new
+    arel.project Arel.star
+    arel.from arel_table
+    arel.join(User.arel_table).on(arel_table[:user_id].eq User.arel_table[:id])
+    arel.where arel_table[:rating].gt(Arel::Nodes::BindParam.new(binds[0]))
+    arel.take Arel::Nodes::BindParam.new(binds[1])
+
+    return arel, binds
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -417,11 +417,6 @@ class Test::Unit::TestCase
 
   private
 
-  def new_bind_param
-    ar_version('4.2') ? Arel::Nodes::BindParam.new : Arel::Nodes::BindParam.new('?')
-  end
-  alias_method :arel_bind_param, :new_bind_param
-
   def prepared_statements?(connection = ActiveRecord::Base.connection)
     connection.send :prepared_statements
   rescue NoMethodError # on MRI


### PR DESCRIPTION
In Arel 9 used in AR 5.2, the way bind params work has changed:
  https://github.com/rails/arel/commit/db1bb4e9a728a437d16f8bdb48c3b772c3e4edb0
The values are now stored directly in the BindParam itself.

With this change, to_sql() in AR 5.2 now either accepts an Arel AST w/o
any binds or a SQL string with binds.

Change the tests to use the new syntax and test both ways. With this
in place fix PG explain with an Arel AST. Using to_sql() leads to no
binds at all and in turn makes PG complain. Instead use to_sql_and_bind()
which extracts the actual bind values from the Arel AST.

(Pretty sure plain AR5.2 on MRI is broken here for PG)