### PR TITLE
Use precision-accepting BigDecimal.newInstance

### DIFF
--- a/src/java/arjdbc/jdbc/RubyJdbcConnection.java
+++ b/src/java/arjdbc/jdbc/RubyJdbcConnection.java
@@ -2726,8 +2726,9 @@ public class RubyJdbcConnection extends RubyObject {
             statement.setDouble(index, ((RubyNumeric) value).getDoubleValue());
         }
         else { // e.g. `BigDecimal '42.00000000000000000001'`
+            Ruby runtime = context.runtime;
             statement.setBigDecimal(index,
-                    RubyBigDecimal.newInstance(context, context.runtime.getModule("BigDecimal"), value).getValue());
+                    RubyBigDecimal.newInstance(context, runtime.getModule("BigDecimal"), value, RubyFixnum.zero(runtime)).getValue());
         }
     }
 

--- a/src/java/arjdbc/sqlite3/SQLite3RubyJdbcConnection.java
+++ b/src/java/arjdbc/sqlite3/SQLite3RubyJdbcConnection.java
@@ -511,7 +511,8 @@ public class SQLite3RubyJdbcConnection extends RubyJdbcConnection {
             statement.setDouble(index, ((RubyNumeric) value).getDoubleValue());
         }
         else { // e.g. `BigDecimal '42.00000000000000000001'`
-            RubyBigDecimal val = RubyBigDecimal.newInstance(context, context.runtime.getModule("BigDecimal"), value);
+            Ruby runtime = context.runtime;
+            RubyBigDecimal val = RubyBigDecimal.newInstance(context, runtime.getModule("BigDecimal"), value, RubyFixnum.zero(runtime));
             statement.setString(index, val.getValue().toString());
         }
     }


### PR DESCRIPTION
Should fix compile issues on master but I'm not sure whether this method should be restored.