### PR TITLE
Revert "Update sqlite-jdbc to 3.46"

### DIFF
--- a/jdbc-sqlite3/lib/jdbc/sqlite3/version.rb
+++ b/jdbc-sqlite3/lib/jdbc/sqlite3/version.rb
@@ -1,6 +1,6 @@
 module Jdbc
   module SQLite3
-    DRIVER_VERSION = '3.46.0.0'
+    DRIVER_VERSION = '3.42.0.0'
     VERSION = DRIVER_VERSION
   end
 end


### PR DESCRIPTION
Reverts jruby/activerecord-jdbc-adapter#1149

Problem is sqlite3 added a new dependency: **https://github.com/xerial/sqlite-jdbc/commit/21c77a481f6970622b99d712d36d0336d63fd554**