### PR TITLE
[postgres] fix bind params length

### DIFF
--- a/lib/arjdbc/postgresql/adapter.rb
+++ b/lib/arjdbc/postgresql/adapter.rb
@@ -690,6 +690,10 @@ module ArJdbc
       @local_tz ||= execute('SHOW TIME ZONE', 'SCHEMA').first["TimeZone"]
     end
 
+    def bind_params_length
+      32767
+    end
+
   end
 end
 

--- a/test/bind_params_length_test.rb
+++ b/test/bind_params_length_test.rb
@@ -1,0 +1,17 @@
+require 'test_helper'
+require 'models/topic'
+
+class BindParamsLengthTest < Test::Unit::TestCase
+  def setup
+    TopicMigration.up
+    Topic.create!(title: 'blub')
+  end
+
+  def teardown
+    TopicMigration.down
+  end
+
+  def test_bind_param_length
+    assert Topic.where(id: [1] * 75000).first
+  end
+end

--- a/test/db/mysql/bind_params_length_test.rb
+++ b/test/db/mysql/bind_params_length_test.rb
@@ -1,0 +1,2 @@
+require 'db/mysql'
+require 'bind_params_length_test'

--- a/test/db/postgresql/bind_params_length_test.rb
+++ b/test/db/postgresql/bind_params_length_test.rb
@@ -1,0 +1,2 @@
+require 'db/postgres'
+require 'bind_params_length_test'


### PR DESCRIPTION
pgjdbc doesn't like more than 32767 bind params.

Fixes #977