### PR TITLE
Catch HOUR_OF_DAY error

### DIFF
--- a/test/simple.rb
+++ b/test/simple.rb
@@ -321,7 +321,42 @@ module SimpleTestMethods
           end
         end
       end
+    end
 
+    def test_time_in_dst_change_hour_utc
+      with_system_tz 'Europe/Prague' do
+        Time.use_zone 'Europe/Prague' do
+          with_timezone_config default: :utc do
+            id = DbType.connection.insert(
+              "INSERT INTO db_types (sample_datetime)
+              values ('2024-03-31 03:30:00')"
+            )
+            saved_time = DbType.find(id).sample_datetime
+
+            assert_equal Time.utc(2024, 3, 31, 3, 30), saved_time
+            assert_equal 'UTC', saved_time.zone
+          end
+        end
+      end
+    end
+
+    def test_time_in_dst_change_hour_local
+      skip "with_system_tz not working in tomcat" if ActiveRecord::Base.connection.raw_connection.jndi?
+
+      with_system_tz 'Europe/Prague' do
+        Time.use_zone 'Europe/Prague' do
+          with_timezone_config default: :local do
+            id = DbType.connection.insert(
+              "INSERT INTO db_types (sample_datetime)
+              values ('2024-03-31 02:30:00')"
+            )
+            saved_time = DbType.find(id).sample_datetime
+
+            assert_equal Time.local(2024, 3, 31, 1, 30), saved_time
+            assert_not_equal 'UTC', saved_time.zone
+          end
+        end
+      end
     end
 
     #


### PR DESCRIPTION
If the time stored in the missing daylight saving hour, MySQL JDBC driver starting from version 8.0.23 will raise this error (https://dev.mysql.com/doc/relnotes/connector-j/en/news-8-0-23.html).
If the date time value stored in the column actually is UTC time, then it will return a string representation of the value, not the time converted to the local time zone.
More in https://github.com/jruby/activerecord-jdbc-adapter/issues/1091