### PR TITLE
Random Rails 6 bits

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -76,8 +76,10 @@ matrix:
     #  env: DB=mysql2
     #- rvm: jruby-head
     #  env: DB=postgresql
-    #- rvm: jruby-head
-    #  env: DB=sqlite3
+    - rvm: jruby-head
+      env: DB=sqlite3
+    - rvm: jruby-head
+      env: DB=sqlite3    TEST_PREFIX="rails:" AR_VERSION="v6.0.0.beta1"
     # testing against MariaDB
     - addons:
         mariadb: '10.0'

--- a/lib/arjdbc/abstract/core.rb
+++ b/lib/arjdbc/abstract/core.rb
@@ -72,13 +72,6 @@ module ArJdbc
     end
   end
 
-  module LogSubscriber
-    JDBC_GEM_ROOT = File.expand_path("../../../..", __FILE__) + "/"
-
-    # Remove this gem from log trace so that query shows where it was called in application
-    def ignored_callstack(path)
-      super || path.start_with?(JDBC_GEM_ROOT)
-    end
-  end
-  ActiveRecord::LogSubscriber.prepend(ArJdbc::LogSubscriber)
+  JDBC_GEM_ROOT = File.expand_path("../../../..", __FILE__) + "/"
+  ActiveRecord::LogSubscriber.backtrace_cleaner.add_silencer { |line| line.start_with?(JDBC_GEM_ROOT) }
 end

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
   <url>http://github.com/jruby/activerecord-jdbc-adapter/wiki</url>
 
   <properties>
-    <jruby.version>9.1.6.0</jruby.version>
+    <jruby.version>9.2.5.0</jruby.version>
   </properties>
 
   <issueManagement>
@@ -75,7 +75,7 @@
     <dependency>
       <groupId>org.postgresql</groupId>
       <artifactId>postgresql</artifactId>
-      <version>42.1.4.jre7</version>
+      <version>42.1.4</version>
     </dependency>
   </dependencies>
 
@@ -103,8 +103,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>2.5.1</version>
         <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin>
     </plugins>

--- a/test/rails/excludes/mysql2/LogSubscriberTest.rb
+++ b/test/rails/excludes/mysql2/LogSubscriberTest.rb
@@ -1,0 +1,1 @@
+exclude :test_vebose_query_logs, 'Rails cuts itself from the backtrace when tests run from gem directory (e.g. when bundled via git)'

--- a/test/rails/excludes/postgresql/LogSubscriberTest.rb
+++ b/test/rails/excludes/postgresql/LogSubscriberTest.rb
@@ -1,0 +1,1 @@
+exclude :test_vebose_query_logs, 'Rails cuts itself from the backtrace when tests run from gem directory (e.g. when bundled via git)'

--- a/test/rails/excludes/sqlite3/LogSubscriberTest.rb
+++ b/test/rails/excludes/sqlite3/LogSubscriberTest.rb
@@ -1,0 +1,1 @@
+exclude :test_vebose_query_logs, 'Rails cuts itself from the backtrace when tests run from gem directory (e.g. when bundled via git)'


### PR DESCRIPTION
Once JRuby 9.2.6.0 is released and the .travis.yml is changed to use it, this _should_ turn CI green for Rails 6.0.0.beta1.