### PR TITLE
Changed params of type_to_sql to match the ones of AR5.2

### DIFF
--- a/lib/arjdbc/db2/adapter.rb
+++ b/lib/arjdbc/db2/adapter.rb
@@ -487,9 +487,9 @@ module ArJdbc
       types
     end
 
-    def type_to_sql(type, limit = nil, precision = nil, scale = nil)
+    def type_to_sql(type, limit: nil, precision: nil, scale: nil, **)
       limit = nil if type.to_sym == :integer
-      super(type, limit, precision, scale)
+      super
     end
 
     # @private
@@ -502,7 +502,7 @@ module ArJdbc
 
     def add_column(table_name, column_name, type, options = {})
       # The keyword COLUMN allows to use reserved names for columns (ex: date)
-      add_column_sql = "ALTER TABLE #{quote_table_name(table_name)} ADD COLUMN #{quote_column_name(column_name)} #{type_to_sql(type, options[:limit], options[:precision], options[:scale])}"
+      add_column_sql = "ALTER TABLE #{quote_table_name(table_name)} ADD COLUMN #{quote_column_name(column_name)} #{type_to_sql(type, options)}"
       add_column_options!(add_column_sql, options)
       execute(add_column_sql)
     end
@@ -645,7 +645,7 @@ module ArJdbc
     end
 
     def change_column(table_name, column_name, type, options = {})
-      data_type = type_to_sql(type, options[:limit], options[:precision], options[:scale])
+      data_type = type_to_sql(type, options)
       sql = "ALTER TABLE #{table_name} ALTER COLUMN #{column_name} SET DATA TYPE #{data_type}"
       execute_table_change(sql, table_name, 'Change Column')
 


### PR DESCRIPTION
Currently migrations are failing on AR5.2 because the `type_to_sql` was changed from 4 parameters to 2 parameters. 

Changed the method in db2 adapter to match this 