### PR TITLE
Fixes #891. Modifies super-call for log method in AbstractAdapter.

### DIFF
--- a/lib/arjdbc/abstract/core.rb
+++ b/lib/arjdbc/abstract/core.rb
@@ -67,7 +67,7 @@ module ArJdbc
         if binds.any? && (type_casted_binds.nil? || type_casted_binds.empty?)
           type_casted_binds = ->{ extract_raw_bind_values(binds) }
         end
-        super
+        super(sql, name, binds, statement_name)
       end
     end
   end


### PR DESCRIPTION
Removes the ArgumentError by providing the 4 required arguments explicitly.