### PR TITLE
[51-52, postgres] Fix translate_exception()

### DIFF
--- a/lib/arjdbc/postgresql/adapter.rb
+++ b/lib/arjdbc/postgresql/adapter.rb
@@ -594,6 +594,8 @@ module ArJdbc
     end
 
     def translate_exception(exception, message)
+      return super unless exception.is_a?(ActiveRecord::JDBCError)
+
       # TODO: Can we base these on an error code of some kind?
       case exception.message
       when /duplicate key value violates unique constraint/


### PR DESCRIPTION
Only JDBC errors are handled by the adapter specific version of
translate_exception(), everything else should be handled by the
super implementation. It accidentally turned an ActiveModel::RangeError
into an ActiveRecord::RangeError, failing finder tests.

Fixes two errors (Rails 5.1 and 5.2) in
* rails/test/cases/finder_test.rb