### PR TITLE
Relax on ActiveRecord gem version identifer.

### DIFF
--- a/activerecord-jdbc-adapter.gemspec
+++ b/activerecord-jdbc-adapter.gemspec
@@ -41,7 +41,7 @@ Gem::Specification.new do |gem|
   gem.executables = gem.files.grep(%r{^bin/}).map { |f| File.basename(f) }
   gem.test_files = gem.files.grep(%r{^test/})
 
-  gem.add_dependency 'activerecord', '~> 7.1.3'
+  gem.add_dependency 'activerecord', '~> 7.1'
 
   #gem.add_development_dependency 'test-unit', '2.5.4'
   #gem.add_development_dependency 'test-unit-context', '>= 0.3.0'

--- a/test/db/postgresql/table_name_test.rb
+++ b/test/db/postgresql/table_name_test.rb
@@ -87,9 +87,6 @@ class PostgreSQLTableNameTest < Test::Unit::TestCase
   end
 
   def test_serial_with_trigger
-    pend "Issue happens in active record 7.1 internals, issue wass logged in rails repo"
-    # issue link: https://github.com/rails/rails/issues/52485
-
     sn = SerialWithTrigger.create!(value: 1_234_567_890.to_s)
 
     assert sn.reload


### PR DESCRIPTION
And re-enabled test serial with trigger.

This PR is more intended to trigger the CI.