### PR TITLE
Rails 6.0 fixes

### DIFF
--- a/lib/arjdbc/postgresql/adapter.rb
+++ b/lib/arjdbc/postgresql/adapter.rb
@@ -384,7 +384,11 @@ module ArJdbc
     end
 
     def execute_batch(statements, name = nil)
-      execute(combine_multi_statements(statements), name)
+      if statements.is_a? Array
+        execute(combine_multi_statements(statements), name)
+      else
+        execute(statements, name)
+      end
     end
 
     def explain(arel, binds = [])
@@ -444,8 +448,13 @@ module ArJdbc
       sql
     end
 
-    def build_truncate_statements(table_names)
-      ["TRUNCATE TABLE #{table_names.map(&method(:quote_table_name)).join(", ")}"]
+    def build_truncate_statements(*table_names)
+      ["TRUNCATE TABLE #{table_names.flatten.map(&method(:quote_table_name)).join(", ")}"]
+    end
+
+    def truncate(table_name, name = nil)
+      ActiveRecord::Base.clear_query_caches_for_current_thread if @query_cache_enabled
+      execute("TRUNCATE TABLE #{quote_table_name(table_name)}", name)
     end
 
     def all_schemas

--- a/lib/arjdbc/sqlite3/adapter.rb
+++ b/lib/arjdbc/sqlite3/adapter.rb
@@ -327,6 +327,15 @@ module ArJdbc
       "DELETE FROM #{quote_table_name(table_name)}"
     end
 
+    def build_truncate_statements(*table_names)
+      table_names.flatten.map { |table_name| build_truncate_statement table_name }
+    end
+
+    def truncate(table_name, name = nil)
+      ActiveRecord::Base.clear_query_caches_for_current_thread if @query_cache_enabled
+      execute(build_truncate_statement(table_name), name)
+    end
+
     def check_version
       if database_version < "3.8.0"
         raise "Your version of SQLite (#{database_version}) is too old. Active Record supports SQLite >= 3.8."

--- a/lib/arjdbc/sqlite3/adapter.rb
+++ b/lib/arjdbc/sqlite3/adapter.rb
@@ -364,7 +364,8 @@ module ArJdbc
     # See: https://www.sqlite.org/lang_altertable.html
     # SQLite has an additional restriction on the ALTER TABLE statement
     def invalid_alter_table_type?(type, options)
-      type.to_sym == :primary_key || options[:primary_key]
+      type.to_sym == :primary_key || options[:primary_key] ||
+        options[:null] == false && options[:default].nil?
     end
 
     def alter_table(table_name, foreign_keys = foreign_keys(table_name), **options)

--- a/lib/arjdbc/sqlite3/adapter.rb
+++ b/lib/arjdbc/sqlite3/adapter.rb
@@ -97,6 +97,10 @@ module ArJdbc
       true
     end
 
+    def supports_common_table_expressions?
+      database_version >= "3.8.3"
+    end
+
     def supports_insert_on_conflict?
       database_version >= "3.24.0"
     end
@@ -154,7 +158,9 @@ module ArJdbc
     # DATABASE STATEMENTS ======================================
     #++
 
-    READ_QUERY = ActiveRecord::ConnectionAdapters::AbstractAdapter.build_read_query_regexp(:begin, :commit, :explain, :select, :pragma, :release, :savepoint, :rollback) # :nodoc:
+    READ_QUERY = ActiveRecord::ConnectionAdapters::AbstractAdapter.build_read_query_regexp(
+      :begin, :commit, :explain, :select, :pragma, :release, :savepoint, :rollback, :with
+    ) # :nodoc:
     private_constant :READ_QUERY
 
     def write_query?(sql) # :nodoc:
@@ -317,11 +323,8 @@ module ArJdbc
       SQLite3Adapter::Version.new(query_value("SELECT sqlite_version(*)"))
     end
 
-    def build_truncate_statements(*table_names)
-      truncate_tables = table_names.map do |table_name|
-        "DELETE FROM #{quote_table_name(table_name)}"
-      end
-      combine_multi_statements(truncate_tables)
+    def build_truncate_statement(table_name)
+      "DELETE FROM #{quote_table_name(table_name)}"
     end
 
     def check_version


### PR DESCRIPTION
This fixes things with 6-0-stable branch again. The first and last commit is actually stuff that is already on master. Problem is that this alone would break the current stable Rails 6.0.2 because of an internal API change that got back-ported from 6.1. The commit in the middle fixes this.

This will cause a merge-conflict during 60-stable -> master merge. Resolution is simple: master shouldn't change 😉 