### PR TITLE
[chore] adjust update benchmark code

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -98,7 +98,7 @@ group :test do
 
   gem 'mysql2', '>= 0.4.4', require: nil, platform: :mri
   gem 'pg', '>= 0.18.0', require: nil, platform: :mri
-  gem 'sqlite3', '~> 1.3.6', require: nil, platform: :mri
+  gem 'sqlite3', '~> 1.4', require: nil, platform: :mri
 
   # group :mssql do
   #   gem 'tiny_tds', require: nil, platform: :mri

--- a/Gemfile
+++ b/Gemfile
@@ -44,7 +44,13 @@ elsif ENV['AR_VERSION'] # Use specific version of AR and not .gemspec version
     end
   end
 else
-  gemspec name: 'activerecord-jdbc-adapter' # Use versiom from .gemspec
+  if defined? JRUBY_VERSION
+    gemspec name: 'activerecord-jdbc-adapter' # Use versiom from .gemspec
+  else # read add_dependency 'activerecord', '~> 7.0' and use the same requirement on MRI
+    ar_req = File.read('activerecord-jdbc-adapter.gemspec').match(/add_dependency.*?activerecord.*['"](.*?)['"]/)[1]
+    raise "add_dependency 'activerecord', ... line not detected in gemspec" unless ar_req
+    gem 'activerecord', ar_req
+  end
 end
 
 gem 'rake', require: nil

--- a/Gemfile
+++ b/Gemfile
@@ -83,7 +83,7 @@ group :rails do
 end
 
 group :development do
-  gem 'ruby-debug', require: nil # if ENV['DEBUG']
+  #gem 'ruby-debug', require: nil # if ENV['DEBUG']
   group :doc do
     gem 'yard', require: nil
     gem 'kramdown', require: nil

--- a/bench/benchmark_create.rb
+++ b/bench/benchmark_create.rb
@@ -36,12 +36,12 @@ Benchmark.ips do |x|
     label = value
     label = "#{value[0,16]}...(#{value.size})" if value.is_a?(String) && value.size > 16
     x.report("BenchRecord.create('#{field}' => #{label.inspect})") do
-      BenchRecord.create(field => value)
+      BenchRecord.create!(field => value)
     end
   end
 
   x.report("BenchRecord.create(...)") do
-    BenchRecord.create(fields.dup)
+    BenchRecord.create!(fields.dup)
   end
 
 end

--- a/bench/benchmark_update.rb
+++ b/bench/benchmark_update.rb
@@ -27,25 +27,29 @@ fields = {
 
 empty = {}
 
+record_1 = BenchRecord.create.reload
+record_2 = BenchRecord.create.reload
+record_3 = BenchRecord.create.reload
+def record_3.changed_attribute_names_to_save; attribute_names end # will always update all attributes
+
 Benchmark.ips do |x|
   x.config(:suite => BenchTestHelper::Suite::INSTANCE)
 
-  record = BenchRecord.create.reload
-  x.report("BenchRecord#update()") do
-    record.update empty
+  x.report("BenchRecord#update() [NOOP]") do
+    record_1.update! empty # base-line expected to be a no-op
   end
 
   fields.each do |field, value|
     label = value
     label = "#{value[0,16]}...(#{value.size})" if value.is_a?(String) && value.size > 16
-    record = BenchRecord.create.reload
     x.report("BenchRecord#update('#{field}' => #{label.inspect})") do
-      record.update(field => value)
+      record_2.send "#{field}_will_change!" # forces the change even if the value did not change
+      record_2.update!(field => value)
     end
   end
 
   x.report("BenchRecord#update(...)") do
-    record.update(fields)
+    record_3.update!(fields)
   end
 
 end


### PR DESCRIPTION
following up on https://github.com/jruby/activerecord-jdbc-adapter/pull/1115 - mostly to make the update benchmark "useful" ...

each `update!` operation will now enforce an actual DB `UPDATE ...`, numbers:

### MRI 2.7.5

```
--- RUBY_VERSION: 2.7.5
--- ActiveRecord: 7.0.3

 - BenchRecord.connection.drop_table(:bench_records) took 0.01099091
 - BenchRecord.connection.create_table(:bench_records) { ... } took 0.002893369

Warming up --------------------------------------
BenchRecord#update() [NOOP]
                       210.000  i/100ms
BenchRecord#update('a_binary' => "|vR*:\xCA\xA5\xA3\\\x0Ei\xEE\x98\xC4\xE6\xAF...(1536)")
                       159.000  i/100ms
BenchRecord#update('a_boolean' => true)
                        87.000  i/100ms
BenchRecord#update('a_date' => Tue, 17 May 2022)
                        64.000  i/100ms
BenchRecord#update('a_datetime' => Tue, 17 May 2022 09:16:33 +0200)
                        53.000  i/100ms
BenchRecord#update('a_decimal' => 0.123456789055555e10)
                        49.000  i/100ms
BenchRecord#update('a_float' => 999.99)
                        44.000  i/100ms
BenchRecord#update('a_integer' => 4242)
                        40.000  i/100ms
BenchRecord#update('a_string' => "BORAT Ipsum!")
                        38.000  i/100ms
BenchRecord#update('a_text' => "Kazakhstan is th...(464)")
                        35.000  i/100ms
BenchRecord#update('a_time' => 2022-05-17 09:16:33.034207129 +0200)
                        33.000  i/100ms
BenchRecord#update('a_timestamp' => 2022-05-17 09:16:33.034209926 +0200)
                        31.000  i/100ms
BenchRecord#update(...)
                        28.000  i/100ms
Calculating -------------------------------------
BenchRecord#update() [NOOP]
                        719.840  (±19.0%) i/s -      3.570k in   5.135364s
BenchRecord#update('a_binary' => "|vR*:\xCA\xA5\xA3\\\x0Ei\xEE\x98\xC4\xE6\xAF...(1536)")
                        297.178  (± 3.4%) i/s -      1.590k in   5.355845s
BenchRecord#update('a_boolean' => true)
                        267.203  (± 3.0%) i/s -      1.392k in   5.213965s
BenchRecord#update('a_date' => Tue, 17 May 2022)
                        230.367  (±14.8%) i/s -      1.152k in   5.165145s
BenchRecord#update('a_datetime' => Tue, 17 May 2022 09:16:33 +0200)
                        228.270  (± 2.2%) i/s -      1.166k in   5.110086s
BenchRecord#update('a_decimal' => 0.123456789055555e10)
                        216.606  (± 1.8%) i/s -      1.127k in   5.204703s
BenchRecord#update('a_float' => 999.99)
                        205.377  (± 1.9%) i/s -      1.056k in   5.143555s
BenchRecord#update('a_integer' => 4242)
                        184.553  (±15.7%) i/s -    920.000  in   5.173868s
BenchRecord#update('a_string' => "BORAT Ipsum!")
                        185.404  (± 4.3%) i/s -    950.000  in   5.135944s
BenchRecord#update('a_text' => "Kazakhstan is th...(464)")
                        178.247  (± 2.2%) i/s -    910.000  in   5.107842s
BenchRecord#update('a_time' => 2022-05-17 09:16:33.034207129 +0200)
                        171.348  (± 1.8%) i/s -    858.000  in   5.009028s
BenchRecord#update('a_timestamp' => 2022-05-17 09:16:33.034209926 +0200)
                        158.497  (±15.8%) i/s -    775.000  in   5.094515s
BenchRecord#update(...)
                        250.749  (±10.0%) i/s -      1.260k in   5.070571s

```

### JRuby 9.4 SNAPSHOT (Java 17) no-indy

```
--- RUBY_VERSION: 3.1.0 (JRUBY_VERSION: 9.4.0.0-SNAPSHOT 17.0.3+7)
    JRUBY_OPTS = "-Xcompile.invokedynamic=false"
--- ActiveRecord: 7.0.3 (AR-JDBC: 70.0.pre 99b4c601)

 - BenchRecord.connection.drop_table(:bench_records) took 0.012343
 - BenchRecord.connection.create_table(:bench_records) { ... } took 0.008102

Warming up --------------------------------------
BenchRecord#update() [NOOP]
                       261.000  i/100ms
BenchRecord#update('a_binary' => "\x12\xA4\x11\xBF\xA9\a\x18m\xBA\xC2=\a\xC9\xCD\xA8\xC7...(1536)")
                       103.000  i/100ms
BenchRecord#update('a_boolean' => true)
                       197.000  i/100ms
BenchRecord#update('a_date' => Tue, 17 May 2022)
                       221.000  i/100ms
BenchRecord#update('a_datetime' => Tue, 17 May 2022 09:18:44 +0200)
                       264.000  i/100ms
BenchRecord#update('a_decimal' => 0.123456789055555e10)
                       302.000  i/100ms
BenchRecord#update('a_float' => 999.99)
                       319.000  i/100ms
BenchRecord#update('a_integer' => 4242)
                       328.000  i/100ms
BenchRecord#update('a_string' => "BORAT Ipsum!")
                       311.000  i/100ms
BenchRecord#update('a_text' => "Kazakhstan is th...(464)")
                       323.000  i/100ms
BenchRecord#update('a_time' => 2022-05-17 09:18:44.13612 +0200)
                       288.000  i/100ms
BenchRecord#update('a_timestamp' => 2022-05-17 09:18:44.136195 +0200)
                       307.000  i/100ms
BenchRecord#update(...)
                        23.000  i/100ms
Calculating -------------------------------------
BenchRecord#update() [NOOP]
                         11.063k (± 2.4%) i/s -     55.332k in   5.004339s
BenchRecord#update('a_binary' => "\x12\xA4\x11\xBF\xA9\a\x18m\xBA\xC2=\a\xC9\xCD\xA8\xC7...(1536)")
                          3.381k (± 3.5%) i/s -     16.892k in   5.002516s
BenchRecord#update('a_boolean' => true)
                          3.392k (± 1.9%) i/s -     17.139k in   5.054619s
BenchRecord#update('a_date' => Tue, 17 May 2022)
                          3.129k (±15.2%) i/s -     15.249k in   5.066312s
BenchRecord#update('a_datetime' => Tue, 17 May 2022 09:18:44 +0200)
                          3.145k (± 3.1%) i/s -     15.840k in   5.041702s
BenchRecord#update('a_decimal' => 0.123456789055555e10)
                          3.348k (± 2.0%) i/s -     16.912k in   5.053482s
BenchRecord#update('a_float' => 999.99)
                          3.393k (± 1.7%) i/s -     17.226k in   5.079147s
BenchRecord#update('a_integer' => 4242)
                          3.366k (± 2.5%) i/s -     17.056k in   5.070505s
BenchRecord#update('a_string' => "BORAT Ipsum!")
                          3.321k (± 2.3%) i/s -     16.794k in   5.059153s
BenchRecord#update('a_text' => "Kazakhstan is th...(464)")
                          3.290k (± 1.9%) i/s -     16.473k in   5.008530s
BenchRecord#update('a_time' => 2022-05-17 09:18:44.13612 +0200)
                          3.202k (± 2.1%) i/s -     16.128k in   5.038541s
BenchRecord#update('a_timestamp' => 2022-05-17 09:18:44.136195 +0200)
                          3.276k (± 1.6%) i/s -     16.578k in   5.062079s
BenchRecord#update(...)
                        242.297  (± 5.0%) i/s -      1.219k in   5.044220s

```

### JRuby 9.4 SNAPSHOT (Java 17) indy

```
--- RUBY_VERSION: 3.1.0 (JRUBY_VERSION: 9.4.0.0-SNAPSHOT 17.0.3+7)
    JRUBY_OPTS = "-Xcompile.invokedynamic=true"
--- ActiveRecord: 7.0.3 (AR-JDBC: 70.0.pre 99b4c601)

 - BenchRecord.connection.drop_table(:bench_records) took 0.030751
 - BenchRecord.connection.create_table(:bench_records) { ... } took 0.008308

Warming up --------------------------------------
BenchRecord#update() [NOOP]
                       231.000  i/100ms
BenchRecord#update('a_binary' => "\xB0\xC9q\x0F\xA1\xCF=\xFA&V\x10g\x9A\v9\x17...(1536)")
                        56.000  i/100ms
BenchRecord#update('a_boolean' => true)
                       150.000  i/100ms
BenchRecord#update('a_date' => Tue, 17 May 2022)
                       189.000  i/100ms
BenchRecord#update('a_datetime' => Tue, 17 May 2022 09:20:30 +0200)
                       172.000  i/100ms
BenchRecord#update('a_decimal' => 0.123456789055555e10)
                       180.000  i/100ms
BenchRecord#update('a_float' => 999.99)
                       225.000  i/100ms
BenchRecord#update('a_integer' => 4242)
                       329.000  i/100ms
BenchRecord#update('a_string' => "BORAT Ipsum!")
                       285.000  i/100ms
BenchRecord#update('a_text' => "Kazakhstan is th...(464)")
                       326.000  i/100ms
BenchRecord#update('a_time' => 2022-05-17 09:20:30.528412 +0200)
                       224.000  i/100ms
BenchRecord#update('a_timestamp' => 2022-05-17 09:20:30.528468 +0200)
                       310.000  i/100ms
BenchRecord#update(...)
                         6.000  i/100ms
Calculating -------------------------------------
BenchRecord#update() [NOOP]
                         17.934k (±27.9%) i/s -     75.306k in   5.000268s
BenchRecord#update('a_binary' => "\xB0\xC9q\x0F\xA1\xCF=\xFA&V\x10g\x9A\v9\x17...(1536)")
                          5.433k (±26.7%) i/s -     24.024k in   5.004684s
BenchRecord#update('a_boolean' => true)
                          6.088k (± 3.3%) i/s -     30.450k in   5.007451s
BenchRecord#update('a_date' => Tue, 17 May 2022)
                          5.551k (±16.0%) i/s -     26.649k in   4.999634s
BenchRecord#update('a_datetime' => Tue, 17 May 2022 09:20:30 +0200)
                          5.591k (± 3.5%) i/s -     28.036k in   5.021172s
BenchRecord#update('a_decimal' => 0.123456789055555e10)
                          6.127k (± 3.9%) i/s -     30.600k in   5.001905s
BenchRecord#update('a_float' => 999.99)
                          6.252k (± 3.9%) i/s -     31.275k in   5.010786s
BenchRecord#update('a_integer' => 4242)
                          6.304k (± 2.6%) i/s -     31.584k in   5.013855s
BenchRecord#update('a_string' => "BORAT Ipsum!")
                          6.170k (± 2.6%) i/s -     31.065k in   5.038119s
BenchRecord#update('a_text' => "Kazakhstan is th...(464)")
                          5.848k (± 2.8%) i/s -     29.340k in   5.021411s
BenchRecord#update('a_time' => 2022-05-17 09:20:30.528412 +0200)
                          5.639k (± 4.6%) i/s -     28.224k in   5.016502s
BenchRecord#update('a_timestamp' => 2022-05-17 09:20:30.528468 +0200)
                          5.842k (± 2.1%) i/s -     29.450k in   5.043538s
BenchRecord#update(...)
                         58.180  (± 5.2%) i/s -    294.000  in   5.065265s

```