### PR TITLE
[52, mysql] Update some rails test excludes

### DIFF
--- a/test/rails/excludes/mysql2/ActiveRecord/MysqlDBCreateWithInvalidPermissionsTest.rb
+++ b/test/rails/excludes/mysql2/ActiveRecord/MysqlDBCreateWithInvalidPermissionsTest.rb
@@ -1,0 +1,1 @@
+exclude :test_raises_error, "test relying on mysql2 internals"

--- a/test/rails/excludes/mysql2/AttributeMethodsTest.rb
+++ b/test/rails/excludes/mysql2/AttributeMethodsTest.rb
@@ -1,1 +1,0 @@
-exclude :test_read_attributes_before_type_cast_on_boolean, 'This test was a jruby-specific guard when we did wrong thing.  We do right thing now...need pr to remove that guard from test'

--- a/test/rails/excludes/mysql2/Mysql2ConnectionTest.rb
+++ b/test/rails/excludes/mysql2/Mysql2ConnectionTest.rb
@@ -1,4 +1,5 @@
-exclude :test_passing_arbitary_flags_to_adapter, 'no support for arbitrary flags such as Mysql2::Client::COMPRESS'
+exclude :test_passing_arbitrary_flags_to_adapter, 'no support for arbitrary flags such as Mysql2::Client::COMPRESS'
 exclude :test_passing_flags_by_array_to_adapter, 'no support for passing flags: ... not supported by JDBC adapter'
 exclude :test_quote_after_disconnect, 'AR-JDBC does not rely on driver to do quoting - thus wont raise an error'
+exclude :test_execute_after_disconnect, "test relying on mysql2 internals"
 exclude :test_mysql_connection_collation_is_configured, "Issue #884"


### PR DESCRIPTION
* Exclude tests relying on mysql2 gem internals
* Rename an exclude where rails fixed a typo
* Delete an exclude for a test that no longer exists