### PR TITLE
 Fixing cancel timer logic to work with mysql-connector-java 8

### DIFF
--- a/src/java/arjdbc/mysql/MySQLRubyJdbcConnection.java
+++ b/src/java/arjdbc/mysql/MySQLRubyJdbcConnection.java
@@ -337,9 +337,13 @@ public class MySQLRubyJdbcConnection extends RubyJdbcConnection {
                     if ( match.find() ) {
                         final int major = Integer.parseInt( match.group(1) );
                         final int minor = Integer.parseInt( match.group(2) );
-                        if ( major < 5 || ( major == 5 && minor <= 1 ) ) {
+                        if ( major < 5 || ( major == 5 && minor < 1) ) {
+                            killCancelTimer = Boolean.TRUE;
+                        } else if ( major == 5 && minor == 1 ) {
                             final int patch = Integer.parseInt( match.group(3) );
                             killCancelTimer = patch < 11;
+                        } else {
+                            killCancelTimer = Boolean.FALSE;
                         }
                     }
                     else {


### PR DESCRIPTION
mysql-connector-java 8 is the recommended connector for all mysql versions, including mysql 5.5, 5.6, and 5.7: https://dev.mysql.com/downloads/connector/j/

This PR fixes this NPE when using mysql-connector-java version 8:
```
LoadError: load error: /Users/clark.perkins/Workspace/activerecord-jdbc-adapter/test/db/mysql/schema_dump_test -- java.lang.NullPointerException: null
                                                                                            require at org/jruby/RubyKernel.java:956
                                                                                   block in require at /Users/clark.perkins/.rvm/gems/jruby-9.1.17.0@jdbc/gems/activesupport-4.2.11.1/lib/active_support/dependencies.rb:274
                                                                                    load_dependency at /Users/clark.perkins/.rvm/gems/jruby-9.1.17.0@jdbc/gems/activesupport-4.2.11.1/lib/active_support/dependencies.rb:240
                                                                                            require at /Users/clark.perkins/.rvm/gems/jruby-9.1.17.0@jdbc/gems/activesupport-4.2.11.1/lib/active_support/dependencies.rb:274
  block in /Users/clark.perkins/.rvm/rubies/jruby-9.1.17.0/lib/ruby/stdlib/rake/rake_test_loader.rb at /Users/clark.perkins/.rvm/rubies/jruby-9.1.17.0/lib/ruby/stdlib/rake/rake_test_loader.rb:15
                                                                                             select at org/jruby/RubyArray.java:2566
                                                                                             <main> at /Users/clark.perkins/.rvm/rubies/jruby-9.1.17.0/lib/ruby/stdlib/rake/rake_test_loader.rb:4
```