### PR TITLE
postgreSQL fixes from master

### DIFF
--- a/lib/arjdbc/abstract/database_statements.rb
+++ b/lib/arjdbc/abstract/database_statements.rb
@@ -10,6 +10,8 @@ module ArJdbc
       NO_BINDS = [].freeze
 
       def exec_insert(sql, name = nil, binds = NO_BINDS, pk = nil, sequence_name = nil)
+        binds = convert_legacy_binds_to_attributes(binds) if binds.first.is_a?(Array)
+
         if without_prepared_statement?(binds)
           log(sql, name) { @connection.execute_insert(sql) }
         else
@@ -22,6 +24,8 @@ module ArJdbc
       # It appears that at this point (AR 5.0) "prepare" should only ever be true
       # if prepared statements are enabled
       def exec_query(sql, name = nil, binds = NO_BINDS, prepare: false)
+        binds = convert_legacy_binds_to_attributes(binds) if binds.first.is_a?(Array)
+
         if without_prepared_statement?(binds)
           log(sql, name) { @connection.execute_query(sql) }
         else
@@ -34,6 +38,8 @@ module ArJdbc
       end
 
       def exec_update(sql, name = nil, binds = NO_BINDS)
+        binds = convert_legacy_binds_to_attributes(binds) if binds.first.is_a?(Array)
+
         if without_prepared_statement?(binds)
           log(sql, name) { @connection.execute_update(sql) }
         else

--- a/lib/arjdbc/postgresql/column.rb
+++ b/lib/arjdbc/postgresql/column.rb
@@ -15,7 +15,7 @@ module ArJdbc
       end
 
       # Extracts the value from a PostgreSQL column default definition.
-      def extract_value_from_default(default) # :nodoc:
+      def extract_value_from_default(default)
         case default
           # Quoted types
           when /\A[\(B]?'(.*)'.*::"?([\w. ]+)"?(?:\[\])?\z/m
@@ -41,10 +41,13 @@ module ArJdbc
         end
       end
 
-      def extract_default_function(default_value, default) # :nodoc:
-        default if ! default_value && ( %r{\w+\(.*\)|\(.*\)::\w+} === default )
+      def extract_default_function(default_value, default)
+        default if has_default_function?(default_value, default)
       end
 
+      def has_default_function?(default_value, default)
+        !default_value && %r{\w+\(.*\)|\(.*\)::\w+|CURRENT_DATE|CURRENT_TIMESTAMP} === default
+      end
     end
 
   end


### PR DESCRIPTION
Here we have
* better support PG v10 and higher for 5x regarding schema dump and default values. This is already in master but with a minor syntax detail changed for JRuby 9.1 support.
* Legacy binds. This is already in 52-stable. Not that important.