### PR TITLE
WIP/RFC: [52, sqlite3] Work around JRuby 9.1.x bug calling "super"

### DIFF
--- a/lib/arjdbc/sqlite3/adapter.rb
+++ b/lib/arjdbc/sqlite3/adapter.rb
@@ -255,7 +255,8 @@ module ArJdbc
     def valid_alter_table_type?(type, options = {})
       !invalid_alter_table_type?(type, options)
     end
-    deprecate :valid_alter_table_type?
+    # DIFFERENCE: deprecated causes a JRuby 9.1 bug where "super" calls itself
+    #deprecate :valid_alter_table_type?
 
     def add_column(table_name, column_name, type, options = {}) #:nodoc:
       if invalid_alter_table_type?(type, options)


### PR DESCRIPTION
See diff. Calling super from this method leads to an infinite loop
of the method calling itself and pretty soon to a stack overflow.
This only happens in 9.1, things work ok in 9.2

To reproduce this is:
> rake rails:test_sqlite3 TEST=test/cases/migration_test.rb

The method #translate_exception is implemented in
* class ActiveRecord::ConnectionAdapters::AbstractAdapter
* module ArJdbc::Core
* module ArJdbc::SQLite3

The Arjdbc class SQLiteAdapter < AbstractAdapter includes both
modules. Yet calling super from the method in SQLite3 causes an infinite
loop in 9.1. Moving it from the module to the class solves the problem.
Interestingly, the Postgres adapter does the same w/o problems.

The relevant stack traces (cleaned up a bit for readability). Run with
JRuby 9.1.17.0, Java HotSpot(TM) 64-Bit Server VM (build 25.162-b12, mixed mode):

Ruby side:
...and so on
```
activerecord-jdbc-adapter/lib/arjdbc/sqlite3/adapter.rb:477:in `translate_exception'
activerecord-jdbc-adapter/lib/arjdbc/sqlite3/adapter.rb:477:in `translate_exception'
activerecord-jdbc-adapter/lib/arjdbc/sqlite3/adapter.rb:477:in `translate_exception'
activerecord-jdbc-adapter/lib/arjdbc/sqlite3/adapter.rb:477:in `translate_exception'
activerecord-jdbc-adapter/lib/arjdbc/sqlite3/adapter.rb:477:in `translate_exception'
activerecord-jdbc-adapter/lib/arjdbc/sqlite3/adapter.rb:477:in `translate_exception'
activerecord-jdbc-adapter/lib/arjdbc/sqlite3/adapter.rb:477:in `translate_exception'
activerecord-jdbc-adapter/lib/arjdbc/sqlite3/adapter.rb:477:in `translate_exception'
activerecord-jdbc-adapter/lib/arjdbc/sqlite3/adapter.rb:722:in `translate_exception'
rails52/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:563:in `translate_exception_class'
rails52/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:582:in `block in log'
rails52/activesupport/lib/active_support/notifications/instrumenter.rb:23:in `instrument'
rails52/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:569:in `log'
activerecord-jdbc-adapter/lib/arjdbc/abstract/database_statements.rb:65:in `execute'
rails52/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb:496:in `drop_table'
rails52/activerecord/test/cases/migration_test.rb:57:in `block in MigrationTest'
rails52/activerecord/test/cases/migration_test.rb:56:in `each'
rails52/activerecord/test/cases/migration_test.rb:56:in `block in MigrationTest'
...
```


Java side:
```
Java::JavaLang::StackOverflowError:
    org.joni.Matcher.forwardSearchRange(Matcher.java:131)
    org.joni.Matcher.searchInterruptible(Matcher.java:415)
    org.jruby.RubyRegexp$SearchMatchTask.run(RubyRegexp.java:269)
    org.jruby.RubyRegexp$SearchMatchTask.run(RubyRegexp.java:250)
    org.jruby.RubyThread.executeTask(RubyThread.java:1481)
    org.jruby.RubyRegexp.matcherSearch(RubyRegexp.java:233)
    org.jruby.RubyRegexp.search19(RubyRegexp.java:1232)
    org.jruby.RubyRegexp.search19(RubyRegexp.java:1178)
    org.jruby.RubyRegexp.eqq19(RubyRegexp.java:1088)
    org.jruby.RubyRegexp$INVOKER$i$1$0$eqq19.call(RubyRegexp$INVOKER$i$1$0$eqq19.gen)
    org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:153)
    activerecord_minus_jdbc_minus_adapter.lib.arjdbc.sqlite3.adapter.invokeOther3:===(activerecord-jdbc-adapter/lib/arjdbc/sqlite3/adapter.rb:462)
    activerecord_minus_jdbc_minus_adapter.lib.arjdbc.sqlite3.adapter.RUBY$method$translate_exception$0(activerecord-jdbc-adapter/lib/arjdbc/sqlite3/adapter.rb:462)
    activerecord_minus_jdbc_minus_adapter.lib.arjdbc.sqlite3.adapter.RUBY$method$translate_exception$0$__VARARGS__(activerecord-jdbc-adapter/lib/arjdbc/sqlite3/adapter.rb)
    org.jruby.internal.runtime.methods.CompiledIRMethod.call(CompiledIRMethod.java:77)
    org.jruby.internal.runtime.methods.MixedModeIRMethod.call(MixedModeIRMethod.java:93)
    org.jruby.ir.runtime.IRRuntimeHelpers.unresolvedSuper(IRRuntimeHelpers.java:1042)
    activerecord_minus_jdbc_minus_adapter.lib.arjdbc.sqlite3.adapter.invokeSuper16:-unknown-super-target-(activerecord-jdbc-adapter/lib/arjdbc/sqlite3/adapter.rb:477)
    activerecord_minus_jdbc_minus_adapter.lib.arjdbc.sqlite3.adapter.RUBY$method$translate_exception$0(activerecord-jdbc-adapter/lib/arjdbc/sqlite3/adapter.rb:477)
    activerecord_minus_jdbc_minus_adapter.lib.arjdbc.sqlite3.adapter.RUBY$method$translate_exception$0$__VARARGS__(activerecord-jdbc-adapter/lib/arjdbc/sqlite3/adapter.rb)
    org.jruby.internal.runtime.methods.CompiledIRMethod.call(CompiledIRMethod.java:77)
    org.jruby.internal.runtime.methods.MixedModeIRMethod.call(MixedModeIRMethod.java:93)
    org.jruby.ir.runtime.IRRuntimeHelpers.unresolvedSuper(IRRuntimeHelpers.java:1042)
    activerecord_minus_jdbc_minus_adapter.lib.arjdbc.sqlite3.adapter.invokeSuper16:-unknown-super-target-(activerecord-jdbc-adapter/lib/arjdbc/sqlite3/adapter.rb:477)
    activerecord_minus_jdbc_minus_adapter.lib.arjdbc.sqlite3.adapter.RUBY$method$translate_exception$0(activerecord-jdbc-adapter/lib/arjdbc/sqlite3/adapter.rb:477)
    Uctiverecord_minus_jdbc_minus_adapter.lib.arjdbc.sqlite3.adapter.RUBY$method$translate_exception$0$__VARARGS__(activerecord-jdbc-adapter/lib/arjdbc/sqlite3/adapter.rb)
	... and a ton more of these
```