### PR TITLE
[db2] Add DB2 and AS400 support  for AR52

### DIFF
--- a/lib/arjdbc/db2/as400.rb
+++ b/lib/arjdbc/db2/as400.rb
@@ -4,6 +4,18 @@ module ArJdbc
   module AS400
     include DB2
 
+    module ActiveRecord::ConnectionAdapters
+      remove_const(:AS400Adapter) if const_defined?(:AS400Adapter)
+      class AS400Adapter < DB2Adapter
+
+        include ::ArJdbc::AS400
+
+        def jdbc_connection_class(spec)
+          ArJdbc::AS400.jdbc_connection_class
+        end
+      end
+    end
+
     # @private
     def self.extended(adapter); DB2.extended(adapter); end
 

--- a/lib/arjdbc/db2/column.rb
+++ b/lib/arjdbc/db2/column.rb
@@ -47,6 +47,9 @@ module ArJdbc
 
       # @override
       def type_cast(value)
+        # AR5.2
+        return super unless respond_to?(:type)
+
         return nil if value.nil? || value == 'NULL' || value =~ /^\s*NULL\s*$/i
         case type
         when :string    then value

--- a/lib/arjdbc/db2/connection_methods.rb
+++ b/lib/arjdbc/db2/connection_methods.rb
@@ -15,6 +15,8 @@ ArJdbc::ConnectionMethods.module_eval do
     end
     config[:driver] ||= ::ArJdbc::DB2::DRIVER_NAME
     config[:connection_alive_sql] ||= 'SELECT 1 FROM syscat.tables FETCH FIRST 1 ROWS ONLY'
+    config[:adapter_class] = ActiveRecord::ConnectionAdapters::DB2Adapter unless config.key?(:adapter_class)
+
     jdbc_connection(config)
   end
   alias_method :jdbcdb2_connection, :db2_connection
@@ -38,6 +40,8 @@ ArJdbc::ConnectionMethods.module_eval do
     require 'arjdbc/db2/as400'
     config[:driver] ||= ::ArJdbc::AS400::DRIVER_NAME
     config[:connection_alive_sql] ||= 'SELECT 1 FROM sysibm.tables FETCH FIRST 1 ROWS ONLY'
+    config[:adapter_class] = ActiveRecord::ConnectionAdapters::AS400Adapter unless config.key?(:adapter_class)
+
     jdbc_connection(config)
   end
   alias_method :jdbcas400_connection, :as400_connection

--- a/lib/arjdbc/jdbc.rb
+++ b/lib/arjdbc/jdbc.rb
@@ -9,6 +9,9 @@ module ArJdbc
   # @private
   AR50 = ::ActiveRecord::VERSION::MAJOR > 4
 
+  # @private
+  AR52 = ::ActiveRecord::VERSION::STRING >= '5.2'
+
   class << self
 
     # @private Internal API

--- a/lib/arjdbc/jdbc/column.rb
+++ b/lib/arjdbc/jdbc/column.rb
@@ -26,7 +26,9 @@ module ActiveRecord
           end
         end
 
-        if ArJdbc::AR50
+        if ArJdbc::AR52
+          # undefined method `cast' for #<ActiveRecord::ConnectionAdapters::SqlTypeMetadata> on AR52
+        elsif ArJdbc::AR50
           default = args[0].cast(default)
 
           sql_type = args.delete_at(1)
@@ -42,7 +44,7 @@ module ActiveRecord
         # super <= 4.1: (name, default, sql_type = nil, null = true)
         # super >= 4.2: (name, default, cast_type, sql_type = nil, null = true)
         # super >= 5.0: (name, default, sql_type_metadata = nil, null = true)
-        
+
         super(name, default, *args)
         init_column(name, default, *args)
       end


### PR DESCRIPTION
Fixes https://github.com/jruby/activerecord-jdbc-adapter/issues/955 and adds basic support for DB2/AS400

Had to add ArJcbc::AR52 to the JdbcColumn class to initialize adapter.
