### PR TITLE
[postgres] Fix varchar arrays in WHERE clause

### DIFF
--- a/src/java/arjdbc/jdbc/RubyJdbcConnection.java
+++ b/src/java/arjdbc/jdbc/RubyJdbcConnection.java
@@ -2898,7 +2898,7 @@ public class RubyJdbcConnection extends RubyObject {
         final RubySymbol type = (RubySymbol) attributeSQLType(context, attribute);
 
         // For some reason the driver doesn't like "character varying" as a type
-        if ( type.eql(context.runtime.newSymbol("string")) ) return "text";
+        if ( type.eql(context.runtime.newSymbol("string")) ) return "varchar";
 
         final RubyHash nativeTypes = (RubyHash) getAdapter().callMethod(context, "native_database_types");
         // e.g. `integer: { name: 'integer' }`


### PR DESCRIPTION
PG JDBC driver doesn't like "character varying" when constructing arrays.
Using "text" as type works for insert/update, but results in a
  ERROR: operator does not exist: character varying[] = text[]
when used in a WHERE clause. "varchar" is the right type for the
JDBC driver

Fixes errors in:
* rails52/test/cases/adapters/postgresql/array_test.rb #test_uniqueness_validation
* rails52/test/cases/adapters/postgresql/array_test.rb #test_where_by_attribute_with_array