### PR TITLE
[52, mysql] Fix rails fixtures tests

### DIFF
--- a/test/rails/excludes/mysql2/FixturesTest.rb
+++ b/test/rails/excludes/mysql2/FixturesTest.rb
@@ -1,0 +1,4 @@
+exclude :test_bulk_insert_multiple_table_with_a_multi_statement_query, "bulk insert not yet implemented"
+exclude :test_bulk_insert_with_multi_statements_enabled, "bulk insert not yet implemented"
+exclude :test_insert_fixtures_set_concat_total_sql_into_a_single_packet_smaller_than_max_allowed_packet, "bulk insert not yet implemented"
+exclude :test_insert_fixtures_set_raises_an_error_when_max_allowed_packet_is_smaller_than_fixtures_set_size, "bulk insert not yet implemented"


### PR DESCRIPTION
This is a follow-up for a8a2d41
([mysql] make fixtures work and Rails 5.2 test run again (#909))

* Adds the missing #default_insert_value(). This fixes a problem
  with auto_increment primary keys.
* Implements dummy methods to make the standard insert_fixtures_set()
  code work properly.
* Exclude some tests that are bulk insert specific

This makes all of these pass:
* rails52/test/cases/fixtures_test.rb

Proper bulk insert can be implemented later, ideally using JDBC
addBatch()/executeBatch() instead of manually concatenating statements.