### PR TITLE
[postgres] Update version regex matcher to ignore anyting after version number

### DIFF
--- a/lib/arjdbc/postgresql/adapter.rb
+++ b/lib/arjdbc/postgresql/adapter.rb
@@ -52,7 +52,7 @@ module ArJdbc
       @postgresql_version ||=
         begin
           version = @connection.database_product
-          if version.match /PostgreSQL (\d+.*)/
+          if version.match /PostgreSQL\s*([\d\.]*\d).*/
             version_numbers = $1.split('.').map(&:to_i)
             # PostgreSQL version representation does not have more than 4 digits
             return 0 if version_numbers.length > 4

--- a/test/db/postgresql/version_test.rb
+++ b/test/db/postgresql/version_test.rb
@@ -23,6 +23,10 @@ class VersionTest < Test::Unit::TestCase
     assert_equal connection_stub('9'), 90000
   end
 
+  def test_pg_version_with_os_version
+    assert_equal connection_stub('10.4 (Ubuntu 10.4-2.pgdg16.04+1)'), 100400
+  end
+
   private
 
   def connection_stub(version_string)


### PR DESCRIPTION
PPA repositories (of Ubuntu) appends its own version string after 'PostgreSQL <version-number>' i.e. it becomes 'PostgreSQL <version-number> <version-string-by-PPA>'. E.g: PostgreSQL 10.4 (Ubuntu 10.4-2.pgdg16.04+1)