### PR TITLE
[ci] Make sure Travis uses Bundler 1.17.3 but not 2.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ bundler_args: --without development
 script: bundle exec rake ${TEST_PREFIX}test_$DB
 before_install:
   - unset _JAVA_OPTIONS
+  - rvm @default,@global do gem uninstall bundler -a -x -I || true
+  - gem install bundler -v "~>1.17.3"
 before_script:
   - echo "JAVA_OPTS=$JAVA_OPTS"
   - export JRUBY_OPTS="-J-Xms64M -J-Xmx1024M"


### PR DESCRIPTION
Recent release of Bundler 2.0 breaks the build since it cannot install
with older rubygems version. Make sure 1.17.3 is installed.