### PR TITLE
[52, postgres] supports_validate_constraints?

### DIFF
--- a/lib/arjdbc/postgresql/adapter.rb
+++ b/lib/arjdbc/postgresql/adapter.rb
@@ -227,6 +227,8 @@ module ArJdbc
 
     def supports_foreign_keys?; true end
 
+    def supports_validate_constraints?; true end
+
     def supports_index_sort_order?; true end
 
     def supports_partial_index?; true end


### PR DESCRIPTION
Fixes:
* rails52/test/cases/migration/foreign_key_test.rb