### PR TITLE
[50-52, core] Fix exception handling within transaction

### DIFF
--- a/src/java/arjdbc/jdbc/RubyJdbcConnection.java
+++ b/src/java/arjdbc/jdbc/RubyJdbcConnection.java
@@ -3441,12 +3441,14 @@ public class RubyJdbcConnection extends RubyObject {
                 if ( ! gotConnection ) { // SQLException from driver/data-source
                     reconnectOnRetry = connected;
                 }
+                else if (!autoCommit) {
+                    // never retry inside a transaction
+                    break;
+                }
                 else if ( isTransient(exception) ) {
                     reconnectOnRetry = false; // continue;
                 }
                 else {
-                    if ( ! autoCommit ) break; // do not retry if (inside) transactions
-
                     if ( isConnectionValid(context, getConnectionImpl()) ) {
                         break; // connection not broken yet failed (do not retry)
                     }


### PR DESCRIPTION
When inside a transaction, never retry any statements. Retrying
transient errors is wrong as the transaction is typically already
rolled back. Retrying then only re-does the last statement, possibly
in a series of multiple statements, leading to unnoticed data loss.

The MySQL driver for example throws a MySQLTransactionRollbackException
when a deadlock is found. This inherits from MySQLTransientException
which inherits from SQLTransientException. The transaction is already
rolled back when the last statement was retried.

Fixes:
* rails/test/cases/adapters/mysql2/transaction_test.rb