### PR TITLE
[test] fix query cache tests for Rail 5.1..6.0

### DIFF
--- a/test/simple.rb
+++ b/test/simple.rb
@@ -1035,7 +1035,6 @@ module SimpleTestMethods
   end
 
   def test_query_cache
-    pend '#839 is open to resolve if this is really a valid test or not in 5.1'  if ActiveRecord::Base.connection.adapter_name =~ /mysql|sqlite|postgres/i
     user_1 = User.create! :login => 'query_cache_1'
     user_2 = User.create! :login => 'query_cache_2'
     user_3 = User.create! :login => 'query_cache_3'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -505,7 +505,7 @@ module ActiveRecord
     end
 
     def call(name, start, finish, message_id, values)
-      return if 'CACHE' == values[:name]
+      return if values[:cached]
 
       sql = values[:sql]
       sql = sql.to_sql unless sql.is_a?(String)


### PR DESCRIPTION
5.1 and higher changed the way cached queries are accounted for...

Fixes #839