### PR TITLE
Remove unused simplified_type method

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ jdk:
   - openjdk8
 env:
   global:
-    - AR_VERSION="master"
+    - AR_VERSION="6-0-stable"
 matrix:
   allow_failures:
     - rvm: jruby-head
@@ -99,15 +99,15 @@ matrix:
       env: DB=mariadb PREPARED_STATEMENTS=true
 
     # Rails test-suite :
-    - env: DB=mysql2     TEST_PREFIX="rails:" AR_VERSION="master" # PS off by default
-    - env: DB=mysql2     TEST_PREFIX="rails:" AR_VERSION="master" PREPARED_STATEMENTS=true
-    - env: DB=mysql2     TEST_PREFIX="rails:" AR_VERSION="master" DRIVER=MariaDB
+    - env: DB=mysql2     TEST_PREFIX="rails:" AR_VERSION="6-0-stable" # PS off by default
+    - env: DB=mysql2     TEST_PREFIX="rails:" AR_VERSION="6-0-stable" PREPARED_STATEMENTS=true
+    - env: DB=mysql2     TEST_PREFIX="rails:" AR_VERSION="6-0-stable" DRIVER=MariaDB
 
     - addons:
         postgresql: "9.4"
-      env: DB=postgresql TEST_PREFIX="rails:" AR_VERSION="master" # PS on by default
+      env: DB=postgresql TEST_PREFIX="rails:" AR_VERSION="6-0-stable" # PS on by default
     - addons:
         postgresql: "9.4"
-      env: DB=postgresql TEST_PREFIX="rails:" AR_VERSION="master" PREPARED_STATEMENTS=false
+      env: DB=postgresql TEST_PREFIX="rails:" AR_VERSION="6-0-stable" PREPARED_STATEMENTS=false
 
-    - env: DB=sqlite3    TEST_PREFIX="rails:" AR_VERSION="master"
+    - env: DB=sqlite3    TEST_PREFIX="rails:" AR_VERSION="6-0-stable"

--- a/lib/arjdbc/db2/column.rb
+++ b/lib/arjdbc/db2/column.rb
@@ -80,45 +80,6 @@ module ArJdbc
 
       private
 
-      def simplified_type(field_type)
-        case field_type
-        when /^decimal\(1\)$/i   then DB2.emulate_booleans? ? :boolean : :integer
-        when /smallint/i         then DB2.emulate_booleans? ? :boolean : :integer
-        when /boolean/i          then :boolean
-        when /^real|double/i     then :float
-        when /int|serial/i       then :integer
-        # if a numeric column has no scale, lets treat it as an integer.
-        # The AS400 rpg guys do this ALOT since they have no integer datatype ...
-        when /decimal|numeric|decfloat/i
-          extract_scale(field_type) == 0 ? :integer : :decimal
-        when /timestamp/i        then :timestamp
-        when /datetime/i         then :datetime
-        when /time/i             then :time
-        when /date/i             then :date
-        # DB2 provides three data types to store these data objects as strings of up to 2 GB in size:
-        #  Character large objects (CLOBs)
-        #    Use the CLOB data type to store SBCS or mixed data, such as documents that contain
-        #    single character set. Use this data type if your data is larger (or might grow larger)
-        #    than the VARCHAR data type permits.
-        #  Double-byte character large objects (DBCLOBs)
-        #    Use the DBCLOB data type to store large amounts of DBCS data, such as documents that
-        #    use a DBCS character set.
-        #  Binary large objects (BLOBs)
-        #    Use the BLOB data type to store large amounts of noncharacter data, such as pictures,
-        #    voice, and mixed media.
-        when /clob|text/i        then :text # handles DBCLOB
-        when /^long varchar/i    then :text # :limit => 32700
-        when /blob|binary/i      then :binary
-        # varchar () for bit data, char () for bit data, long varchar for bit data
-        when /for bit data/i     then :binary
-        when /xml/i              then :xml
-        when /graphic/i          then :graphic # vargraphic, long vargraphic
-        when /rowid/i            then :rowid # rowid is a supported datatype on z/OS and i/5
-        else
-          super
-        end
-      end
-
       # Post process default value from JDBC into a Rails-friendly format (columns{-internal})
       def default_value(value)
         # IBM i (AS400) will return an empty string instead of null for no default

--- a/lib/arjdbc/derby/adapter.rb
+++ b/lib/arjdbc/derby/adapter.rb
@@ -65,25 +65,6 @@ module ArJdbc
         limit
       end
 
-      def simplified_type(field_type)
-        case field_type
-        when /^smallint/i    then Derby.emulate_booleans? ? :boolean : :integer
-        when /^bigint|int/i  then :integer
-        when /^real|double/i then :float
-        when /^dec/i         then # DEC is a DECIMAL alias
-          extract_scale(field_type) == 0 ? :integer : :decimal
-        when /^timestamp/i   then :datetime
-        when /^xml/i         then :xml
-        when 'long varchar'  then :text
-        when /for bit data/i then :binary
-        # :name=>"long varchar for bit data", :limit=>32700
-        # :name=>"varchar() for bit data", :limit=>32672
-        # :name=>"char() for bit data", :limit=>254}
-        else
-          super
-        end
-      end
-
       # Post process default value from JDBC into a Rails-friendly format (columns{-internal})
       def default_value(value)
         # JDBC returns column default strings with actual single quotes around the value.
@@ -420,7 +401,7 @@ module ArJdbc
 
     # @override
     def supports_ddl_transactions?; true end
- 
+
     # @override
     def supports_foreign_keys?; true end
 

--- a/lib/arjdbc/firebird/adapter.rb
+++ b/lib/arjdbc/firebird/adapter.rb
@@ -38,27 +38,6 @@ module ArJdbc
           return $1 unless $1.upcase == 'NULL'
         end
       end
-
-      private
-
-      def simplified_type(field_type)
-        case field_type
-        when /timestamp/i    then :datetime
-        when /^smallint/i    then :integer
-        when /^bigint|int/i  then :integer
-        when /^double/i      then :float # double precision
-        when /^decimal/i     then
-          extract_scale(field_type) == 0 ? :integer : :decimal
-        when /^char\(1\)$/i  then Firebird.emulate_booleans? ? :boolean : :string
-        when /^char/i        then :string
-        when /^blob\ssub_type\s(\d)/i
-          return :binary if $1 == '0'
-          return :text   if $1 == '1'
-        else
-          super
-        end
-      end
-
     end
 
     # @see ActiveRecord::ConnectionAdapters::JdbcAdapter#jdbc_column_class

--- a/lib/arjdbc/h2/adapter.rb
+++ b/lib/arjdbc/h2/adapter.rb
@@ -47,21 +47,6 @@ module ArJdbc
         limit
       end
 
-      def simplified_type(field_type)
-        case field_type
-        when /^bit|bool/i         then :boolean
-        when /^signed|year/i      then :integer
-        when /^real|double/i      then :float
-        when /^varchar/i          then :string
-        when /^longvarchar/i      then :text
-        when /^binary|raw|bytea/i then :binary
-        when /varbinary/i         then :binary # longvarbinary, varbinary
-        when /^blob|image|oid/i   then :binary
-        else
-          super
-        end
-      end
-
       # Post process default value from JDBC into a Rails-friendly format (columns{-internal})
       def default_value(value)
         # H2 auto-generated key default value

--- a/lib/arjdbc/hsqldb/adapter.rb
+++ b/lib/arjdbc/hsqldb/adapter.rb
@@ -42,20 +42,6 @@ module ArJdbc
         limit
       end
 
-      def simplified_type(field_type)
-        case field_type
-        when /^nvarchar/i    then :string
-        when /^character/i   then :string
-        when /^longvarchar/i then :text
-        when /int/i          then :integer # TINYINT, SMALLINT, BIGINT, INT
-        when /real|double/i  then :float
-        when /^bit/i         then :boolean
-        when /binary/i       then :binary # VARBINARY, LONGVARBINARY
-        else
-          super
-        end
-      end
-
       # Post process default value from JDBC into a Rails-friendly format (columns{-internal})
       def default_value(value)
         # JDBC returns column default strings with actual single quotes around the value.

--- a/lib/arjdbc/informix/adapter.rb
+++ b/lib/arjdbc/informix/adapter.rb
@@ -45,20 +45,6 @@ module ArJdbc
       ::ActiveRecord::ConnectionAdapters::InformixColumn
     end
 
-    module ColumnMethods
-
-      private
-      # TODO: Test all Informix column types.
-      def simplified_type(field_type)
-        if field_type =~ /serial/i
-          :primary_key
-        else
-          super
-        end
-      end
-
-    end
-
     def modify_types(types)
       super(types)
       types[:primary_key] = "SERIAL PRIMARY KEY"

--- a/lib/arjdbc/mssql/column.rb
+++ b/lib/arjdbc/mssql/column.rb
@@ -17,26 +17,6 @@ module ArJdbc
       include LockMethods unless AR42
 
       # @override
-      def simplified_type(field_type)
-        case field_type
-        when /int|bigint|smallint|tinyint/i           then :integer
-        when /numeric/i                               then (@scale.nil? || @scale == 0) ? :integer : :decimal
-        when /float|double|money|real|smallmoney/i    then :decimal
-        when /datetime|smalldatetime/i                then :datetime
-        when /timestamp/i                             then :timestamp
-        when /time/i                                  then :time
-        when /date/i                                  then :date
-        when /text|ntext|xml/i                        then :text
-        when /binary|image|varbinary/i                then :binary
-        when /char|nchar|nvarchar|string|varchar/i    then (@limit == 1073741823 ? (@limit = nil; :text) : :string)
-        when /bit/i                                   then :boolean
-        when /uniqueidentifier/i                      then :string
-        else
-          super
-        end
-      end
-
-      # @override
       def default_value(value)
         return $1 if value =~ /^\(N?'(.*)'\)$/ || value =~ /^\(\(?(.*?)\)?\)$/
         value

--- a/lib/arjdbc/sqlite3/adapter.rb
+++ b/lib/arjdbc/sqlite3/adapter.rb
@@ -596,24 +596,6 @@ module ActiveRecord::ConnectionAdapters
 
     private
 
-    # @override {ActiveRecord::ConnectionAdapters::Column#simplified_type}
-    def simplified_type(field_type)
-      case field_type
-        when /boolean/i       then :boolean
-        when /text/i          then :text
-        when /varchar/i       then :string
-        when /int/i           then :integer
-        when /float/i         then :float
-        when /real|decimal/i  then
-          extract_scale(field_type) == 0 ? :integer : :decimal
-        when /datetime/i      then :datetime
-        when /date/i          then :date
-        when /time/i          then :time
-        when /blob/i          then :binary
-        else super
-      end
-    end
-
     # @override {ActiveRecord::ConnectionAdapters::Column#extract_limit}
     def extract_limit(sql_type)
       return nil if sql_type =~ /^(real)\(\d+/i
@@ -667,7 +649,7 @@ module ActiveRecord::ConnectionAdapters
     def begin_isolated_db_transaction(isolation)
       raise ActiveRecord::TransactionIsolationError, 'adapter does not support setting transaction isolation'
     end
-    
+
     # SQLite driver doesn't support all types of insert statements with executeUpdate so
     # make it act like a regular query and the ids will be returned from #last_inserted_id
     # example: INSERT INTO "aircraft" DEFAULT VALUES


### PR DESCRIPTION
Method hasn't been part of ActiveRecord since commit https://github.com/rails/rails/commit/0b682e4b05c8f58c77c655650af6638c483ac903 (May 2014)