### PR TITLE
[mysql, postgres] respect driver_name from jdbc gems

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,6 @@
 language: ruby
 sudo: false
-branches:
-  only:
-  - master
-  - /.*-stable$/
-  - /^test-.*/
-  - /maintenance|support/
-  - /.*dev$/
+
 bundler_args: --without development
 script: bundle exec rake ${TEST_PREFIX}test_$DB
 before_install:

--- a/activerecord-jdbcmysql-adapter/activerecord-jdbcmysql-adapter.gemspec
+++ b/activerecord-jdbcmysql-adapter/activerecord-jdbcmysql-adapter.gemspec
@@ -20,5 +20,5 @@ Gem::Specification.new do |gem|
   gem.files = `git ls-files`.split("\n") # assuming . working directory
 
   gem.add_dependency 'activerecord-jdbc-adapter', "#{version}"
-  gem.add_dependency 'jdbc-mysql', '~> 5.1.36' #, '< 8'
+  gem.add_dependency 'jdbc-mysql', '~> 5.1.36', '< 9'
 end

--- a/lib/arjdbc/mysql/connection_methods.rb
+++ b/lib/arjdbc/mysql/connection_methods.rb
@@ -39,7 +39,8 @@ ArJdbc::ConnectionMethods.module_eval do
 
     properties = ( config[:properties] ||= {} )
     if mysql_driver
-      properties['zeroDateTimeBehavior'] ||= 'convertToNull'
+      properties['zeroDateTimeBehavior'] ||=
+        config[:driver].to_s.start_with?('com.mysql.cj.') ? 'CONVERT_TO_NULL' : 'convertToNull'
       properties['jdbcCompliantTruncation'] ||= false
       # NOTE: this is "better" than passing what users are used to set on MRI
       # e.g. 'utf8mb4' will fail cause the driver will check for a Java charset

--- a/lib/arjdbc/mysql/connection_methods.rb
+++ b/lib/arjdbc/mysql/connection_methods.rb
@@ -10,17 +10,20 @@ ArJdbc::ConnectionMethods.module_eval do
 
     return jndi_connection(config) if jndi_config?(config)
 
-    driver = config[:driver] ||=
-      defined?(::Jdbc::MySQL.driver_name) ? ::Jdbc::MySQL.driver_name : 'com.mysql.jdbc.Driver'
-
-    mysql_driver = driver.start_with?('com.mysql.')
-    mariadb_driver = ! mysql_driver && driver.start_with?('org.mariadb.')
+    driver = config[:driver]
+    mysql_driver = driver.nil? || driver.to_s.start_with?('com.mysql.')
+    mariadb_driver = ! mysql_driver && driver.to_s.start_with?('org.mariadb.')
 
     begin
       require 'jdbc/mysql'
       ::Jdbc::MySQL.load_driver(:require) if defined?(::Jdbc::MySQL.load_driver)
     rescue LoadError # assuming driver.jar is on the class-path
     end if mysql_driver
+
+    if driver.nil?
+      config[:driver] ||=
+        defined?(::Jdbc::MySQL.driver_name) ? ::Jdbc::MySQL.driver_name : 'com.mysql.jdbc.Driver'
+    end
 
     config[:username] = 'root' unless config.key?(:username)
     # jdbc:mysql://[host][,failoverhost...][:port]/[database]
@@ -108,7 +111,8 @@ ArJdbc::ConnectionMethods.module_eval do
     rescue LoadError # assuming driver.jar is on the class-path
     end
 
-    config[:driver] ||= 'org.mariadb.jdbc.Driver'
+    config[:driver] ||=
+      defined?(::Jdbc::MariaDB.driver_name) ? ::Jdbc::MariaDB.driver_name : 'org.mariadb.jdbc.Driver'
 
     mysql_connection(config)
   end

--- a/lib/arjdbc/postgresql/connection_methods.rb
+++ b/lib/arjdbc/postgresql/connection_methods.rb
@@ -16,7 +16,8 @@ ArJdbc::ConnectionMethods.module_eval do
       ::Jdbc::Postgres.load_driver(:require) if defined?(::Jdbc::Postgres.load_driver)
     rescue LoadError # assuming driver.jar is on the class-path
     end
-    driver = config[:driver] ||= 'org.postgresql.Driver'
+    driver = (config[:driver] ||=
+      defined?(::Jdbc::Postgres.driver_name) ? ::Jdbc::Postgres.driver_name : 'org.postgresql.Driver')
 
     host = config[:host] ||= ( config[:hostaddr] || ENV['PGHOST'] || 'localhost' )
     port = config[:port] ||= ( ENV['PGPORT'] || 5432 )

--- a/test/db/mysql/simple_test.rb
+++ b/test/db/mysql/simple_test.rb
@@ -424,9 +424,10 @@ class MySQLSimpleTest < Test::Unit::TestCase
       assert error.error_code.is_a?(Fixnum)
       assert error.sql_state
 
+      # MySQL driver 5.1 :
       # #<ActiveRecord::JDBCError: com.mysql.jdbc.exceptions.jdbc4.MySQLSyntaxErrorException: Table 'arjdbc_test.bogus' doesn't exist>
       unless mariadb_driver?
-        assert_match /com.mysql.jdbc.exceptions.jdbc4.MySQLSyntaxErrorException: Table '.*?bogus' doesn't exist/, error.message
+        assert_match(/SQLSyntaxErrorException: Table '.*?bogus' doesn't exist/, error.message)
       else
         assert_match /java.sql.SQLSyntaxErrorException: .*Table '.*?bogus' doesn't exist/, error.message
       end

--- a/test/db/mysql/unit_test.rb
+++ b/test/db/mysql/unit_test.rb
@@ -109,6 +109,117 @@ class MySQLUnitTest < Test::Unit::TestCase
       assert config[:adapter_class]
     end
 
+    test 'configuration attempts to load MySQL driver by default' do
+      load_jdbc_mysql
+
+      connection_handler = connection_handler_stub
+
+      config = { database: 'MyDB' }
+      connection_handler.expects(:jdbc_connection)
+      ::Jdbc::MySQL.expects(:load_driver).with(:require)
+      connection_handler.mysql_connection config
+    end
+
+    test 'configuration uses driver_name from Jdbc::MySQL' do
+      load_jdbc_mysql
+
+      connection_handler = connection_handler_stub
+
+      config = { database: 'MyDB' }
+      connection_handler.expects(:jdbc_connection)
+      ::Jdbc::MySQL.expects(:driver_name).returns('com.mysql.CustomDriver')
+      connection_handler.mysql_connection config
+      assert_equal 'com.mysql.CustomDriver', config[:driver]
+    end
+
+    test 'configuration sets up properties according to connector/j driver (>= 8.0)' do
+      load_jdbc_mysql
+
+      connection_handler = connection_handler_stub
+
+      config = { database: 'MyDB' }
+      connection_handler.expects(:jdbc_connection)
+      ::Jdbc::MySQL.expects(:driver_name).returns('com.mysql.cj.jdbc.Driver')
+      connection_handler.mysql_connection config
+      assert_equal 'com.mysql.cj.jdbc.Driver', config[:driver]
+      assert_equal 'CONVERT_TO_NULL', config[:properties]['zeroDateTimeBehavior']
+      assert_equal false, config[:properties]['useLegacyDatetimeCode']
+      assert_equal false, config[:properties]['jdbcCompliantTruncation']
+      assert_equal false, config[:properties]['useSSL']
+    end
+
+    def load_jdbc_mysql
+      require 'jdbc/mysql'
+    end
+
+  end
+
+  context 'connection (Jdbc::MySQL missing)' do
+
+    module ::Jdbc; end
+
+    @@jdbc_mysql = ::Jdbc::MySQL rescue nil
+
+    def setup
+      ::Jdbc.send :remove_const, :MySQL if @@jdbc_mysql
+    end
+
+    def teardown
+      ::Jdbc.const_set :MySQL, @@jdbc_mysql if @@jdbc_mysql
+    end
+
+    test 'configuration sets url and properties assuming mysql driver (<= 5.1)' do
+      connection_handler = connection_handler_stub
+
+      config = { host: '127.0.0.1', database: 'MyDB' }
+      connection_handler.expects(:jdbc_connection)
+      connection_handler.mysql_connection config
+
+      # we do not complete username/database etc :
+      assert_equal 'root', config[:username]
+      assert_equal 'com.mysql.jdbc.Driver', config[:driver]
+      assert_equal 'jdbc:mysql://127.0.0.1/MyDB', config[:url]
+      assert_equal 'UTF-8', config[:properties]['characterEncoding']
+      assert_equal 'convertToNull', config[:properties]['zeroDateTimeBehavior']
+      assert_equal false, config[:properties]['useLegacyDatetimeCode']
+      assert_equal false, config[:properties]['jdbcCompliantTruncation']
+      assert_equal false, config[:properties]['useSSL']
+    end
+
+    test 'configuration attempts to load MySQL driver by default' do
+      connection_handler = connection_handler_stub
+
+      config = { database: 'MyDB' }
+      connection_handler.expects(:jdbc_connection)
+      connection_handler.expects(:require).with('jdbc/mysql')
+      connection_handler.mysql_connection config
+    end
+
+    test 'configuration allows to skip driver loading' do
+      connection_handler = connection_handler_stub
+
+      config = { database: 'MyDB', driver: false }
+      connection_handler.expects(:jdbc_connection)
+      connection_handler.expects(:require).never
+      connection_handler.mysql_connection config
+      assert_not config[:driver] # allow Java's service discovery mechanism (with connector/j 8.0)
+    end
+
+    test 'configuration works with MariaDB driver specified' do
+      connection_handler = connection_handler_stub
+
+      config = { database: 'MyDB', driver: 'org.mariadb.jdbc.Driver' }
+      connection_handler.expects(:jdbc_connection)
+      connection_handler.mysql_connection config
+
+      # we do not complete username/database etc :
+      assert_equal 'root', config[:username]
+      assert_equal 'org.mariadb.jdbc.Driver', config[:driver]
+      assert_equal 'jdbc:mysql://localhost/MyDB', config[:url]
+      assert_equal false, config[:properties]['useLegacyDatetimeCode']
+      assert_equal false, config[:properties]['useSsl']
+    end
+
   end
 
 end if defined? JRUBY_VERSION


### PR DESCRIPTION
this is mostly a preparation for supporting the new major version of MySQL Connector/J (8.0)
... which changed the driver class name

AR-JDBC (at least currently supported AR versions) should work with both major driver versions
... to ease the transition

and since there's no limiting of the jdbc-mysql gem in our helper gem (activerecord-jdbcmysql-adapter), we should delay releasing the MySQL driver (8.0) till new versions of AR-JDBC incorporating support are released