### PR TITLE
Fix some arjdbc mysql tests to support AR 7.1

### DIFF
--- a/lib/arjdbc/mysql/adapter.rb
+++ b/lib/arjdbc/mysql/adapter.rb
@@ -58,6 +58,11 @@ module ActiveRecord
         @connection_parameters ||= @config
       end
 
+      # NOTE: redefines constant defined in abstract class however this time
+      # will use methods defined in the mysql abstract class and map properly
+      # mysql types.
+      TYPE_MAP = Type::TypeMap.new.tap { |m| initialize_type_map(m) }
+
       def self.database_exists?(config)
         conn = ActiveRecord::Base.mysql2_connection(config)
         conn && conn.really_valid?

--- a/lib/arjdbc/mysql/adapter.rb
+++ b/lib/arjdbc/mysql/adapter.rb
@@ -239,6 +239,8 @@ module ActiveRecord
         case message
         when /Table .* doesn't exist/i
           StatementInvalid.new(message, sql: sql, binds: binds, connection_pool: @pool)
+        when /BLOB, TEXT, GEOMETRY or JSON column .* can't have a default value/i
+          StatementInvalid.new(message, sql: sql, binds: binds, connection_pool: @pool)
         else
           super
         end

--- a/test/db/mysql/change_column_test.rb
+++ b/test/db/mysql/change_column_test.rb
@@ -13,6 +13,7 @@ class MySQLChangeColumnTest < Test::Unit::TestCase
       ActiveRecord::Migration.add_column :people, :about, :string, :default => 'x'
       # NOTE: even in non strict mode MySQL does not allow us add or change
       # text/binary with a default ...
+      #  Message: BLOB, TEXT, GEOMETRY or JSON column '%s' can't have a default value
       if mariadb_server? && db_version >= '10.2'
         ActiveRecord::Migration.change_column :people, :about, :text
       else

--- a/test/db/mysql/schema_dump_test.rb
+++ b/test/db/mysql/schema_dump_test.rb
@@ -132,7 +132,8 @@ class MysqlInfoTest < Test::Unit::TestCase
 
   def test_should_include_limit
     text_column = connection.columns('memos').find { |c| c.name == 'text' }
-    assert_equal 4294967295, text_column.limit
+
+    assert_equal 4_294_967_295, text_column.limit
   end
 
   def test_should_set_sqltype_to_longtext

--- a/test/db/mysql/simple_test.rb
+++ b/test/db/mysql/simple_test.rb
@@ -451,10 +451,10 @@ class MySQLSimpleTest < Test::Unit::TestCase
 
     # active record change of behaviour 7.1, reconnects on query execution.
     result = assert_nothing_raised do
-      connection.execute('SELECT 1 + 2')
+      connection.execute('SELECT 1 + 2 as total')
     end
 
-    assert_equal 3, result.rows.flatten.first
+    assert_equal 3, result.first['total']
   ensure
     connection.reconnect!
   end


### PR DESCRIPTION
Hi @headius & @enebo 

Here we have more fixes.

Hopefully we will have mysql tests green.