### PR TITLE
Fix bundler error when using --enable=frozen-string-literal

### DIFF
--- a/activerecord-jdbc-adapter.gemspec
+++ b/activerecord-jdbc-adapter.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |gem|
   gem.homepage = 'https://github.com/jruby/activerecord-jdbc-adapter'
   gem.license = 'BSD-2-Clause'
   gem.summary = 'JDBC adapter for ActiveRecord, for use within JRuby on Rails.'
-  gem.description = "" <<
+  gem.description = +"" <<
     "AR-JDBC is a database adapter for Rails' ActiveRecord component " <<
     "designed to be used with JRuby built upon Java's JDBC API for " <<
     "database access. Provides (ActiveRecord) built-in adapters: MySQL,  " <<


### PR DESCRIPTION
Error:

```sh
  There was an error while loading `activerecord-jdbc-adapter.gemspec`: can't modify frozen String,
  created at /Users/nicolas/PROJECTS/CONCERTO/concerto/.bundle/jruby/3.4.0/bundler/gems/activerecord-jdbc-adapter-c56c7b476da8/activerecord-jdbc-adapter.gemspec:13.
  Bundler cannot continue.
```

Thank you!