### PR TITLE
Update check_all_foreign_keys_valid for Rails 7.1

### DIFF
--- a/lib/arjdbc/sqlite3/adapter.rb
+++ b/lib/arjdbc/sqlite3/adapter.rb
@@ -219,7 +219,22 @@ module ArJdbc
     end
 
     def all_foreign_keys_valid? # :nodoc:
-      execute("PRAGMA foreign_key_check").blank?
+      # Rails 7
+      check_all_foreign_keys_valid!
+      true
+    rescue ActiveRecord::StatementInvalid
+      false
+    end
+
+    def check_all_foreign_keys_valid! # :nodoc:
+      # Rails 7.1
+      sql = "PRAGMA foreign_key_check"
+      result = execute(sql)
+
+      unless result.blank?
+        tables = result.map { |row| row["table"] }
+        raise ActiveRecord::StatementInvalid.new("Foreign key violations found: #{tables.join(", ")}", sql: sql)
+      end
     end
 
     # SCHEMA STATEMENTS ========================================


### PR DESCRIPTION
ref: https://github.com/rails/rails/pull/47990

In Rails 7.1 (when that PR is merged), there will be a new method, `check_all_foreign_keys_valid!`, which adapters can implement to check foreign keys when fixtures are loaded. This PR just implements that method. The Rails 7 `all_foreign_keys_valid?` method is also preserved.