### PR TITLE
chore: Update to support Rails 8.0                                   …

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,10 @@ Versions are targeted at certain versions of Rails and live on their own branche
 | 61.x        | 6.1.x         | 61-stable | 9.2.7     | 8        |
 | 70.x        | 7.0.x         | 70-stable | 9.3.0     | 8        |
 | 71.x        | 7.1.x         | 71-stable | 9.4.3     | 8        |
-| 72.x        | 7.2.x         | master    | 9.4.3     | 8        |
+| 72.x        | 7.2.x         | 72-stable | 9.4.3     | 8        |
+| 80.x        | 8.0.x         | master    | 10.0.0    | 8        |
 
-Note: 72.x is still under development and not supported yet.
+Note: 80.x is still under development and not supported yet.
 
 Note that JRuby 9.1.x and JRuby 9.2.x are at end-of-life. We recommend Java 8
 at a minimum for all versions.

--- a/activerecord-jdbc-adapter.gemspec
+++ b/activerecord-jdbc-adapter.gemspec
@@ -41,7 +41,7 @@ Gem::Specification.new do |gem|
   gem.executables = gem.files.grep(%r{^bin/}).map { |f| File.basename(f) }
   gem.test_files = gem.files.grep(%r{^test/})
 
-  gem.add_dependency "activerecord", "~> 7.2.2"
+  gem.add_dependency "activerecord", "~> 8.0.0"
 
   #gem.add_development_dependency 'test-unit', '2.5.4'
   #gem.add_development_dependency 'test-unit-context', '>= 0.3.0'

--- a/lib/arjdbc/version.rb
+++ b/lib/arjdbc/version.rb
@@ -1,3 +1,3 @@
 module ArJdbc
-  VERSION = '71.0'
+  VERSION = '80.0'
 end

--- a/rakelib/02-test.rake
+++ b/rakelib/02-test.rake
@@ -36,7 +36,7 @@ def test_task_for(adapter, options = {})
     test_task.libs = []
     if defined?(JRUBY_VERSION)
       test_task.libs << 'lib'
-      test_task.libs << "jdbc-#{driver}/lib" if driver && File.exists?("jdbc-#{driver}/lib")
+      test_task.libs << "jdbc-#{driver}/lib" if driver && File.exist?("jdbc-#{driver}/lib")
       test_task.libs.push *FileList["activerecord-jdbc#{adapter}*/lib"]
     end
     test_task.libs << 'test'


### PR DESCRIPTION
- Bump version to 80.0 for Rails 8.0.x support                                                                                                                                                                                                               - Update activerecord dependency to ~> 8.0.0                                                                                                                                                                                                              
- Update README to show master branch targets Rails 8.0.x                                                                                                                                                                                                    - Add 72-stable branch for Rails 7.2.x support                                                                                                                                                                                                            
- Require JRuby 10.0.0 minimum for Rails 8                                                                                                                                                                                                                   - Fix deprecated File.exists? to File.exist?


PS: still getting familiar with this code base.