### PR TITLE
[52, mysql] make fixtures work and Rails test run agin

### DIFF
--- a/lib/arjdbc/mysql/adapter.rb
+++ b/lib/arjdbc/mysql/adapter.rb
@@ -57,6 +57,19 @@ module ActiveRecord
         true
       end
 
+      # FIXME: optimize by implementing with_multi_statements() instead of this
+      def insert_fixtures_set(fixture_set, tables_to_delete = [])
+        disable_referential_integrity do
+          transaction(requires_new: true) do
+            tables_to_delete.each { |table| delete "DELETE FROM #{quote_table_name(table)}", "Fixture Delete" }
+
+            fixture_set.each do |table_name, rows|
+              rows.each { |row| insert_fixture(row, table_name) }
+            end
+          end
+        end
+      end
+
       # HELPER METHODS ===========================================
 
       # Reloading the type map in abstract/statement_cache.rb blows up postgres


### PR DESCRIPTION
Rails 5.2 introduced a insert_fixtures_set() with special optimization
for MySQL, namely using multiple statements in one call. This requires
the connection params to be set up and a method with_multi_statements
that we're not (yet) implementing. The C version changes flags of the
connection for that.

The easy fix is to just use the plain loop from the SQLite3 adapter.
This is slower than it could be, but at least the Rails tests run again
with this. And it looks pretty nice already:

5459 runs, 15416 assertions, 15 failures, 6 errors, 5 skips

(that's with jruby-9.2 so two of the failures are about FrozenError..)