### PR TITLE
Fix using gem from local and basic raw prepared statement with Time.current (active Support time with zone)

### DIFF
--- a/lib/arjdbc.rb
+++ b/lib/arjdbc.rb
@@ -12,6 +12,18 @@ if defined?(JRUBY_VERSION)
   rescue LoadError => e
     warn "activerecord-jdbc-adapter failed to load railtie: #{e.inspect}"
   end if defined?(Rails) && ActiveRecord::VERSION::MAJOR >= 3
+
+  ActiveSupport.on_load(:active_record) do
+    ActiveRecord::ConnectionAdapters.register(
+      "sqlite3", "ActiveRecord::ConnectionAdapters::SQLite3Adapter", "arjdbc/sqlite3/adapter"
+    )
+    ActiveRecord::ConnectionAdapters.register(
+      "postgresql", "ActiveRecord::ConnectionAdapters::PostgreSQLAdapter", "arjdbc/postgresql/adapter"
+    )
+    ActiveRecord::ConnectionAdapters.register(
+      "mysql2", "ActiveRecord::ConnectionAdapters::Mysql2Adapter", "arjdbc/mysql/adapter"
+    )
+  end
 else
   warn "activerecord-jdbc-adapter is for use with JRuby only"
 end

--- a/src/java/arjdbc/jdbc/RubyJdbcConnection.java
+++ b/src/java/arjdbc/jdbc/RubyJdbcConnection.java
@@ -126,6 +126,7 @@ public class RubyJdbcConnection extends RubyObject {
     private IRubyObject adapter; // the AbstractAdapter instance we belong to
     private volatile boolean connected = true;
     private RubyClass attributeClass;
+    private RubyClass timeZoneClass;
 
     private boolean lazy = false; // final once set on initialize
     private boolean jndi; // final once set on initialize
@@ -135,6 +136,7 @@ public class RubyJdbcConnection extends RubyObject {
     protected RubyJdbcConnection(Ruby runtime, RubyClass metaClass) {
         super(runtime, metaClass);
         attributeClass = runtime.getModule("ActiveModel").getClass("Attribute");
+        timeZoneClass = runtime.getModule("ActiveSupport").getClass("TimeWithZone");
     }
 
     private static final ObjectAllocator ALLOCATOR = new ObjectAllocator() {
@@ -2441,6 +2443,9 @@ public class RubyJdbcConnection extends RubyObject {
         if (attributeClass.isInstance(attribute)) {
             type = jdbcTypeForAttribute(context, attribute);
             value = valueForDatabase(context, attribute);
+        } else if (timeZoneClass.isInstance(attribute)) {
+            type = jdbcTypeFor("timestamp");
+            value = attribute;
         } else {
             type = jdbcTypeForPrimitiveAttribute(context, attribute);
             value = attribute;

--- a/test/simple.rb
+++ b/test/simple.rb
@@ -243,6 +243,15 @@ module SimpleTestMethods
     Entry.create(:title => "Bloh")
   end
 
+  def test_find_time_with_raw_prepared_statement
+    user = User.new(login: "jessec")
+
+    assert_equal true, user.save
+
+    right_now = Time.current
+    assert_equal 1, User.where("created_at <= ?", right_now).to_a.size
+  end
+
   def test_find_and_update_entry
     title = "First post!"
     content = "Hello from JRuby on Rails!"


### PR DESCRIPTION
Hi @enebo

These fix are kind of important for a common scenarios

1) Use gem from source

```ruby
platforms :jruby do
  gem 'activerecord-jdbc-adapter', path: '../../vendor_gems/activerecord-jdbc-adapter'
  # gem "activerecord-jdbc-alt-adapter", "~> 72.0.0.rc1"
  gem "jdbc-pgsql"
end
```

2) basic query with hardcoded prepared statement

Before Rails 7.2 queries with `where('updated_at < ?', Time.current)` used to be interpolated in AR guts now in Rails 7.2 they pass as part of the prepared statement 

