### PR TITLE
[50-52, postgres] Fix PG version parsing for PG >= 10

### DIFF
--- a/lib/arjdbc/postgresql/adapter.rb
+++ b/lib/arjdbc/postgresql/adapter.rb
@@ -59,9 +59,25 @@ module ArJdbc
             # PostgreSQL version representation does not have more than 4 digits
             # From version 10 onwards, PG has changed its versioning policy to
             # limit it to only 2 digits. i.e. in 10.x, 10 being the major
-            # version and x representing the minor release
-            # Refer https://www.postgresql.org/support/versioning/ for more info
-            version[0, 4].zip([10000, 100, 1, 0]).map { |e| e.reduce(:*) }.sum
+            # version and x representing the patch release
+            # Refer to:
+            #   https://www.postgresql.org/support/versioning/
+            #   https://www.postgresql.org/docs/10/static/libpq-status.html -> PQserverVersion()
+            # for more info
+
+            if version.size >= 3
+              (version[0] * 100 + version[1]) * 100 + version[2]
+            elsif version.size == 2
+              if version[0] >= 10
+                version[0] * 100 * 100 + version[1]
+              else
+                (version[0] * 100 + version[1]) * 100
+              end
+            elsif version.size == 1
+              version[0] * 100 * 100
+            else
+              0
+            end
           else
             0
           end

--- a/test/db/postgresql/version_test.rb
+++ b/test/db/postgresql/version_test.rb
@@ -5,10 +5,11 @@ require 'db/postgresql/test_helper'
 class VersionTest < Test::Unit::TestCase
   def test_pg_9_version
     assert_equal 90608, connection_stub('9.6.8')
+    assert_equal 90600, connection_stub('9.6devel')
   end
 
   def test_pg_10_version
-    assert_equal 100400, connection_stub('10.4')
+    assert_equal 100004, connection_stub('10.4')
   end
 
   def test_pg_4part_version
@@ -32,7 +33,7 @@ class VersionTest < Test::Unit::TestCase
   end
 
   def test_pg_version_with_os_version
-    assert_equal 100400, connection_stub('10.4 (Ubuntu 10.4-2.pgdg16.04+1)')
+    assert_equal 100004, connection_stub('10.4 (Ubuntu 10.4-2.pgdg16.04+1)')
   end
 
   def test_custom_version


### PR DESCRIPTION
Do the same as libpq, see
https://github.com/postgres/postgres/blob/master/src/interfaces/libpq/fe-exec.c