### PR TITLE
Travis: use postgresql-9.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,8 @@ rvm:
   - jruby-9.1.16.0
 jdk:
   - openjdk8
+addons:
+  postgresql: "9.4"
 env:
   - DB=mysql2 PREPARED_STATEMENTS=false
   - DB=mysql2 PREPARED_STATEMENTS=true


### PR DESCRIPTION
By default Travis uses PG 9.2. But it seems the client is actually newer
than that. One of the test errors is the server complaining about
"lock_timeout" which is a 9.3+ thing. Using a newer server version
fixes the problem. 9.2 is EOL anyway and 9.3 will be in a few weeks,
so go for 9.4