### PR TITLE
Add Rails 8.1 compatibility

### DIFF
--- a/activerecord-jdbc-adapter.gemspec
+++ b/activerecord-jdbc-adapter.gemspec
@@ -41,7 +41,7 @@ Gem::Specification.new do |gem|
   gem.executables = gem.files.grep(%r{^bin/}).map { |f| File.basename(f) }
   gem.test_files = gem.files.grep(%r{^test/})
 
-  gem.add_dependency "activerecord", "~> 8.0.0"
+  gem.add_dependency "activerecord", "~> 8.0"
 
   #gem.add_development_dependency 'test-unit', '2.5.4'
   #gem.add_development_dependency 'test-unit-context', '>= 0.3.0'

--- a/lib/arjdbc/abstract/database_statements.rb
+++ b/lib/arjdbc/abstract/database_statements.rb
@@ -9,6 +9,21 @@ module ArJdbc
 
       NO_BINDS = [].freeze
 
+      unless method_defined?(:mark_transaction_written_if_write)
+        def mark_transaction_written_if_write(sql)
+          if write_query?(sql)
+            ensure_writes_are_allowed(sql)
+            mark_transaction_written
+          end
+        end
+      end
+
+      unless method_defined?(:check_if_write_query)
+        def check_if_write_query(sql)
+          ensure_writes_are_allowed(sql) if write_query?(sql)
+        end
+      end
+
       def exec_insert(sql, name = nil, binds = NO_BINDS, pk = nil, sequence_name = nil, returning: nil)
         if preventing_writes?
           raise ActiveRecord::ReadOnlyError, "Write query attempted while in readonly mode: #{sql}"

--- a/lib/arjdbc/postgresql/schema_statements.rb
+++ b/lib/arjdbc/postgresql/schema_statements.rb
@@ -6,6 +6,23 @@ module ArJdbc
       ForeignKeyDefinition = ActiveRecord::ConnectionAdapters::ForeignKeyDefinition
       Utils = ActiveRecord::ConnectionAdapters::PostgreSQL::Utils
 
+      def decode_string_array(value)
+        return value if value.is_a?(Array)
+        _arjdbc_array_parser.parse_pg_array(value)
+      end
+
+      private
+
+      def _arjdbc_array_parser
+        @_arjdbc_array_parser ||= begin
+          obj = Object.new
+          obj.extend(ActiveRecord::ConnectionAdapters::PostgreSQL::ArrayParser)
+          obj
+        end
+      end
+
+      public
+
       def foreign_keys(table_name)
         scope = quoted_scope(table_name)
         fk_info = internal_exec_query(<<~SQL, "SCHEMA", allow_retry: true, materialize_transactions: false)


### PR DESCRIPTION
Closes #1184

- Relax activerecord dependency ~> 8.0.0 to ~> 8.0
- mark_transaction_written_if_write and check_if_write_query removed in Rails 8.1
- override decode_string_array in PostgreSQL adapter. ARJDBC may return PG arrays as either a Ruby Array or a PG string ("{a,b}"), so handle both cases.