### PR TITLE
[50-stable, postgres]: Improve handling of DB type "money"

### DIFF
--- a/src/java/arjdbc/postgresql/PostgreSQLRubyJdbcConnection.java
+++ b/src/java/arjdbc/postgresql/PostgreSQLRubyJdbcConnection.java
@@ -54,6 +54,7 @@ import org.joda.time.DateTimeZone;
 import org.jruby.*;
 import org.jruby.anno.JRubyMethod;
 import org.jruby.exceptions.RaiseException;
+import org.jruby.ext.bigdecimal.RubyBigDecimal;
 import org.jruby.javasupport.JavaUtil;
 import org.jruby.runtime.ObjectAllocator;
 import org.jruby.runtime.ThreadContext;
@@ -99,6 +100,7 @@ public class PostgreSQLRubyJdbcConnection extends arjdbc.jdbc.RubyJdbcConnection
         POSTGRES_JDBC_TYPE_FOR.put("line", Types.OTHER);
         POSTGRES_JDBC_TYPE_FOR.put("lseg", Types.OTHER);
         POSTGRES_JDBC_TYPE_FOR.put("ltree", Types.OTHER);
+        POSTGRES_JDBC_TYPE_FOR.put("money", Types.OTHER);
         POSTGRES_JDBC_TYPE_FOR.put("numrange", Types.OTHER);
         POSTGRES_JDBC_TYPE_FOR.put("path", Types.OTHER);
         POSTGRES_JDBC_TYPE_FOR.put("point", Types.OTHER);
@@ -437,6 +439,14 @@ public class PostgreSQLRubyJdbcConnection extends arjdbc.jdbc.RubyJdbcConnection
                     statement.setObject(index, new PGline(pointValues[0], pointValues[1], pointValues[2]));
                 } else {
                     statement.setObject(index, new PGline(pointValues[0], pointValues[1], pointValues[2], pointValues[3]));
+                }
+                break;
+
+            case "money":
+                if (value instanceof RubyBigDecimal) {
+                    statement.setBigDecimal(index, ((RubyBigDecimal) value).getValue());
+                } else {
+                    setPGobjectParameter(statement, index, value, columnType);
                 }
                 break;
 

--- a/test/db/postgresql/types_test.rb
+++ b/test/db/postgresql/types_test.rb
@@ -613,6 +613,14 @@ _SQL
     assert_equal new_value, @first_money.wealth
   end
 
+  def test_update_money_num
+    new_value = 123.45
+    @first_money.wealth = new_value
+    @first_money.save!
+    @first_money.reload
+    assert_equal new_value, @first_money.wealth
+  end
+
   def test_money_type_cast
     type = PostgresqlMoney.type_for_attribute('wealth')
 


### PR DESCRIPTION
When using BigDecimal for money values, the standard handling with
setPGobjectParameter() does not work since it does a toString() on the
value. For a BigDecimal("123.45") this will produce "0.12345e3" which
PG doesn't like.

This registers a handler for PG type "money" which uses
statement.setBigDecimal() when a RubyBigDecimal is provided and falls
back to the standard handling setPGobjectParameter() for everything
else.

This fixes test errors:
* ajrdbc: test/db/postgresql/types_test.rb#test_update_money
* rails: test/cases/adapters/postgresql/money_test.rb#test_create_and_update_money