### PR TITLE
Ability to release gems for one database type at a time

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -96,7 +96,7 @@ end
 
 desc "Releasing AR-JDBC gems (use NOOP=true to disable gem pushing)"
 task 'release:do' do
-  if !ENV["DBS"]
+  unless ENV["DBS"]
     puts "you must explicitly provide a DBS env var when calling release:do. An empty one will not default to 'all' " \
            "for this command\n\n"
     invalid_dbs!
@@ -142,7 +142,7 @@ end
 
 def make_db_list
   env_dbs = ENV["DBS"]
-  env_dbs = "mysql,postgresql,sqlite3" if env_dbs == "all" || env_dbs.nil?
+  env_dbs = "mysql,postgresql,sqlite3" if !env_dbs || env_dbs == "all"
   requested = env_dbs.split(",").map(&:strip).reject(&:empty?).map(&:downcase)
   invalid_dbs! unless requested.size > 0 && requested.size <= 3 && requested == requested.uniq
 

--- a/Rakefile
+++ b/Rakefile
@@ -96,6 +96,12 @@ end
 
 desc "Releasing AR-JDBC gems (use NOOP=true to disable gem pushing)"
 task 'release:do' do
+  if !ENV["DBS"] || ENV["DBS"].strip.empty?
+    puts "you must explicitly provide a DBS env var when calling release:do. An empty one will not default to 'all' " \
+           "for this command\n\n"
+    invalid_dbs!
+  end
+
   Rake::Task['build'].invoke
   Rake::Task['build:adapters'].invoke
 
@@ -135,8 +141,9 @@ def invalid_dbs!
 end
 
 def make_db_list
-ENV["DBS"] = "mysql,postgresql,sqlite3" if ENV["DBS"] == "all" || ENV["DBS"].nil? || ENV["DBS"].strip.empty?
-requested = ENV["DBS"].split(",").map(&:strip).reject(&:empty?).map(&:downcase)
+  env_dbs = ENV["DBS"]
+  env_dbs = "mysql,postgresql,sqlite3" if env_dbs == "all" || env_dbs.nil? || env_dbs.strip.empty?
+  requested = env_dbs.split(",").map(&:strip).reject(&:empty?).map(&:downcase)
   invalid_dbs! unless requested.size > 0 && requested.size <= 3 && requested == requested.uniq
 
   canonical = requested.map do |name|

--- a/Rakefile
+++ b/Rakefile
@@ -142,7 +142,7 @@ end
 
 def make_db_list
   env_dbs = ENV["DBS"]
-  env_dbs = "mysql,postgresql,sqlite3" if env_dbs == "all" || env_dbs.nil? || env_dbs.strip.empty?
+  env_dbs = "mysql,postgresql,sqlite3" if env_dbs == "all" || env_dbs.nil?
   requested = env_dbs.split(",").map(&:strip).reject(&:empty?).map(&:downcase)
   invalid_dbs! unless requested.size > 0 && requested.size <= 3 && requested == requested.uniq
 

--- a/Rakefile
+++ b/Rakefile
@@ -96,7 +96,7 @@ end
 
 desc "Releasing AR-JDBC gems (use NOOP=true to disable gem pushing)"
 task 'release:do' do
-  if !ENV["DBS"] || ENV["DBS"].strip.empty?
+  if !ENV["DBS"]
     puts "you must explicitly provide a DBS env var when calling release:do. An empty one will not default to 'all' " \
            "for this command\n\n"
     invalid_dbs!


### PR DESCRIPTION
Introduces a new `DBS` env var, that will let you choose which subset of MySQL, Postgres, or SQLite you are trying to build and release gems for. Not setting it defaults to all of them, with the exception of `release:do`: for that, just to be extra safe that what is being done is intentional, I've required the caller to explicitly set it.