### PR TITLE
Fixed for AR52

### DIFF
--- a/lib/arjdbc/abstract/core.rb
+++ b/lib/arjdbc/abstract/core.rb
@@ -22,7 +22,7 @@ module ArJdbc
 
         connection.configure_connection # will call us (maybe)
       end
-      
+
       # Retrieve the raw `java.sql.Connection` object.
       # The unwrap parameter is useful if an attempt to unwrap a pooled (JNDI)
       # connection should be made - to really return the 'native' JDBC object.
@@ -71,6 +71,21 @@ module ArJdbc
         end
         super
       end
+    end
+  end
+end
+
+
+module ActiveRecord
+  class LogSubscriber
+
+    JDBC_GEM_ROOT = File.expand_path("../../../..", __FILE__) + "/"
+
+    # Remove this gem from log trace so that query shows where it was called in application
+    def ignored_callstack(path)
+      path.start_with?(JDBC_GEM_ROOT) ||
+      path.start_with?(RAILS_GEM_ROOT) ||
+      path.start_with?(RbConfig::CONFIG["rubylibdir"])
     end
   end
 end

--- a/lib/arjdbc/abstract/core.rb
+++ b/lib/arjdbc/abstract/core.rb
@@ -73,19 +73,14 @@ module ArJdbc
       end
     end
   end
-end
 
-
-module ActiveRecord
-  class LogSubscriber
-
+  module LogSubscriber
     JDBC_GEM_ROOT = File.expand_path("../../../..", __FILE__) + "/"
 
     # Remove this gem from log trace so that query shows where it was called in application
     def ignored_callstack(path)
-      path.start_with?(JDBC_GEM_ROOT) ||
-      path.start_with?(RAILS_GEM_ROOT) ||
-      path.start_with?(RbConfig::CONFIG["rubylibdir"])
+      super || path.start_with?(JDBC_GEM_ROOT)
     end
   end
+  ActiveRecord::LogSubscriber.prepend(ArJdbc::LogSubscriber)
 end

--- a/lib/arjdbc/jdbc/adapter.rb
+++ b/lib/arjdbc/jdbc/adapter.rb
@@ -250,12 +250,6 @@ module ActiveRecord
         end
       end
 
-      # @private
-      # @override
-      def select_rows(sql, name = nil, binds = [])
-        exec_query_raw(sql, name, binds).map!(&:values)
-      end
-
       # Executes the SQL statement in the context of this connection.
       # The return value from this method depends on the SQL type (whether
       # it's a SELECT, INSERT etc.). For INSERTs a generated id might get


### PR DESCRIPTION
- Log in rails dev server console now shows where query was executed from
- `User.exists? 1` won't fail due to ID not being passed 