### PR TITLE
[postgres] Use pgjdbc "autosave" option for hot compat

### DIFF
--- a/lib/arjdbc/postgresql/adapter.rb
+++ b/lib/arjdbc/postgresql/adapter.rb
@@ -689,21 +689,6 @@ module ActiveRecord::ConnectionAdapters
       TableDefinition.new(*args)
     end
 
-    def exec_query(sql, name = nil, binds = [], prepare: false)
-      super
-    rescue ActiveRecord::StatementInvalid => e
-      raise unless e.cause.message.include?('cached plan must not change result type'.freeze)
-
-      if open_transactions > 0
-        # In a transaction, have to fail it - See AR code for details
-        raise ActiveRecord::PreparedStatementCacheExpired.new(e.cause.message)
-      else
-        # Not in a transaction, clear the prepared statement and try again
-        delete_cached_statement(sql)
-        retry
-      end
-    end
-
     public :sql_for_insert
 
     def schema_creation # :nodoc:

--- a/lib/arjdbc/postgresql/connection_methods.rb
+++ b/lib/arjdbc/postgresql/connection_methods.rb
@@ -51,8 +51,15 @@ ArJdbc::ConnectionMethods.module_eval do
     properties['tcpKeepAlive'] ||= config[:keepalives] if config.key?(:keepalives)
     properties['kerberosServerName'] ||= config[:krbsrvname] if config[:krbsrvname]
 
-    # If prepared statements are off, lets make sure they are really *off*
-    properties['prepareThreshold'] ||= 0 unless config[:prepared_statements]
+    prepared_statements = config.fetch(:prepared_statements) { true }
+    prepared_statements = false if prepared_statements == 'false'
+    if prepared_statements
+      # this makes the pgjdbc driver handle hot compatibility internally
+      properties['autosave'] ||= 'conservative'
+    else
+      # If prepared statements are off, lets make sure they are really *off*
+      properties['prepareThreshold'] = 0
+    end
 
     jdbc_connection(config)
   end


### PR DESCRIPTION
The pgjdbc driver internally caches parsed statements (the most heavy
part of prepareStatement()). The hot_compatibility.rb test for INSERT
fails because the internal cache is used, not the ARJDBC one (only used
for queries).

Setting the option "autosave = ' conservative'", the driver handles
the cached plan changes internally: it creates a savepoint before the
query, when the problem is hit, it rolls back to the savepoint, clears
the cache and retries. This works for all statements and even when
inside a transaction. No more special handling required.

Fixes:
* rails/test/cases/hot_compatibility_test.rb