### PR TITLE
Initial work to support Active Record 7.1 (Rails 7.1.x)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,7 @@ Gemfile.lock
 .settings
 activerecord-jdbc.iml
 lib/arjdbc/jdbc/adapter_java.jar
+.jrubyrc
+.rubocop.yml
+.solargraph.yml
+pik.sh

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,8 @@ nbproject
 .project
 *.sqlite
 *.sqlite3
+*.sqlite3-shm
+*.sqlite3-wal
 *.derby
 derby.log
 test.hsqldb*

--- a/activerecord-jdbc-adapter.gemspec
+++ b/activerecord-jdbc-adapter.gemspec
@@ -41,7 +41,7 @@ Gem::Specification.new do |gem|
   gem.executables = gem.files.grep(%r{^bin/}).map { |f| File.basename(f) }
   gem.test_files = gem.files.grep(%r{^test/})
 
-  gem.add_dependency 'activerecord', '~> 7.1.0'
+  gem.add_dependency 'activerecord', '~> 7.1.3'
 
   #gem.add_development_dependency 'test-unit', '2.5.4'
   #gem.add_development_dependency 'test-unit-context', '>= 0.3.0'

--- a/lib/arjdbc/abstract/connection_management.rb
+++ b/lib/arjdbc/abstract/connection_management.rb
@@ -36,10 +36,13 @@ module ArJdbc
       #  end
       # end
 
+      private
+
       # DIFFERENCE: we delve into jdbc shared code and this does self.class.new_client.
       def connect
-        @raw_connection = jdbc_connection_class(@config[:adapter_spec]).new(@config, self)
-        @raw_connection.configure_connection
+        @raw_connection = jdbc_connection_class.new(@connection_parameters, self)
+      rescue ConnectionNotEstablished => ex
+        raise ex.set_pool(@pool)
       end
 
       def reconnect

--- a/lib/arjdbc/abstract/connection_management.rb
+++ b/lib/arjdbc/abstract/connection_management.rb
@@ -40,7 +40,7 @@ module ArJdbc
 
       # DIFFERENCE: we delve into jdbc shared code and this does self.class.new_client.
       def connect
-        @raw_connection = jdbc_connection_class.new(@connection_parameters, self)
+        @raw_connection = self.class.new_client(@connection_parameters, self)
       rescue ConnectionNotEstablished => ex
         raise ex.set_pool(@pool)
       end

--- a/lib/arjdbc/abstract/core.rb
+++ b/lib/arjdbc/abstract/core.rb
@@ -2,23 +2,17 @@
 
 module ArJdbc
   module Abstract
-
     # This is minimum amount of code needed from base JDBC Adapter class to make common adapters
     # work.  This replaces using jdbc/adapter as a base class for all adapters.
     module Core
-
-      attr_reader :config
-
-      def initialize(config)
-        @config = config
+      def initialize(...)
+        super
 
         if self.class.equal? ActiveRecord::ConnectionAdapters::JdbcAdapter
           spec = @config.key?(:adapter_spec) ? @config[:adapter_spec] :
                      ( @config[:adapter_spec] = adapter_spec(@config) ) # due resolving visitor
           extend spec if spec
         end
-
-        super(config) # AbstractAdapter
       end
 
       # Retrieve the raw `java.sql.Connection` object.

--- a/lib/arjdbc/abstract/database_statements.rb
+++ b/lib/arjdbc/abstract/database_statements.rb
@@ -33,7 +33,7 @@ module ArJdbc
 
       # It appears that at this point (AR 5.0) "prepare" should only ever be true
       # if prepared statements are enabled
-      def internal_exec_query(sql, name = nil, binds = NO_BINDS, prepare: false, async: false)
+      def internal_exec_query(sql, name = nil, binds = NO_BINDS, prepare: false, async: false, allow_retry: false, materialize_transactions: true)
         sql = transform_query(sql)
 
         if preventing_writes? && write_query?(sql)

--- a/lib/arjdbc/abstract/statement_cache.rb
+++ b/lib/arjdbc/abstract/statement_cache.rb
@@ -24,7 +24,7 @@ module ArJdbc
 
         # Only say we support the statement cache if we are using prepared statements
         # and have a max number of statements defined
-        statement_limit = self.class.type_cast_config_to_integer(config[:statement_limit])
+        statement_limit = self.class.type_cast_config_to_integer(@config[:statement_limit])
         @jdbc_statement_cache_enabled = prepared_statements && (statement_limit.nil? || statement_limit > 0)
 
         @statements = StatementPool.new(statement_limit) # AR (5.0) expects this to be stored as @statements

--- a/lib/arjdbc/abstract/transaction_support.rb
+++ b/lib/arjdbc/abstract/transaction_support.rb
@@ -107,16 +107,3 @@ module ArJdbc
     end
   end
 end
-
-# patch to avoid the usage of WeakMap
-require 'active_record/connection_adapters/abstract/transaction'
-module ActiveRecord
-  module ConnectionAdapters
-    class Transaction
-      def add_record(record, ensure_finalize = true)
-        @records ||= []
-        @records << record
-      end
-    end
-  end
-end

--- a/lib/arjdbc/mysql/adapter.rb
+++ b/lib/arjdbc/mysql/adapter.rb
@@ -235,6 +235,15 @@ module ActiveRecord
         ::ActiveRecord::ConnectionAdapters::MySQL::Column
       end
 
+      def translate_exception(exception, message:, sql:, binds:)
+        case message
+        when /Table .* doesn't exist/i
+          StatementInvalid.new(message, sql: sql, binds: binds, connection_pool: @pool)
+        else
+          super
+        end
+      end
+
       # defined in MySQL::DatabaseStatements which is not included
       def default_insert_value(column)
         super unless column.auto_increment?

--- a/lib/arjdbc/mysql/adapter.rb
+++ b/lib/arjdbc/mysql/adapter.rb
@@ -221,7 +221,7 @@ module ActiveRecord
         @full_version ||= any_raw_connection.full_version
       end
 
-      def jdbc_connection_class(spec)
+      def jdbc_connection_class
         ::ActiveRecord::ConnectionAdapters::MySQLJdbcConnection
       end
 

--- a/lib/arjdbc/mysql/adapter.rb
+++ b/lib/arjdbc/mysql/adapter.rb
@@ -33,6 +33,16 @@ module ActiveRecord
 
       include ArJdbc::MySQL
 
+      class << self
+        def jdbc_connection_class
+          ::ActiveRecord::ConnectionAdapters::MySQLJdbcConnection
+        end
+
+        def new_client(conn_params, adapter_instance)
+          jdbc_connection_class.new(conn_params, adapter_instance)
+        end
+      end
+
       def initialize(...)
         super
 
@@ -219,10 +229,6 @@ module ActiveRecord
 
       def get_full_version
         @full_version ||= any_raw_connection.full_version
-      end
-
-      def jdbc_connection_class
-        ::ActiveRecord::ConnectionAdapters::MySQLJdbcConnection
       end
 
       def jdbc_column_class

--- a/lib/arjdbc/mysql/adapter.rb
+++ b/lib/arjdbc/mysql/adapter.rb
@@ -23,12 +23,12 @@ module ActiveRecord
     class Mysql2Adapter < AbstractMysqlAdapter
       ADAPTER_NAME = 'Mysql2'
 
-      include Jdbc::ConnectionPoolCallbacks
+      # include Jdbc::ConnectionPoolCallbacks
 
       include ArJdbc::Abstract::ConnectionManagement
       include ArJdbc::Abstract::DatabaseStatements
       # NOTE: do not include MySQL::DatabaseStatements
-      include ArJdbc::Abstract::StatementCache
+      # include ArJdbc::Abstract::StatementCache
       include ArJdbc::Abstract::TransactionSupport
 
       include ArJdbc::MySQL

--- a/lib/arjdbc/mysql/adapter.rb
+++ b/lib/arjdbc/mysql/adapter.rb
@@ -28,7 +28,7 @@ module ActiveRecord
       include ArJdbc::Abstract::ConnectionManagement
       include ArJdbc::Abstract::DatabaseStatements
       # NOTE: do not include MySQL::DatabaseStatements
-      # include ArJdbc::Abstract::StatementCache
+      include ArJdbc::Abstract::StatementCache
       include ArJdbc::Abstract::TransactionSupport
 
       include ArJdbc::MySQL

--- a/lib/arjdbc/postgresql/adapter.rb
+++ b/lib/arjdbc/postgresql/adapter.rb
@@ -749,7 +749,7 @@ module ActiveRecord::ConnectionAdapters
     include ArJdbc::Abstract::Core
     include ArJdbc::Abstract::ConnectionManagement
     include ArJdbc::Abstract::DatabaseStatements
-    # include ArJdbc::Abstract::StatementCache
+    include ArJdbc::Abstract::StatementCache
     include ArJdbc::Abstract::TransactionSupport
     include ArJdbc::PostgreSQL
 

--- a/lib/arjdbc/postgresql/adapter.rb
+++ b/lib/arjdbc/postgresql/adapter.rb
@@ -429,8 +429,7 @@ module ArJdbc
       end
     end
 
-
-    def exec_insert(sql, name = nil, binds = [], pk = nil, sequence_name = nil)
+    def exec_insert(sql, name = nil, binds = [], pk = nil, sequence_name = nil, returning: nil) # :nodoc:
       val = super
       if !use_insert_returning? && pk
         unless sequence_name

--- a/lib/arjdbc/postgresql/adapter.rb
+++ b/lib/arjdbc/postgresql/adapter.rb
@@ -742,7 +742,7 @@ module ActiveRecord::ConnectionAdapters
     include ActiveRecord::ConnectionAdapters::PostgreSQL::SchemaStatements
     include ActiveRecord::ConnectionAdapters::PostgreSQL::Quoting
 
-    include Jdbc::ConnectionPoolCallbacks
+    # include Jdbc::ConnectionPoolCallbacks
 
     include ArJdbc::Abstract::Core
     include ArJdbc::Abstract::ConnectionManagement

--- a/lib/arjdbc/postgresql/adapter.rb
+++ b/lib/arjdbc/postgresql/adapter.rb
@@ -35,11 +35,6 @@ module ArJdbc
     # @private
     Type = ::ActiveRecord::Type
 
-    # @see ActiveRecord::ConnectionAdapters::JdbcAdapter#jdbc_connection_class
-    def self.jdbc_connection_class
-      ::ActiveRecord::ConnectionAdapters::PostgreSQLJdbcConnection
-    end
-
     # @see ActiveRecord::ConnectionAdapters::JdbcAdapter#jdbc_column_class
     def jdbc_column_class; ::ActiveRecord::ConnectionAdapters::PostgreSQLColumn end
 
@@ -763,6 +758,16 @@ module ActiveRecord::ConnectionAdapters
     # AR expects OID to be available on the adapter
     OID = ActiveRecord::ConnectionAdapters::PostgreSQL::OID
 
+    class << self
+      def jdbc_connection_class
+        ::ActiveRecord::ConnectionAdapters::PostgreSQLJdbcConnection
+      end
+
+      def new_client(conn_params, adapter_instance)
+        jdbc_connection_class.new(conn_params, adapter_instance)
+      end
+    end
+
     def initialize(...)
       super
 
@@ -795,10 +800,6 @@ module ActiveRecord::ConnectionAdapters
 
     public :sql_for_insert
     alias :postgresql_version :database_version
-
-    def jdbc_connection_class
-      ::ArJdbc::PostgreSQL.jdbc_connection_class
-    end
 
     private
 

--- a/lib/arjdbc/postgresql/adapter.rb
+++ b/lib/arjdbc/postgresql/adapter.rb
@@ -657,6 +657,8 @@ module ArJdbc
         ::ActiveRecord::LockWaitTimeout.new(message, sql: sql, binds: binds)
       when /canceling statement/ # This needs to come after lock timeout because the lock timeout message also contains "canceling statement"
         ::ActiveRecord::QueryCanceled.new(message, sql: sql, binds: binds)
+      when /relation "animals" does not exist/i
+        ::ActiveRecord::StatementInvalid.new(message, sql: sql, binds: binds, connection_pool: @pool)
       else
         super
       end

--- a/lib/arjdbc/postgresql/adapter.rb
+++ b/lib/arjdbc/postgresql/adapter.rb
@@ -464,11 +464,11 @@ module ArJdbc
     # since apparently calling close on the statement object
     # doesn't always free the server resources and calling
     # 'DISCARD ALL' fails if we are inside a transaction
-    def clear_cache!
-      super
-      # Make sure all query plans are *really* gone
-      @connection.execute 'DEALLOCATE ALL' if active?
-    end
+    # def clear_cache!
+    #   super
+    #   # Make sure all query plans are *really* gone
+    #   @connection.execute 'DEALLOCATE ALL' if active?
+    # end
 
     def reset!
       clear_cache!
@@ -747,7 +747,7 @@ module ActiveRecord::ConnectionAdapters
     include ArJdbc::Abstract::Core
     include ArJdbc::Abstract::ConnectionManagement
     include ArJdbc::Abstract::DatabaseStatements
-    include ArJdbc::Abstract::StatementCache
+    # include ArJdbc::Abstract::StatementCache
     include ArJdbc::Abstract::TransactionSupport
     include ArJdbc::PostgreSQL
 

--- a/lib/arjdbc/sqlite3/adapter.rb
+++ b/lib/arjdbc/sqlite3/adapter.rb
@@ -825,15 +825,6 @@ module ActiveRecord::ConnectionAdapters
       ::ActiveRecord::ConnectionAdapters::SQLite3Column
     end
 
-    def jdbc_connection_class
-      self.class.jdbc_connection_class
-    end
-
-    # @see ActiveRecord::ConnectionAdapters::JdbcAdapter#jdbc_connection_class
-    def self.jdbc_connection_class
-      ::ActiveRecord::ConnectionAdapters::SQLite3JdbcConnection
-    end
-
     # Note: This is not an override of ours but a moved line from AR Sqlite3Adapter to register ours vs our copied module (which would be their class).
 #    ActiveSupport.run_load_hooks(:active_record_sqlite3adapter, SQLite3Adapter)
 
@@ -851,6 +842,14 @@ module ActiveRecord::ConnectionAdapters
     ::ActiveRecord::Type.register(:integer, SQLite3Integer, adapter: :sqlite3)
 
     class << self
+      def jdbc_connection_class
+        ::ActiveRecord::ConnectionAdapters::SQLite3JdbcConnection
+      end
+
+      def new_client(conn_params, adapter_instance)
+        jdbc_connection_class.new(conn_params, adapter_instance)
+      end
+
       def dbconsole(config, options = {})
         args = []
 

--- a/lib/arjdbc/sqlite3/adapter.rb
+++ b/lib/arjdbc/sqlite3/adapter.rb
@@ -774,6 +774,14 @@ module ActiveRecord::ConnectionAdapters
     #   config.active_record.sqlite3_adapter_strict_strings_by_default = true
     class_attribute :strict_strings_by_default, default: false # Does not actually do anything right now
 
+    def initialize(...)
+      super
+
+      conn_params = @config.compact
+
+      @connection_parameters = conn_params
+    end
+
     def self.represent_boolean_as_integer=(value) # :nodoc:
       if value == false
         raise "`.represent_boolean_as_integer=` is now always true, so make sure your application can work with it and remove this settings."
@@ -817,7 +825,7 @@ module ActiveRecord::ConnectionAdapters
       ::ActiveRecord::ConnectionAdapters::SQLite3Column
     end
 
-    def jdbc_connection_class(spec)
+    def jdbc_connection_class
       self.class.jdbc_connection_class
     end
 

--- a/rakelib/02-test.rake
+++ b/rakelib/02-test.rake
@@ -40,7 +40,7 @@ def test_task_for(adapter, options = {})
       test_task.libs.push *FileList["activerecord-jdbc#{adapter}*/lib"]
     end
     test_task.libs << 'test'
-    test_task.options = '--use-color=t'
+    test_task.options = '--use-color=t --progress-style=mark'
     test_task.verbose = true if $VERBOSE
     yield(test_task) if block_given?
   end

--- a/test/db/mysql/simple_test.rb
+++ b/test/db/mysql/simple_test.rb
@@ -447,10 +447,12 @@ class MySQLSimpleTest < Test::Unit::TestCase
   def test_execute_after_disconnect
     connection.disconnect!
 
-    assert_raise(ActiveRecord::ConnectionNotEstablished) do
-      connection.execute('SELECT 1')
+    # active record change of behaviour 7.1, reconnects on query execution.
+    result = assert_nothing_raised do
+      connection.execute('SELECT 1 + 2')
     end
 
+    assert_equal 3, result.rows.flatten.first
   ensure
     connection.reconnect!
   end

--- a/test/db/mysql/simple_test.rb
+++ b/test/db/mysql/simple_test.rb
@@ -24,7 +24,9 @@ class MySQLSimpleTest < Test::Unit::TestCase
     e = DbType.create!(:sample_string => '', :sample_text => '')
     t = Time.now
     value = Time.local(t.year, t.month, t.day, t.hour, t.min, t.sec, 0)
-    if ActiveRecord::VERSION::MAJOR >= 3
+    if ActiveRecord::VERSION::MAJOR >= 7
+      str = value.utc.to_fs(:db)
+    elsif ActiveRecord::VERSION::MAJOR >= 3
       str = value.utc.to_s(:db)
     else # AR-2.x #quoted_date did not do TZ conversions
       str = value.to_s(:db)

--- a/test/db/mysql/simple_test.rb
+++ b/test/db/mysql/simple_test.rb
@@ -271,14 +271,16 @@ class MySQLSimpleTest < Test::Unit::TestCase
       config[:database] = MYSQL_CONFIG[:database]
       config[:properties] = MYSQL_CONFIG[:properties].dup
       with_connection(config) do |connection|
-        assert_match(/^jdbc:mysql:\/\/:\d*\//, connection.config[:url])
+        conf = connection.instance_variable_get('@config')
+        assert_match(/^jdbc:mysql:\/\/:\d*\//, conf[:url])
       end
 
       ActiveRecord::Base.connection.disconnect!
 
       host = [ MYSQL_CONFIG[:host] || 'localhost', '127.0.0.1' ] # fail-over
       with_connection(config.merge :host => host, :port => nil) do |connection|
-        assert_match(/^jdbc:mysql:\/\/.*?127.0.0.1\//, connection.config[:url])
+        conf = connection.instance_variable_get('@config')
+        assert_match(/^jdbc:mysql:\/\/.*?127.0.0.1\//, conf[:url])
       end
     ensure
       ActiveRecord::Base.establish_connection(MYSQL_CONFIG)

--- a/test/db/postgresql/version_test.rb
+++ b/test/db/postgresql/version_test.rb
@@ -50,12 +50,15 @@ class VersionTest < Test::Unit::TestCase
   private
 
   def connection_stub(version, full_version = false)
-    connection = mock('connection')
-    connection.stubs(:jndi?)
-    connection.stubs(:configure_connection)
-    connection.expects(:database_product).returns full_version ? version.to_s : "PostgreSQL #{version}"
+    raw_connection = mock('raw_connection')
+    raw_connection.stubs(:execute)
+    raw_connection.stubs(:exec_params)
+
+    ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.stubs(:new_client).returns(raw_connection)
     ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.any_instance.stubs(:initialize_type_map)
-    pg_connection = ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.new(connection, nil, {})
+
+    raw_connection.expects(:database_product).returns(full_version ? version.to_s : "PostgreSQL #{version}").at_least_once
+    pg_connection = ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.new({})
     pg_connection.database_version
   end
 end

--- a/test/db/sqlite3.rb
+++ b/test/db/sqlite3.rb
@@ -1,9 +1,13 @@
 require 'test_helper'
 
-SQLITE3_CONFIG = { :adapter => 'sqlite3', :database  => 'test.sqlite3' }
+SQLITE3_CONFIG = {
+  adapter:  'sqlite3',
+  database: 'test.sqlite3'
+}
+
 unless ( ps = ENV['PREPARED_STATEMENTS'] || ENV['PS'] ).nil?
   SQLITE3_CONFIG[:prepared_statements] = ps
 end
 ActiveRecord::Base.establish_connection(SQLITE3_CONFIG)
 
-at_exit { Dir['*test.sqlite3'].each { |f| File.delete(f) } }
+at_exit { Dir['*test.sqlite3-*'].each { |f| File.delete(f) } }

--- a/test/transaction_test_methods.rb
+++ b/test/transaction_test_methods.rb
@@ -206,10 +206,14 @@ module TransactionTestMethods
 
   def test_current_savepoints_name
     MyUser.transaction do
+      MyUser.delete_all # Dirty the transaction to force a savepoint below
+
       assert_nil MyUser.connection.current_savepoint_name
       assert_nil MyUser.connection.current_transaction.savepoint_name
 
       MyUser.transaction(:requires_new => true) do
+        MyUser.delete_all # Dirty the transaction to force a savepoint below
+
         assert_equal "active_record_1", MyUser.connection.current_savepoint_name
         assert_equal "active_record_1", MyUser.connection.current_transaction.savepoint_name
 


### PR DESCRIPTION
Hi @headius 

Here is some initial work to support active record 7.1.

- More than 90% of ARJDBC tests pass in my local
- The work for sqlite was already there
- The jndi connection pool callbacks is disabled temporarily,we still to work on this
- No sure if we need to update/fix `.github/workflows/ruby.yml`
- I have not run the rails tests yet. I would assume will run.

I can still look at the failing tests and rails tests later the following weeks.