### PR TITLE
[ci] use PostgreSQL 10 (as default)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,9 +60,11 @@ matrix:
     - env: DB=mysql2 DRIVER=MariaDB
 
     - env: DB=postgresql PREPARED_STATEMENTS=false INSERT_RETURNING=false
+    - env: DB=postgresql PREPARED_STATEMENTS=false INSERT_RETURNING=true
     - addons:
         postgresql: "9.4"
       env: DB=postgresql PREPARED_STATEMENTS=false INSERT_RETURNING=true
+    - env: DB=postgresql PREPARED_STATEMENTS=true
     - addons:
         postgresql: "9.6"
       env: DB=postgresql PREPARED_STATEMENTS=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ dist: xenial
 services:
   - mysql
 addons:
-  postgresql: 9.4
+  postgresql: 10
 
 before_install:
   - unset _JAVA_OPTIONS
@@ -59,14 +59,12 @@ matrix:
     - env: DB=mysql2 PREPARED_STATEMENTS=true
     - env: DB=mysql2 DRIVER=MariaDB
 
-    - addons:
-        postgresql: "9.4"
-      env: DB=postgresql PREPARED_STATEMENTS=false INSERT_RETURNING=false
+    - env: DB=postgresql PREPARED_STATEMENTS=false INSERT_RETURNING=false
     - addons:
         postgresql: "9.4"
       env: DB=postgresql PREPARED_STATEMENTS=false INSERT_RETURNING=true
     - addons:
-        postgresql: "9.4"
+        postgresql: "9.6"
       env: DB=postgresql PREPARED_STATEMENTS=true
     - addons:
         postgresql: "9.4"
@@ -83,8 +81,6 @@ matrix:
       jdk: oraclejdk11
     - env: DB=postgresql
       jdk: oraclejdk11
-      addons:
-        postgresql: "9.4"
     - env: DB=sqlite3
       jdk: oraclejdk11
 
@@ -93,8 +89,6 @@ matrix:
       env: DB=mysql2
     - rvm: jruby-head
       env: DB=postgresql
-      addons:
-        postgresql: "9.4"
     - rvm: jruby-head
       env: DB=sqlite3
 
@@ -111,11 +105,7 @@ matrix:
     - env: DB=mysql2     TEST_PREFIX="rails:" AR_VERSION="6-0-stable" PREPARED_STATEMENTS=true
     - env: DB=mysql2     TEST_PREFIX="rails:" AR_VERSION="6-0-stable" DRIVER=MariaDB
 
-    - addons:
-        postgresql: "9.4"
-      env: DB=postgresql TEST_PREFIX="rails:" AR_VERSION="6-0-stable" # PS on by default
-    - addons:
-        postgresql: "9.4"
-      env: DB=postgresql TEST_PREFIX="rails:" AR_VERSION="6-0-stable" PREPARED_STATEMENTS=false
+    - env: DB=postgresql TEST_PREFIX="rails:" AR_VERSION="6-0-stable" # PS on by default
+    - env: DB=postgresql TEST_PREFIX="rails:" AR_VERSION="6-0-stable" PREPARED_STATEMENTS=false
 
     - env: DB=sqlite3    TEST_PREFIX="rails:" AR_VERSION="6-0-stable"


### PR DESCRIPTION
match up Rails 6-0-stable, currently this has one failure in the Rails suite (compared to 9.4)