### PR TITLE
[52] Deprecate supports_statement_cache?

### DIFF
--- a/lib/arjdbc/abstract/database_statements.rb
+++ b/lib/arjdbc/abstract/database_statements.rb
@@ -27,7 +27,7 @@ module ArJdbc
         else
           log(sql, name, binds) do
             # It seems that #supports_statement_cache? is defined but isn't checked before setting "prepare" (AR 5.0)
-            cached_statement = fetch_cached_statement(sql) if prepare && supports_statement_cache?
+            cached_statement = fetch_cached_statement(sql) if prepare && @jdbc_statement_cache_enabled
             @connection.execute_prepared_query(sql, binds, cached_statement)
           end
         end

--- a/lib/arjdbc/abstract/statement_cache.rb
+++ b/lib/arjdbc/abstract/statement_cache.rb
@@ -42,6 +42,7 @@ module ArJdbc
       end
 
       def supports_statement_cache?
+        ActiveSupport::Deprecation.deprecation_warning(__method__)
         @jdbc_statement_cache_enabled
       end
 


### PR DESCRIPTION
It's deprecated in Rails 5.2 and always returns true. For now, just
deprecate in ARJDBC to be able to disable the cache.

Fixes:
* rails52/test/cases/bind_parameter_test.rb #test_deprecate_supports_statement_cache