### PR TITLE
Replace git.io URL

### DIFF
--- a/lib/arjdbc/jdbc/adapter.rb
+++ b/lib/arjdbc/jdbc/adapter.rb
@@ -431,7 +431,7 @@ module ActiveRecord
       private
 
       # Helper useful during {#quote} since AREL might pass in it's literals
-      # to be quoted, fixed since AREL 4.0.0.beta1 : http://git.io/7gyTig
+      # to be quoted, fixed since AREL 4.0.0.beta1 : https://github.com/rails/arel/commit/9c514f3
       def sql_literal?(value); ::Arel::Nodes::SqlLiteral === value; end
 
       # Helper to get local/UTC time (based on `ActiveRecord::Base.default_timezone`).

--- a/lib/arjdbc/util/table_copier.rb
+++ b/lib/arjdbc/util/table_copier.rb
@@ -4,7 +4,8 @@ module ArJdbc
   module Util
     module TableCopier
 
-      # taken from SQLite adapter, code loosely based on http://git.io/P7tFQA
+      # taken from SQLite adapter, code loosely based on
+      # https://github.com/rails/rails/blob/d3e5118/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
 
       # Performs changes for table by first copying (and preserving contents)
       # into another (temporary) table, than alters and copies all data back.


### PR DESCRIPTION
Hi,

git.io URL has been deprecated, and it will stop redirecting on April 29, 2022.

For more detail:
https://github.blog/changelog/2022-04-25-git-io-deprecation/