### PR TITLE
gemspec: Drop rubyforge_project property

### DIFF
--- a/activerecord-jdbcderby-adapter/activerecord-jdbcderby-adapter.gemspec
+++ b/activerecord-jdbcderby-adapter/activerecord-jdbcderby-adapter.gemspec
@@ -13,7 +13,6 @@ Gem::Specification.new do |gem|
   gem.homepage = 'https://github.com/jruby/activerecord-jdbc-adapter'
   gem.license = "BSD"
 
-  gem.rubyforge_project = %q{jruby-extras}
   gem.summary = %q{Derby JDBC adapter for JRuby on Rails.}
 
   gem.require_paths = ["lib"]


### PR DESCRIPTION
The RubyGems gemspec property `rubyforge_project` has been removed without a replacement. This PR removes that property.

## Background

* [RubyForge was closed down in 2013][1].
* [rubygems/rubygems#2436 deprecated the `rubyforge_project` property][2].

[1]: https://twitter.com/evanphx/status/399552820380053505
[2]: rubygems/rubygems#2436