### PR TITLE
[test] fix some ArgumentError: argument out of range

### DIFF
--- a/test/simple.rb
+++ b/test/simple.rb
@@ -1056,7 +1056,7 @@ module SimpleTestMethods
       :sample_float => 10.5,
       :sample_boolean => true,
       :sample_decimal => 0.12345678,
-      :sample_time => Time.now.change(sec: 36, usec: 12000000),
+      :sample_time => Time.now.change(sec: 36, usec: 120000),
       :sample_binary => '01' * 512
     )
     expected.reload


### PR DESCRIPTION
This is already in 52-stable. With latest Rails 5.0.x, it happens too.