### PR TITLE
[postgres] Fix postgresql_version parser for PG version 10 and higher

### DIFF
--- a/lib/arjdbc/postgresql/adapter.rb
+++ b/lib/arjdbc/postgresql/adapter.rb
@@ -52,7 +52,7 @@ module ArJdbc
       @postgresql_version ||=
         begin
           version = @connection.database_product
-          if version.match /PostgreSQL ((\d+\.)+\d+)/
+          if version.match /PostgreSQL (\d+.*)/
             version_numbers = $1.split('.').map(&:to_i)
             # PostgreSQL version representation does not have more than 3 digits
             return 0 if version_numbers.length > 3

--- a/lib/arjdbc/postgresql/adapter.rb
+++ b/lib/arjdbc/postgresql/adapter.rb
@@ -52,8 +52,15 @@ module ArJdbc
       @postgresql_version ||=
         begin
           version = @connection.database_product
-          if version =~ /PostgreSQL (\d+)\.(\d+)\.(\d+)/
-            ($1.to_i * 10000) + ($2.to_i * 100) + $3.to_i
+          if version.match /PostgreSQL ((\d+\.)+\d+)/
+            version_numbers = $1.split('.').map(&:to_i)
+            # PostgreSQL version representation does not have more than 3 digits
+            return 0 if version_numbers.length > 3
+            # From version 10 onwards, PG has changed its versioning policy to
+            # limit it to only 2 digits. i.e. in 10.x, 10 being the major
+            # version and x representing the minor release
+            # Refer https://www.postgresql.org/support/versioning/ for more info
+            version_numbers.zip([10000, 100, 1]).map { |e| e.reduce(:*) }.sum
           else
             0
           end

--- a/test/db/postgresql/version_test.rb
+++ b/test/db/postgresql/version_test.rb
@@ -1,0 +1,33 @@
+require 'test_helper'
+require 'db/postgres'
+require 'db/postgresql/test_helper'
+
+class VersionTest < Test::Unit::TestCase
+  def test_pg_9_version
+    assert_equal connection_stub('9.6.8'), 90608
+  end
+
+  def test_pg_10_version
+    assert_equal connection_stub('10.4'), 100400
+  end
+
+  def test_pg_failed_version
+    assert_equal connection_stub('9.6.8.1'), 0
+  end
+
+  def test_pg_single_version
+    assert_equal connection_stub('9'), 90000
+	end
+
+  private
+
+  def connection_stub(version_string)
+    connection = mock('connection')
+    connection.expects(:jndi?)
+    connection.expects(:configure_connection)
+    connection.stubs(:database_product).returns("PostgreSQL #{version_string}")
+    ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.any_instance.stubs(:initialize_type_map)
+    pg_connection = ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.new(connection, nil, {})
+		pg_connection.postgresql_version
+  end
+end


### PR DESCRIPTION
Fix #926: From PostgreSQL version 10 and higher, the versioning policy
has changed. The updated method now captures whole version number
instead of fixed number of digits and returns integer that is compatible
to the depending methods and previous versions.