### PR TITLE
Drop upper bound on jdbc-sqlite3

### DIFF
--- a/activerecord-jdbcsqlite3-adapter/activerecord-jdbcsqlite3-adapter.gemspec
+++ b/activerecord-jdbcsqlite3-adapter/activerecord-jdbcsqlite3-adapter.gemspec
@@ -20,5 +20,5 @@ Gem::Specification.new do |gem|
   gem.files = `git ls-files`.split("\n") # assuming . working directory
 
   gem.add_dependency 'activerecord-jdbc-adapter', "#{version}"
-  gem.add_dependency 'jdbc-sqlite3', '~> 3.8', '< 3.34'
+  gem.add_dependency 'jdbc-sqlite3', '~> 3.8'
 end


### PR DESCRIPTION
Having this upper bound prevents updating jdbc-sqlite3 to any recent version, which in turn prevents Rails 6.1 + JRuby + MacOS + ARM64 from working due to the older sqlite JDBC drivers not having such support.

This commit removes the upper bound so that any newer 3.x jdbc-sqlite3 can be used with Rails 6.1 + JRuby.