### PR TITLE
[50-52, postgres] Fix insert_returning: false for mixed case tables

### DIFF
--- a/lib/arjdbc/postgresql/adapter.rb
+++ b/lib/arjdbc/postgresql/adapter.rb
@@ -377,6 +377,12 @@ module ArJdbc
       @connection.configure_connection
     end
 
+    def default_sequence_name(table_name, pk = "id") #:nodoc:
+      serial_sequence(table_name, pk)
+    rescue ActiveRecord::StatementInvalid
+      %Q("#{table_name}_#{pk}_seq")
+    end
+
     def last_insert_id_result(sequence_name)
       exec_query("SELECT currval('#{sequence_name}')", 'SQL')
     end

--- a/test/rails/excludes/postgresql/ActiveRecord/ConnectionAdapters/PostgreSQLAdapterTest.rb
+++ b/test/rails/excludes/postgresql/ActiveRecord/ConnectionAdapters/PostgreSQLAdapterTest.rb
@@ -2,3 +2,5 @@ if ActiveRecord::Base.connection.prepared_statements
   exclude :test_exec_with_binds, 'it uses $1 for parameter mapping which is not currently supported'
   exclude :test_exec_typecasts_bind_vals, 'it uses $1 for parameter mapping which is not currently supported'
 end
+
+exclude :test_default_sequence_name_bad_table, "ARJDBC does more quoting (which is not wrong)"


### PR DESCRIPTION
It's all about quoting. The AR implementation undoes the proper
quoting. serial_sequence() returns a properly quoted string, the fallback
should actually never be used in PG >= 8.0