### PR TITLE
[50-52, postgres] Add missing supports_x? methods

### DIFF
--- a/lib/arjdbc/postgresql/adapter.rb
+++ b/lib/arjdbc/postgresql/adapter.rb
@@ -224,6 +224,8 @@ module ArJdbc
 
     def supports_ddl_transactions?; true end
 
+    def supports_advisory_locks?; true end
+
     def supports_explain?; true end
 
     def supports_expression_index?; true end
@@ -244,6 +246,12 @@ module ArJdbc
 
     def supports_views?; true end
 
+    def supports_bulk_alter?; true end
+
+    def supports_datetime_with_precision?; true end
+
+    def supports_comments?; true end
+
     # Does PostgreSQL support standard conforming strings?
     def supports_standard_conforming_strings?
       standard_conforming_strings?
@@ -252,6 +260,14 @@ module ArJdbc
 
     def supports_hex_escaped_bytea?
       postgresql_version >= 90000
+    end
+
+    def supports_materialized_views?
+      postgresql_version >= 90300
+    end
+
+    def supports_json?
+      postgresql_version >= 90200
     end
 
     def supports_insert_with_returning?


### PR DESCRIPTION
This mostly makes sure that the tests for these features are
actually executed.