### PR TITLE
[postgres] Fix NPE in internedTypeFor()

### DIFF
--- a/src/java/arjdbc/postgresql/PostgreSQLRubyJdbcConnection.java
+++ b/src/java/arjdbc/postgresql/PostgreSQLRubyJdbcConnection.java
@@ -203,9 +203,9 @@ public class PostgreSQLRubyJdbcConnection extends arjdbc.jdbc.RubyJdbcConnection
         RubyClass arrayClass = oidArray(context);
         RubyBasicObject attributeType = (RubyBasicObject) attributeType(context, attribute);
         // The type or its delegate is an OID::Array
-        if (arrayClass.isInstance(attributeType) ||
+        if (attributeType != null && (arrayClass.isInstance(attributeType) ||
                 (attributeType.hasInstanceVariable("@delegate_dc_obj") &&
-                        arrayClass.isInstance(attributeType.getInstanceVariable("@delegate_dc_obj")))) {
+                        arrayClass.isInstance(attributeType.getInstanceVariable("@delegate_dc_obj"))))) {
             return "array";
         }
 


### PR DESCRIPTION
attributeType() can return null. Then NPE is triggered when executing
rails52:test/cases/bind_parameter_test.rb:71

Check for null to prevent the exception. This turns the test above
from an error to a failure (missing deprecation warning).