### PR TITLE
[52, mysql] Remove "ENGINE=InnoDB" from create_table

### DIFF
--- a/lib/arjdbc/mysql/adapter.rb
+++ b/lib/arjdbc/mysql/adapter.rb
@@ -86,10 +86,6 @@ module ActiveRecord
         exception.error_code if exception.is_a?(JDBCError)
       end
 
-      def create_table(table_name, **options) #:nodoc:
-        super(table_name, options: "ENGINE=InnoDB", **options)
-      end
-
       #--
       # QUOTING ==================================================
       #+


### PR DESCRIPTION
In Rails 5.2, the option "ENGINE=InnoDB" got removed from create_table
in rails/rails@7ac7f4a1 (Remove default ENGINE=InnoDB for Mysql2 adapter).
For compatibility reasons, it's still added for <= 5.1 migrations.

Follow Rails 5.2 here. This fixes a bunch of test failures:

* rails52/test/cases/adapters/mysql2/active_schema_test.rb
* rails52/test/cases/adapters/mysql2/table_options_test.rb