### PR TITLE
51.x fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -92,9 +92,9 @@ matrix:
         mariadb: '10.1'
       env: DB=mariadb PREPARED_STATEMENTS=true
     # Rails test-suite :
-    - env: DB=mysql2     TEST_PREFIX="rails:" AR_VERSION="v5.1.6.1" # PS off by default
-    - env: DB=mysql2     TEST_PREFIX="rails:" AR_VERSION="v5.1.6.1" PREPARED_STATEMENTS=true
-    - env: DB=mysql2     TEST_PREFIX="rails:" AR_VERSION="v5.1.6.1" DRIVER=MariaDB
-    - env: DB=postgresql TEST_PREFIX="rails:" AR_VERSION="v5.1.6.1" # PS on by default
-    - env: DB=postgresql TEST_PREFIX="rails:" AR_VERSION="v5.1.6.1" PREPARED_STATEMENTS=false
-    - env: DB=sqlite3    TEST_PREFIX="rails:" AR_VERSION="v5.1.6.1"
+    - env: DB=mysql2     TEST_PREFIX="rails:" AR_VERSION="v5.1.7" # PS off by default
+    - env: DB=mysql2     TEST_PREFIX="rails:" AR_VERSION="v5.1.7" PREPARED_STATEMENTS=true
+    - env: DB=mysql2     TEST_PREFIX="rails:" AR_VERSION="v5.1.7" DRIVER=MariaDB
+    - env: DB=postgresql TEST_PREFIX="rails:" AR_VERSION="v5.1.7" # PS on by default
+    - env: DB=postgresql TEST_PREFIX="rails:" AR_VERSION="v5.1.7" PREPARED_STATEMENTS=false
+    - env: DB=sqlite3    TEST_PREFIX="rails:" AR_VERSION="v5.1.7"

--- a/lib/arjdbc/postgresql/adapter.rb
+++ b/lib/arjdbc/postgresql/adapter.rb
@@ -528,67 +528,6 @@ module ArJdbc
       execute "TRUNCATE TABLE #{quote_table_name(table_name)}", name
     end
 
-    # Returns an array of indexes for the given table.
-    def indexes(table_name, name = nil)
-      if name
-        ActiveSupport::Deprecation.warn(<<-MSG.squish)
-              Passing name to #indexes is deprecated without replacement.
-        MSG
-      end
-
-      # FIXME: AR version => table = Utils.extract_schema_qualified_name(table_name.to_s)
-      schema, table = extract_schema_and_table(table_name.to_s)
-
-      result = query(<<-SQL, 'SCHEMA')
-            SELECT distinct i.relname, d.indisunique, d.indkey, pg_get_indexdef(d.indexrelid), t.oid,
-                            pg_catalog.obj_description(i.oid, 'pg_class') AS comment,
-            (SELECT COUNT(*) FROM pg_opclass o
-               JOIN (SELECT unnest(string_to_array(d.indclass::text, ' '))::int oid) c
-                 ON o.oid = c.oid WHERE o.opcdefault = 'f')
-            FROM pg_class t
-            INNER JOIN pg_index d ON t.oid = d.indrelid
-            INNER JOIN pg_class i ON d.indexrelid = i.oid
-            LEFT JOIN pg_namespace n ON n.oid = i.relnamespace
-            WHERE i.relkind = 'i'
-              AND d.indisprimary = 'f'
-              AND t.relname = '#{table}'
-              AND n.nspname = #{schema ? "'#{schema}'" : 'ANY (current_schemas(false))'}
-            ORDER BY i.relname
-      SQL
-
-      result.map do |row|
-        index_name = row[0]
-        # FIXME: These values [1,2] are returned in a different format than AR expects, maybe we could update it on the Java side to be more accurate
-        unique = row[1].is_a?(String) ? row[1] == 't' : row[1] # JDBC gets us a boolean
-        indkey = row[2].is_a?(Java::OrgPostgresqlUtil::PGobject) ? row[2].value : row[2]
-        indkey = indkey.split(" ").map(&:to_i)
-        inddef = row[3]
-        oid = row[4]
-        comment = row[5]
-        opclass = row[6]
-
-        using, expressions, where = inddef.scan(/ USING (\w+?) \((.+?)\)(?: WHERE (.+))?\z/m).flatten
-
-        if indkey.include?(0) || opclass > 0
-          columns = expressions
-        else
-          columns = Hash[query(<<-SQL.strip_heredoc, "SCHEMA")].values_at(*indkey).compact
-                SELECT a.attnum, a.attname
-                FROM pg_attribute a
-                WHERE a.attrelid = #{oid}
-                AND a.attnum IN (#{indkey.join(",")})
-          SQL
-
-          # add info on sort order for columns (only desc order is explicitly specified, asc is the default)
-          orders = Hash[
-              expressions.scan(/(\w+) DESC/).flatten.map { |order_column| [order_column, :desc] }
-          ]
-        end
-
-        IndexDefinition.new(table_name, index_name, unique, columns, [], orders, where, nil, using.to_sym, comment.presence)
-      end.compact
-    end
-
     # @private
     def column_name_for_operation(operation, node)
       case operation

--- a/test/rails/excludes/mysql2/AttributeMethodsTest.rb
+++ b/test/rails/excludes/mysql2/AttributeMethodsTest.rb
@@ -1,1 +1,1 @@
-exclude :test_read_attributes_before_type_cast_on_boolean, 'This test was a jruby-specific guard when we did wrong thing.  We do right thing now...need pr to remove that guard from test'
+exclude :test_read_attributes_before_type_cast_on_a_boolean, 'This test was a jruby-specific guard when we did wrong thing.  We do right thing now...need pr to remove that guard from test'

--- a/test/rails/excludes/mysql2/Mysql2ConnectionTest.rb
+++ b/test/rails/excludes/mysql2/Mysql2ConnectionTest.rb
@@ -1,6 +1,7 @@
-exclude :test_passing_arbitary_flags_to_adapter, 'no support for arbitrary flags such as Mysql2::Client::COMPRESS'
+exclude :test_passing_arbitrary_flags_to_adapter, 'no support for arbitrary flags such as Mysql2::Client::COMPRESS'
 exclude :test_passing_flags_by_array_to_adapter, 'no support for passing flags: ... not supported by JDBC adapter'
 exclude :test_quote_after_disconnect, 'AR-JDBC does not rely on driver to do quoting - thus wont raise an error'
+exclude :test_execute_after_disconnect, "test relying on mysql2 internals"
 exclude :test_mysql_connection_collation_is_configured, "Issue #884"
 
 if ActiveRecord::Base.connection.jdbc_connection(true).java_class.name.start_with?('org.mariadb.jdbc')

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -486,12 +486,12 @@ module ActiveRecord
       @@ignored_sql = value || []
     end
 
-    # FIXME: this needs to be refactored so specific database can add their own
-    # ignored SQL.  This ignored SQL is for Oracle.
+    # FIXME: this needs to be refactored so specific database can add their own ignored SQL.
     ignored_sql.concat [/^select .*nextval/i,
       /^SAVEPOINT/,
       /^ROLLBACK TO/,
-      /^\s*select .* from all_triggers/im
+      /^\s*select .* from all_triggers/im,
+      /^\s*SELECT sql\b.*\bFROM sqlite_master/im
     ]
 
     @@log = []


### PR DESCRIPTION
One fallout from the 50-stable merge, CI Rails version update, excludes update and one for SQLite3 that probably doesn't trigger for 51-stable, but it sure does for 52-stable.

The remaining two errors on PG I have no idea about yet...test and rake tasks are the same as in Rails 5.2.

This will likely result in conflicts in the 52-merge. Anyways, once this is in, another PR for 52-stable will follow soon after.