### PR TITLE
Make `check_version` public

### DIFF
--- a/lib/arjdbc/sqlite3/adapter.rb
+++ b/lib/arjdbc/sqlite3/adapter.rb
@@ -329,17 +329,17 @@ module ArJdbc
       sql
     end
 
+    def check_version # :nodoc:
+      if sqlite_version < "3.8.0"
+        raise "Your version of SQLite (#{sqlite_version}) is too old. Active Record supports SQLite >= 3.8."
+      end
+    end
+
     private
     # See https://www.sqlite.org/limits.html,
     # the default value is 999 when not configured.
     def bind_params_length
       999
-    end
-
-    def check_version
-      if sqlite_version < "3.8.0"
-        raise "Your version of SQLite (#{sqlite_version}) is too old. Active Record supports SQLite >= 3.8."
-      end
     end
 
     def initialize_type_map(m = type_map)


### PR DESCRIPTION
Since Rails now needs it public. Since https://github.com/rails/rails/pull/35795.