### PR TITLE
[52, sqlite] Exclude some AR 5.2 that rely on sqlite3-ruby API

### DIFF
--- a/test/rails/excludes/sqlite3/ActiveRecord/DatabaseTasksMigrateTest.rb
+++ b/test/rails/excludes/sqlite3/ActiveRecord/DatabaseTasksMigrateTest.rb
@@ -1,0 +1,3 @@
+exclude :test_migrate_set_and_unset_empty_values_for_verbose_and_version_env_vars, "uses sqlite3-ruby API"
+exclude :test_migrate_set_and_unset_nonsense_values_for_verbose_and_version_env_vars, "uses sqlite3-ruby API"
+exclude :test_migrate_set_and_unset_verbose_and_version_env_vars, "uses sqlite3-ruby API"

--- a/test/rails/excludes/sqlite3/ActiveRecord/Migration/PendingMigrationsTest.rb
+++ b/test/rails/excludes/sqlite3/ActiveRecord/Migration/PendingMigrationsTest.rb
@@ -1,0 +1,2 @@
+exclude :test_errors_if_pending, "uses sqlite3-ruby API"
+exclude :test_checks_if_supported, "uses sqlite3-ruby API"


### PR DESCRIPTION
5 test errors less on the AR 5.2 test...