### PR TITLE
[52, mysql] Remove test_mysql_indexes

### DIFF
--- a/test/db/mysql/simple_test.rb
+++ b/test/db/mysql/simple_test.rb
@@ -247,10 +247,6 @@ class MySQLSimpleTest < Test::Unit::TestCase
     assert_equal "}{\"'}  '", e.reload.title
   end
 
-  def test_mysql_indexes
-    assert connection.class.const_defined?(:INDEX_TYPES)
-  end
-
   test 'returns correct visitor type' do
     assert_not_nil visitor = connection.instance_variable_get(:@visitor)
     assert defined? Arel::Visitors::MySQL


### PR DESCRIPTION
In AR 5.2, INDEX_TYPES got removed, so just drop the test