### PR TITLE
Fix #1073 NameError: method 'bind_block' not defined in Arel::Visitors::PostgreSQL

### DIFF
--- a/lib/arel/visitors/postgresql_jdbc.rb
+++ b/lib/arel/visitors/postgresql_jdbc.rb
@@ -2,5 +2,11 @@ require 'arel/visitors/compat'
 
 class Arel::Visitors::PostgreSQL
   # AREL converts bind argument markers "?" to "$n" for PG, but JDBC wants "?".
-  remove_method :bind_block
+  
+  # To fix, BIND_BLOCK is overloaded. The original looks like:
+  # BIND_BLOCK = proc { |i| "$#{i}" }  
+  BIND_BLOCK = proc { "?" }
+  private_constant :BIND_BLOCK
+
+  def bind_block; BIND_BLOCK; end
 end


### PR DESCRIPTION
https://github.com/jruby/activerecord-jdbc-adapter/issues/1073

This fixes the bind_block error.