### PR TITLE
[52] Support legacy binds for connection.(insert|update|delete)

### DIFF
--- a/lib/arjdbc/abstract/database_statements.rb
+++ b/lib/arjdbc/abstract/database_statements.rb
@@ -42,10 +42,30 @@ module ArJdbc
       end
       alias :exec_delete :exec_update
 
+      # overridden to support legacy binds
+      def insert(arel, name = nil, pk = nil, id_value = nil, sequence_name = nil, binds = [])
+        binds = convert_legacy_binds_to_attributes(binds) if binds.first.is_a?(Array)
+        super
+      end
+      alias create insert
+
+      # overridden to support legacy binds
+      def update(arel, name = nil, binds = [])
+        binds = convert_legacy_binds_to_attributes(binds) if binds.first.is_a?(Array)
+        super
+      end
+
+      # overridden to support legacy binds
+      def delete(arel, name = nil, binds = [])
+        binds = convert_legacy_binds_to_attributes(binds) if binds.first.is_a?(Array)
+        super
+      end
+
       def execute(sql, name = nil)
         log(sql, name) { @connection.execute(sql) }
       end
 
+      # overridden to support legacy binds
       def select_all(arel, name = nil, binds = NO_BINDS, preparable: nil)
         binds = convert_legacy_binds_to_attributes(binds) if binds.first.is_a?(Array)
         super


### PR DESCRIPTION
A legacy bind param is an array with two elements, column (often nil)
and the value. Turn those into proper bind params so they're handled
correctly.

Fixes
* rails52:test/cases/adapter_test.rb#test_insert_update_delete_with_legacy

Notes:
* Rails 5.0/5.1 don't have test for this, only Rails 5.2
* Tests were added in rails/rails@18abe37a for 5.2 along with a fix..
* ...for the breakage caused in rails/rails@213796f (after 5.1)