### PR TITLE
Skip test_explain_with_binds when PREPARED_STATEMENTS=false

### DIFF
--- a/test/explain_support_test_methods.rb
+++ b/test/explain_support_test_methods.rb
@@ -27,6 +27,8 @@ module ExplainSupportTestMethods
   end
 
   def test_explain_with_binds
+    skip unless ActiveRecord::Base.connection.prepared_statements
+
     arel, binds = create_explain_arel
 
     pp = ActiveRecord::Base.connection.explain(arel.to_sql, binds)


### PR DESCRIPTION
This version of explain is for Arel < 9 and cannot work w/o prepared
statements. The new-style Arel with bind values included in the AST
works fine. So just skip the test.