### PR TITLE
JRuby 10.1.0.0 compatibility

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -74,6 +74,7 @@ group :test do
   gem 'test-unit-context', require: nil
   gem 'mocha', '~> 2.0', require: false
   gem 'bcrypt', '~> 3.1', require: false
+  gem 'ostruct', require: false
   
   # Database adapters for MRI
   platform :mri do

--- a/src/java/arjdbc/jdbc/RubyJdbcConnection.java
+++ b/src/java/arjdbc/jdbc/RubyJdbcConnection.java
@@ -3573,7 +3573,7 @@ public class RubyJdbcConnection extends RubyObject {
         final ColumnData[] columns, final ResultSet resultSet,
         final RubyJdbcConnection connection) throws SQLException {
 
-        final RubyHash row = new RubyHash(runtime, columns.length);
+        final RubyHash row = RubyHash.newHash(runtime);
 
         for ( int i = 0; i < columns.length; i++ ) {
             final ColumnData column = columns[i];

--- a/src/java/arjdbc/util/StringHelper.java
+++ b/src/java/arjdbc/util/StringHelper.java
@@ -68,7 +68,7 @@ public abstract class StringHelper {
     public static RubyString newDefaultInternalString(final Ruby runtime, final CharSequence str) {
         Encoding enc = runtime.getDefaultInternalEncoding();
         if (enc == null) enc = runtime.getEncodingService().getJavaDefault();
-        return new RubyString(runtime, runtime.getString(), str, enc);
+        return RubyString.newString(runtime, str, enc);
     }
 
     // NOTE: a 'better' RubyString.newInternalFromJavaExternal - to be back-ported in JRuby 9.2


### PR DESCRIPTION
Ensure compatibility with 10.1.0.0 by
- Switching RubyHash construction to factory method and don't pass the second int argument (no longer supported)
- Do the same for RubyString construction
- Add ostruct to Gemfile, as it's no longer bundled by default