### PR TITLE
Add location of jruby.jar to classpath from rbconfig for java 9+

### DIFF
--- a/rakelib/compile.rake
+++ b/rakelib/compile.rake
@@ -1,6 +1,7 @@
 jar_file = File.join(*%w(lib arjdbc jdbc adapter_java.jar))
 begin
   require 'ant'
+  require 'rbconfig'
   directory classes = "pkg/classes"
   CLEAN << classes
 
@@ -12,7 +13,7 @@ begin
     rm_rf FileList["#{classes}/**/*"]
     ant.javac :srcdir => "src/java", :destdir => "pkg/classes",
       :source => "7", :target => "7", :debug => true, :deprecation => true,
-      :classpath => "${java.class.path}:${sun.boot.class.path}:#{driver_jars.join(':')}",
+      :classpath => "${java.class.path}:${sun.boot.class.path}:#{RbConfig::CONFIG['libdir']}/jruby.jar:#{driver_jars.join(':')}",
       :includeantRuntime => false
 
     ant.tstamp do |ts|


### PR DESCRIPTION
Both Rakefile and `compile.rake` define the task
`lib/arjdbc/jdbc/adapter_java.jar`. So, while calling `rake` to compile
the gem, the task gets invoked twice - First from Rakefile followed by
the task defined in `compile.rake`. The classpath issue for Java 9+ was
fixed in Rakefile but not in `rakelib/compile.rake`.