### PR TITLE
Fix RuntimeError: can't add a new key into hash during iteration issu…

### DIFF
--- a/lib/arjdbc/db2/connection_methods.rb
+++ b/lib/arjdbc/db2/connection_methods.rb
@@ -2,6 +2,7 @@ ArJdbc::ConnectionMethods.module_eval do
   # @note Assumes DB2 driver (*db2jcc.jar*) is on class-path.
   def db2_connection(config)
     config[:adapter_spec] ||= ::ArJdbc::DB2
+    config = config.clone
 
     return jndi_connection(config) if jndi_config?(config)
 


### PR DESCRIPTION
AR-JDBC's version used:
52.1

version of Rails / ActiveRecord you're running with:
5.2.1

JRuby version (you might include your Java version as well) - jruby -v
jruby-9.2.0.0

include any (related) back-traces (or Java stack-traces) you've seen in the logs

RuntimeError: can't add a new key into hash during iteration
                             []= at org/jruby/RubyHash.java:1033
                mysql_connection at /Users/ptong/.rvm/gems/jruby-9.2.0.0/gems/activerecord-jdbc-adapter-52.1-java/lib/arjdbc/mysql/connection_methods.rb:8
                  new_connection at /Users/ptong/.rvm/gems/jruby-9.2.0.0/gems/activerecord-5.2.1/lib/active_record/connection_adapters/abstract/connection_pool.rb:809
         checkout_new_connection at /Users/ptong/.rvm/gems/jruby-9.2.0.0/gems/activerecord-5.2.1/lib/active_record/connection_adapters/abstract/connection_pool.rb:853
  try_to_checkout_new_connection at /Users/ptong/.rvm/gems/jruby-9.2.0.0/gems/activerecord-5.2.1/lib/active_record/connection_adapters/abstract/connection_pool.rb:832
              acquire_connection at /Users/ptong/.rvm/gems/jruby-9.2.0.0/gems/activerecord-5.2.1/lib/active_record/connection_adapters/abstract/connection_pool.rb:793
                        checkout at /Users/ptong/.rvm/gems/jruby-9.2.0.0/gems/activerecord-5.2.1/lib/active_record/connection_adapters/abstract/connection_pool.rb:521
                      connection at /Users/ptong/.rvm/gems/jruby-9.2.0.0/gems/activerecord-5.2.1/lib/active_record/connection_adapters/abstract/connection_pool.rb:380
             retrieve_connection at /Users/ptong/.rvm/gems/jruby-9.2.0.0/gems/activerecord-5.2.1/lib/active_record/connection_adapters/abstract/connection_pool.rb:1008
             retrieve_connection at /Users/ptong/.rvm/gems/jruby-9.2.0.0/gems/activerecord-5.2.1/lib/active_record/connection_handling.rb:118
                      connection at /Users/ptong/.rvm/gems/jruby-9.2.0.0/gems/activerecord-5.2.1/lib/active_record/connection_handling.rb:90
               block in evaluate at (irb):1


... a way to reproduce :)
Start a console with 'rails c' and run this line within the console

```100.times { Thread.new { ActiveRecord::Base.connection.execute "SELECT SLEEP(1)" } }```

Solution:
Implemented the fix based on this link:
https://stackoverflow.com/a/27643890