### PR TITLE
Bump activerecord dependency

### DIFF
--- a/activerecord-jdbc-adapter.gemspec
+++ b/activerecord-jdbc-adapter.gemspec
@@ -41,7 +41,7 @@ Gem::Specification.new do |gem|
   gem.executables = gem.files.grep(%r{^bin/}).map { |f| File.basename(f) }
   gem.test_files = gem.files.grep(%r{^test/})
 
-  gem.add_dependency 'activerecord', '~> 6.1.0'
+  gem.add_dependency 'activerecord', '~> 7.0.0'
 
   #gem.add_development_dependency 'test-unit', '2.5.4'
   #gem.add_development_dependency 'test-unit-context', '>= 0.3.0'


### PR DESCRIPTION
So that Rails 7.0 can be tried against the main branch.

---

Hi, 👋🏼 👋🏼 

this is my first attempt to contribute to this project

While trying to upgrade ActiveAdmin to Rails 7.0, we've noticed that `activerecord-jdbc-adapter` unexpectedly downgrades to version 50.0, and that happens because it is the last version with an open dependency constraint (`activerecord >= 2.2`)

I understand that this change is probably not enough to ensure Rails 7.0 compatibility but I'm submitting because I can't find a request to add Rails 7.0 compatibility

Ref: #1076 activeadmin/activeadmin#7235
