### PR TITLE
Solve issue with same table name present in different schemas. primar…

### DIFF
--- a/lib/arjdbc/db2/adapter.rb
+++ b/lib/arjdbc/db2/adapter.rb
@@ -328,6 +328,17 @@ module ArJdbc
       select_one(sql).nil?
     end
 
+    # @override
+    def primary_keys(table)
+      # If no schema in table name is given but present in URL parameter. Use the URL parameter one
+      # This avoids issues if the table is present in multiple schemas
+      if table.split(".").size == 1 && schema
+        table = "#{schema}.#{table}"
+      end
+
+      super
+    end
+
     def next_sequence_value(sequence_name)
       select_value("SELECT NEXT VALUE FOR #{sequence_name} FROM sysibm.sysdummy1")
     end


### PR DESCRIPTION
Ran into an interesting issue:
- 2 tables with same name in different schemas.
- Connection URL has the default schema listed
- When trying to do any operation on the table specified in URL schema, Rails throws a fit because compose keys are not supported

This commit will check if the schema was not specified in table name and default schema is set through URL. Then will add the schema to the table name before checking for it's primary key

