### PR TITLE
[AR52] Ability to handle nil last_inserted_id result

### DIFF
--- a/lib/arjdbc/db2/adapter.rb
+++ b/lib/arjdbc/db2/adapter.rb
@@ -753,11 +753,10 @@ module ArJdbc
 
     # alias_method :execute_and_auto_confirm, :execute
 
-    # Returns the value of an identity column of the last *INSERT* statement
-    # made over this connection.
+    # Returns the value of an identity column of the last *INSERT* statement made over this connection.
     # @note Check the *IDENTITY_VAL_LOCAL* function for documentation.
-    # @return [Fixnum]
-    def last_insert_id
+    # @return [Integer, NilClass]
+    def last_inserted_id(result)
       @connection.identity_val_local
     end
 


### PR DESCRIPTION
When inserting into view's or tables with no ID, exception will be thrown even though the insert goes fine

Code will return `nil` if the result is blank