### PR TITLE
Drop gemspec property rubyforge_project

### DIFF
--- a/activerecord-jdbch2-adapter/activerecord-jdbch2-adapter.gemspec
+++ b/activerecord-jdbch2-adapter/activerecord-jdbch2-adapter.gemspec
@@ -14,7 +14,6 @@ Gem::Specification.new do |gem|
   gem.license = "BSD"
 
   gem.homepage = %q{https://github.com/jruby/activerecord-jdbc-adapter}
-  gem.rubyforge_project = %q{jruby-extras}
   gem.summary = %q{H2 JDBC adapter for JRuby on Rails.}
 
   gem.require_paths = ["lib"]

--- a/activerecord-jdbchsqldb-adapter/activerecord-jdbchsqldb-adapter.gemspec
+++ b/activerecord-jdbchsqldb-adapter/activerecord-jdbchsqldb-adapter.gemspec
@@ -13,7 +13,6 @@ Gem::Specification.new do |gem|
   gem.homepage = 'https://github.com/jruby/activerecord-jdbc-adapter'
   gem.license = "BSD"
 
-  gem.rubyforge_project = %q{jruby-extras}
   gem.summary = %q{HSQLDB JDBC adapter for JRuby on Rails.}
 
   gem.require_paths = ["lib"]

--- a/activerecord-jdbcmssql-adapter/activerecord-jdbcmssql-adapter.gemspec
+++ b/activerecord-jdbcmssql-adapter/activerecord-jdbcmssql-adapter.gemspec
@@ -13,7 +13,6 @@ Gem::Specification.new do |gem|
   gem.homepage = 'https://github.com/jruby/activerecord-jdbc-adapter'
   gem.license = "BSD"
 
-  gem.rubyforge_project = %q{jruby-extras}
   gem.summary = %q{MS_SQL JDBC adapter for JRuby on Rails.}
 
   gem.require_paths = ["lib"]

--- a/activerecord-jdbcmysql-adapter/activerecord-jdbcmysql-adapter.gemspec
+++ b/activerecord-jdbcmysql-adapter/activerecord-jdbcmysql-adapter.gemspec
@@ -13,7 +13,6 @@ Gem::Specification.new do |gem|
   gem.homepage = 'https://github.com/jruby/activerecord-jdbc-adapter'
   gem.license = "BSD"
 
-  gem.rubyforge_project = %q{jruby-extras}
   gem.summary = %q{MySQL JDBC adapter for JRuby on Rails.}
 
   gem.require_paths = ["lib"]

--- a/activerecord-jdbcpostgresql-adapter/activerecord-jdbcpostgresql-adapter.gemspec
+++ b/activerecord-jdbcpostgresql-adapter/activerecord-jdbcpostgresql-adapter.gemspec
@@ -13,7 +13,6 @@ Gem::Specification.new do |gem|
   gem.homepage = 'https://github.com/jruby/activerecord-jdbc-adapter'
   gem.license = "BSD"
 
-  gem.rubyforge_project = %q{jruby-extras}
   gem.summary = %q{Postgres JDBC adapter for JRuby on Rails.}
 
   gem.require_paths = ["lib"]

--- a/activerecord-jdbcsqlite3-adapter/activerecord-jdbcsqlite3-adapter.gemspec
+++ b/activerecord-jdbcsqlite3-adapter/activerecord-jdbcsqlite3-adapter.gemspec
@@ -14,7 +14,6 @@ Gem::Specification.new do |gem|
   gem.license = "BSD"
 
   gem.homepage = %q{https://github.com/jruby/activerecord-jdbc-adapter}
-  gem.rubyforge_project = %q{jruby-extras}
   gem.summary = %q{Sqlite3 JDBC adapter for JRuby on Rails.}
 
   gem.require_paths = ["lib"]


### PR DESCRIPTION
The RubyGems gemspec property `rubyforge_project` has been removed without a replacement. This PR removes that property.

## Background

* [RubyForge was closed down in 2013][1].
* [rubygems/rubygems#2436 deprecated the `rubyforge_project` property][2].

[1]: https://twitter.com/evanphx/status/399552820380053505
[2]: rubygems/rubygems#2436