### PR TITLE
[52, postgres] Register type "date" as OID::Date

### DIFF
--- a/lib/arjdbc/postgresql/oid_types.rb
+++ b/lib/arjdbc/postgresql/oid_types.rb
@@ -81,7 +81,7 @@ module ArJdbc
         register_class_with_limit m, 'bit', OID::Bit
         register_class_with_limit m, 'varbit', OID::BitVarying
         m.alias_type 'timestamptz', 'timestamp'
-        m.register_type 'date', Type::Date.new
+        m.register_type 'date', OID::Date.new
 
         m.register_type 'money', OID::Money.new
         m.register_type 'bytea', OID::Bytea.new
@@ -168,6 +168,7 @@ module ArJdbc
       ActiveRecord::Type.register(:bit_varying, OID::BitVarying, adapter: :postgresql)
       ActiveRecord::Type.register(:binary, OID::Bytea, adapter: :postgresql)
       ActiveRecord::Type.register(:cidr, OID::Cidr, adapter: :postgresql)
+      ActiveRecord::Type.register(:date, OID::Date, adapter: :postgresql)
       ActiveRecord::Type.register(:datetime, OID::DateTime, adapter: :postgresql)
       ActiveRecord::Type.register(:decimal, OID::Decimal, adapter: :postgresql)
       ActiveRecord::Type.register(:enum, OID::Enum, adapter: :postgresql)


### PR DESCRIPTION
OID::Date is new for PostgreSQL adapter in Rails 5.2

Fixes 2 failures in:
* rails52/test/cases/adapters/postgresql/infinity_test.rb