### PR TITLE
More fixes to support Rails 7.2 

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ adapters are available:
 
 ```yml
 development:
-  adapter: mysql2 # or mysql
+  adapter: mysql2
   database: blog_development
   username: blog
   password: 1234
@@ -80,7 +80,7 @@ or preferably using the *properties:* syntax:
 
 ```yml
 production:
-  adapter: mysql
+  adapter: mysql2
   username: blog
   password: blog
   url: "jdbc:mysql://localhost:3306/blog?profileSQL=true"

--- a/lib/arjdbc/abstract/core.rb
+++ b/lib/arjdbc/abstract/core.rb
@@ -60,7 +60,16 @@ module ArJdbc
       # this version of log() automatically fills type_casted_binds from binds if necessary
       def log(sql, name = "SQL", binds = [], type_casted_binds = [], statement_name = nil, async: false)
         if binds.any? && (type_casted_binds.nil? || type_casted_binds.empty?)
-          type_casted_binds = ->{ binds.map(&:value_for_database) } # extract_raw_bind_values
+          type_casted_binds = lambda {
+            # extract_raw_bind_values
+            binds.map do |bind|
+              if bind.respond_to?(:value_for_database)
+                bind.value_for_database
+              else
+                bind
+              end
+            end
+          }
         end
         super
       end

--- a/lib/arjdbc/abstract/transaction_support.rb
+++ b/lib/arjdbc/abstract/transaction_support.rb
@@ -26,7 +26,9 @@ module ArJdbc
       def begin_db_transaction
         log('BEGIN', 'TRANSACTION') do
           with_raw_connection(allow_retry: true, materialize_transactions: false) do |conn|
-            conn.begin
+            result = conn.begin
+            verified!
+            result
           end
         end
       end

--- a/lib/arjdbc/postgresql/adapter.rb
+++ b/lib/arjdbc/postgresql/adapter.rb
@@ -345,7 +345,7 @@ module ArJdbc
           type.typname AS name,
           type.OID AS oid,
           n.nspname AS schema,
-          string_agg(enum.enumlabel, ',' ORDER BY enum.enumsortorder) AS value
+          array_agg(enum.enumlabel ORDER BY enum.enumsortorder) AS value
         FROM pg_enum AS enum
         JOIN pg_type AS type ON (type.oid = enum.enumtypid)
         JOIN pg_namespace n ON type.typnamespace = n.oid

--- a/lib/arjdbc/postgresql/adapter.rb
+++ b/lib/arjdbc/postgresql/adapter.rb
@@ -866,8 +866,11 @@ module ActiveRecord::ConnectionAdapters
     include ArJdbc::Abstract::DatabaseStatements
     include ArJdbc::Abstract::StatementCache
     include ArJdbc::Abstract::TransactionSupport
-    include ArJdbc::PostgreSQL
     include ArJdbc::PostgreSQLConfig
+
+    # NOTE: after AR refactor quote_column_name became class and instance method
+    include ArJdbc::PostgreSQL
+    extend ArJdbc::PostgreSQL
 
     require 'arjdbc/postgresql/oid_types'
     include ::ArJdbc::PostgreSQL::OIDTypes

--- a/lib/arjdbc/postgresql/adapter.rb
+++ b/lib/arjdbc/postgresql/adapter.rb
@@ -69,6 +69,8 @@ module ArJdbc
     # Configures the encoding, verbosity, schema search path, and time zone of the connection.
     # This is called on `connection.connect` and should not be called manually.
     def configure_connection
+      super
+
       #if encoding = config[:encoding]
         # The client_encoding setting is set by the driver and should not be altered.
         # If the driver detects a change it will abort the connection.

--- a/lib/arjdbc/postgresql/adapter.rb
+++ b/lib/arjdbc/postgresql/adapter.rb
@@ -842,6 +842,15 @@ module ActiveRecord::ConnectionAdapters
     # setting, you should immediately run <tt>bin/rails db:migrate</tt> to update the types in your schema.rb.
     class_attribute :datetime_type, default: :timestamp
 
+    ##
+    # :singleton-method:
+    # Toggles automatic decoding of date columns.
+    #
+    #   ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.select_value("select '2024-01-01'::date").class #=> String
+    #   ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.decode_dates = true
+    #   ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.select_value("select '2024-01-01'::date").class #=> Date
+    class_attribute :decode_dates, default: false
+
     # Try to use as much of the built in postgres logic as possible
     # maybe someday we can extend the actual adapter
     include ActiveRecord::ConnectionAdapters::PostgreSQL::ReferentialIntegrity

--- a/lib/arjdbc/postgresql/adapter_hash_config.rb
+++ b/lib/arjdbc/postgresql/adapter_hash_config.rb
@@ -13,7 +13,13 @@ module ArJdbc
       port = (config[:port] ||= ENV["PGPORT"] || 5432)
       database = config[:database] || config[:dbname] || ENV["PGDATABASE"]
 
-      config[:url] ||= "jdbc:postgresql://#{host}:#{port}/#{database}"
+      app = config[:application_name] || config[:appname] || config[:application]
+
+      config[:url] ||= if app
+                         "jdbc:postgresql://#{host}:#{port}/#{database}?ApplicationName=#{app}"
+                       else
+                         "jdbc:postgresql://#{host}:#{port}/#{database}"
+                       end
 
       config[:url] << config[:pg_params] if config[:pg_params]
 

--- a/lib/arjdbc/sqlite3/adapter.rb
+++ b/lib/arjdbc/sqlite3/adapter.rb
@@ -18,6 +18,7 @@ require "active_record/connection_adapters/sqlite3/schema_statements"
 require "active_support/core_ext/class/attribute"
 require "arjdbc/sqlite3/column"
 require "arjdbc/sqlite3/adapter_hash_config"
+require "arjdbc/sqlite3/pragmas"
 
 require "arjdbc/abstract/relation_query_attribute_monkey_patch"
 
@@ -77,6 +78,15 @@ module ArJdbc
         binary:       { name: "blob" },
         boolean:      { name: "boolean" },
         json:         { name: "json" },
+    }
+
+    DEFAULT_PRAGMAS = {
+      "foreign_keys"        => true,
+      "journal_mode"        => :wal,
+      "synchronous"         => :normal,
+      "mmap_size"           => 134217728, # 128 megabytes
+      "journal_size_limit"  => 67108864, # 64 megabytes
+      "cache_size"          => 2000
     }
 
     class StatementPool < ConnectionAdapters::StatementPool # :nodoc:
@@ -686,29 +696,17 @@ module ArJdbc
         end
       end
 
-      # Enforce foreign key constraints
-      # https://www.sqlite.org/pragma.html#pragma_foreign_keys
-      # https://www.sqlite.org/foreignkeys.html
-      raw_execute("PRAGMA foreign_keys = ON", "SCHEMA")
-      unless @memory_database
-        # Journal mode WAL allows for greater concurrency (many readers + one writer)
-        # https://www.sqlite.org/pragma.html#pragma_journal_mode
-        raw_execute("PRAGMA journal_mode = WAL", "SCHEMA")
-        # Set more relaxed level of database durability
-        # 2 = "FULL" (sync on every write), 1 = "NORMAL" (sync every 1000 written pages) and 0 = "NONE"
-        # https://www.sqlite.org/pragma.html#pragma_synchronous
-        raw_execute("PRAGMA synchronous = NORMAL", "SCHEMA")
-        # Set the global memory map so all processes can share some data
-        # https://www.sqlite.org/pragma.html#pragma_mmap_size
-        # https://www.sqlite.org/mmap.html
-        raw_execute("PRAGMA mmap_size = #{128.megabytes}", "SCHEMA")
+      super
+
+      pragmas = @config.fetch(:pragmas, {}).stringify_keys
+      DEFAULT_PRAGMAS.merge(pragmas).each do |pragma, value|
+        if ::SQLite3::Pragmas.respond_to?(pragma)
+          stmt = ::SQLite3::Pragmas.public_send(pragma, value)
+          raw_execute(stmt, "SCHEMA")
+        else
+          warn "Unknown SQLite pragma: #{pragma}"
+        end
       end
-      # Impose a limit on the WAL file to prevent unlimited growth
-      # https://www.sqlite.org/pragma.html#pragma_journal_size_limit
-      raw_execute("PRAGMA journal_size_limit = #{64.megabytes}", "SCHEMA")
-      # Set the local connection cache to 2000 pages
-      # https://www.sqlite.org/pragma.html#pragma_cache_size
-      raw_execute("PRAGMA cache_size = 2000", "SCHEMA")
     end
   end
   # DIFFERENCE: A registration here is moved down to concrete class so we are not registering part of an adapter.

--- a/lib/arjdbc/sqlite3/adapter.rb
+++ b/lib/arjdbc/sqlite3/adapter.rb
@@ -861,6 +861,14 @@ module ActiveRecord::ConnectionAdapters
     def initialize(...)
       super
 
+      @memory_database = false
+      case @config[:database].to_s
+      when ""
+        raise ArgumentError, "No database file specified. Missing argument: database"
+      when ":memory:"
+        @memory_database = true
+      end
+
       # assign arjdbc extra connection params
       conn_params = build_connection_config(@config.compact)
 

--- a/lib/arjdbc/sqlite3/column.rb
+++ b/lib/arjdbc/sqlite3/column.rb
@@ -4,12 +4,14 @@ module ActiveRecord::ConnectionAdapters
   class SQLite3Column < JdbcColumn
 
     attr_reader :rowid
-    
-    def initialize(name, default, sql_type_metadata = nil, null = true, default_function = nil, collation: nil, comment: nil, auto_increment: nil, rowid: false, **)
+
+    def initialize(*, auto_increment: nil, rowid: false, generated_type: nil, **)
       super
+
       @auto_increment = auto_increment
       @default = nil if default =~ /NULL/
       @rowid = rowid
+      @generated_type = generated_type
     end
 
     def self.string_to_binary(value)
@@ -37,6 +39,18 @@ module ActiveRecord::ConnectionAdapters
 
     def auto_incremented_by_db?
       auto_increment? || rowid
+    end
+
+    def virtual?
+      !@generated_type.nil?
+    end
+
+    def virtual_stored?
+      virtual? && @generated_type == :stored
+    end
+
+    def has_default?
+      super && !virtual?
     end
 
     def init_with(coder)

--- a/lib/arjdbc/sqlite3/pragmas.rb
+++ b/lib/arjdbc/sqlite3/pragmas.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+module SQLite3
+  # defines methods to de generate pragma statements
+  module Pragmas
+    class << self
+      # The enumeration of valid synchronous modes.
+      SYNCHRONOUS_MODES = [["full", 2], ["normal", 1], ["off", 0]].freeze
+
+      # The enumeration of valid temp store modes.
+      TEMP_STORE_MODES = [["default", 0], ["file", 1], ["memory", 2]].freeze
+
+      # The enumeration of valid auto vacuum modes.
+      AUTO_VACUUM_MODES = [["none", 0], ["full", 1], ["incremental", 2]].freeze
+
+      # The list of valid journaling modes.
+      JOURNAL_MODES = [["delete"], ["truncate"], ["persist"], ["memory"], ["wal"], ["off"]].freeze
+
+      # The list of valid locking modes.
+      LOCKING_MODES = [["normal"], ["exclusive"]].freeze
+
+      # The list of valid encodings.
+      ENCODINGS = [["utf-8"], ["utf-16"], ["utf-16le"], ["utf-16be"]].freeze
+
+      # The list of valid WAL checkpoints.
+      WAL_CHECKPOINTS = [["passive"], ["full"], ["restart"], ["truncate"]].freeze
+
+      # Enforce foreign key constraints
+      # https://www.sqlite.org/pragma.html#pragma_foreign_keys
+      # https://www.sqlite.org/foreignkeys.html
+      def foreign_keys(value)
+        gen_boolean_pragma(:foreign_keys, value)
+      end
+
+      # Journal mode WAL allows for greater concurrency (many readers + one writer)
+      # https://www.sqlite.org/pragma.html#pragma_journal_mode
+      def journal_mode(value)
+        gen_enum_pragma(:journal_mode, value, JOURNAL_MODES)
+      end
+
+      # Set more relaxed level of database durability
+      # 2 = "FULL" (sync on every write), 1 = "NORMAL" (sync every 1000 written pages) and 0 = "NONE"
+      # https://www.sqlite.org/pragma.html#pragma_synchronous
+      def synchronous(value)
+        gen_enum_pragma(:synchronous, value, SYNCHRONOUS_MODES)
+      end
+
+      def temp_store(value)
+        gen_enum_pragma(:temp_store, value, TEMP_STORE_MODES)
+      end
+
+      # Set the global memory map so all processes can share some data
+      # https://www.sqlite.org/pragma.html#pragma_mmap_size
+      # https://www.sqlite.org/mmap.html
+      def mmap_size(value)
+        "PRAGMA mmap_size = #{value.to_i}"
+      end
+
+      # Impose a limit on the WAL file to prevent unlimited growth
+      # https://www.sqlite.org/pragma.html#pragma_journal_size_limit
+      def journal_size_limit(value)
+        "PRAGMA journal_size_limit = #{value.to_i}"
+      end
+
+      # Set the local connection cache to 2000 pages
+      # https://www.sqlite.org/pragma.html#pragma_cache_size
+      def cache_size(value)
+        "PRAGMA cache_size = #{value.to_i}"
+      end
+
+      private
+
+      def gen_boolean_pragma(name, mode)
+        case mode
+        when String
+          case mode.downcase
+          when "on", "yes", "true", "y", "t" then mode = "'ON'"
+          when "off", "no", "false", "n", "f" then mode = "'OFF'"
+          else
+            raise ActiveRecord::JDBCError, "unrecognized pragma parameter #{mode.inspect}"
+          end
+        when true, 1
+          mode = "ON"
+        when false, 0, nil
+          mode = "OFF"
+        else
+          raise ActiveRecord::JDBCError, "unrecognized pragma parameter #{mode.inspect}"
+        end
+
+        "PRAGMA #{name} = #{mode}"
+      end
+
+      def gen_enum_pragma(name, mode, enums)
+        match = enums.find { |p| p.find { |i| i.to_s.downcase == mode.to_s.downcase } }
+
+        unless match
+          # Unknown pragma value
+          raise ActiveRecord::JDBCError, "unrecognized #{name} #{mode.inspect}"
+        end
+
+        "PRAGMA #{name} = '#{match.first.upcase}'"
+      end
+    end
+  end
+end

--- a/test/db/mysql/simple_test.rb
+++ b/test/db/mysql/simple_test.rb
@@ -262,33 +262,6 @@ class MySQLSimpleTest < Test::Unit::TestCase
     end
   end if defined? JRUBY_VERSION
 
-  test "config :host" do
-    skip unless MYSQL_CONFIG[:database] # JDBC :url defined instead
-    skip if mariadb_driver?
-
-    begin
-      config = { :adapter => 'mysql', :port => 3306 }
-      config[:username] = MYSQL_CONFIG[:username]
-      config[:password] = MYSQL_CONFIG[:password]
-      config[:database] = MYSQL_CONFIG[:database]
-      config[:properties] = MYSQL_CONFIG[:properties].dup
-      with_connection(config) do |connection|
-        conf = connection.instance_variable_get('@config')
-        assert_match(/^jdbc:mysql:\/\/:\d*\//, conf[:url])
-      end
-
-      ActiveRecord::Base.connection.disconnect!
-
-      host = [ MYSQL_CONFIG[:host] || 'localhost', '127.0.0.1' ] # fail-over
-      with_connection(config.merge :host => host, :port => nil) do |connection|
-        conf = connection.instance_variable_get('@config')
-        assert_match(/^jdbc:mysql:\/\/.*?127.0.0.1\//, conf[:url])
-      end
-    ensure
-      ActiveRecord::Base.establish_connection(MYSQL_CONFIG)
-    end
-  end if defined? JRUBY_VERSION
-
   test 'bulk change table' do
     assert ActiveRecord::Base.connection.supports_bulk_alter?
 

--- a/test/db/sqlite3.rb
+++ b/test/db/sqlite3.rb
@@ -10,4 +10,8 @@ unless ( ps = ENV['PREPARED_STATEMENTS'] || ENV['PS'] ).nil?
 end
 ActiveRecord::Base.establish_connection(SQLITE3_CONFIG)
 
-at_exit { Dir['*test.sqlite3-*'].each { |f| File.delete(f) } }
+at_exit do
+  Dir["*test.sqlite3*"].each do |sqlite_file|
+    File.delete(sqlite_file)
+  end
+end


### PR DESCRIPTION
Hi @enebo 

Here is more fixes for the adapter.

I reckon the support for sqlite and Mysql is decent with exception the message pack support.

there are over 20 mysql compatibility tests failing which is not due to the adapter but to AR tests.

all of them pass with:

```
 class BaseCompatibilityTest < ActiveRecord::TestCase
   attr_reader :connection
 
+  self.use_transactional_tests = false
+
   def setup
     @connection = ActiveRecord::Base.lease_connection
     @pool = ActiveRecord::Base.connection_pool
...
```






