### PR TITLE
Fix COMMIT/ROLLBACK/savepoint retry data-loss; harden MySQL connection-loss detection

### DIFF
--- a/lib/arjdbc/abstract/database_statements.rb
+++ b/lib/arjdbc/abstract/database_statements.rb
@@ -44,7 +44,7 @@ module ArJdbc
 
         binds = convert_legacy_binds_to_attributes(binds) if binds.first.is_a?(Array)
 
-        with_raw_connection do |conn|
+        with_raw_connection(allow_retry: allow_retry, materialize_transactions: materialize_transactions) do |conn|
           if without_prepared_statement?(binds)
             log(sql, name, async: async) { conn.execute_query(sql) }
           else

--- a/lib/arjdbc/abstract/transaction_support.rb
+++ b/lib/arjdbc/abstract/transaction_support.rb
@@ -43,11 +43,19 @@ module ArJdbc
         end
       end
 
+      # COMMIT and ROLLBACK must NOT be retried on a connection failure, matching
+      # ActiveRecord's native adapters (which use `allow_retry: false`). Retrying
+      # a COMMIT after a dropped backend is unsafe on a networked database:
+      # `with_raw_connection` would reconnect, replay an *empty* transaction (the
+      # original writes died with the old backend), COMMIT it successfully, and
+      # report success - silently losing the transaction's writes. (BEGIN above
+      # stays retryable because it is idempotent.) See the save-point note below.
+
       # Commits the current database transaction.
       # @override
       def commit_db_transaction
         log('COMMIT', 'TRANSACTION') do
-          with_raw_connection(allow_retry: true, materialize_transactions: false) do |conn|
+          with_raw_connection(allow_retry: false, materialize_transactions: true) do |conn|
             conn.commit
           end
         end
@@ -58,13 +66,23 @@ module ArJdbc
       # @override
       def exec_rollback_db_transaction
         log('ROLLBACK', 'TRANSACTION') do
-          with_raw_connection(allow_retry: true, materialize_transactions: false) do |conn|
+          with_raw_connection(allow_retry: false, materialize_transactions: true) do |conn|
             conn.rollback
           end
         end
       end
 
       ########################## Savepoint Interface ############################
+
+      # Save-point operations must NOT be retried on a connection failure. They
+      # only ever run inside an already-open transaction, so a dropped backend
+      # means the transaction's prior writes are gone. Retrying via
+      # `with_raw_connection(allow_retry: true)` would reconnect, replay an
+      # *empty* transaction (the original writes died with the backend), run the
+      # save-point statement against it, and report success - silently losing
+      # data. ActiveRecord's native adapters route these through
+      # `internal_execute` (allow_retry: false, materialize_transactions: true);
+      # we mirror that here, as do the COMMIT/ROLLBACK methods above.
 
       # Creates a (transactional) save-point one can rollback to.
       # Unlike 'plain' `ActiveRecord` it is allowed to pass a save-point name.
@@ -74,7 +92,7 @@ module ArJdbc
       # @extension added optional name parameter
       def create_savepoint(name = current_savepoint_name)
         log("SAVEPOINT #{name}", 'TRANSACTION') do
-          with_raw_connection(allow_retry: true, materialize_transactions: false) do |conn|
+          with_raw_connection(allow_retry: false, materialize_transactions: true) do |conn|
             conn.create_savepoint(name)
           end
         end
@@ -87,7 +105,7 @@ module ArJdbc
       # @extension added optional name parameter
       def exec_rollback_to_savepoint(name = current_savepoint_name)
         log("ROLLBACK TO SAVEPOINT #{name}", 'TRANSACTION') do
-          with_raw_connection(allow_retry: true, materialize_transactions: false) do |conn|
+          with_raw_connection(allow_retry: false, materialize_transactions: true) do |conn|
             conn.rollback_savepoint(name)
           end
         end
@@ -100,7 +118,7 @@ module ArJdbc
       # @extension added optional name parameter
       def release_savepoint(name = current_savepoint_name)
         log("RELEASE SAVEPOINT #{name}", 'TRANSACTION') do
-          with_raw_connection(allow_retry: true, materialize_transactions: false) do |conn|
+          with_raw_connection(allow_retry: false, materialize_transactions: true) do |conn|
             conn.release_savepoint(name)
           end
         end

--- a/lib/arjdbc/mysql/adapter.rb
+++ b/lib/arjdbc/mysql/adapter.rb
@@ -252,7 +252,42 @@ module ActiveRecord
         ::ActiveRecord::ConnectionAdapters::MySQL::Column
       end
 
+      # MySQL / MariaDB surface a dropped server connection as a JDBC error in
+      # SQLState class 08 (connection exception) - most commonly 08S01
+      # "Communications link failure" - or with one of the "server gone" vendor
+      # error codes. The driver may also wrap it in a recoverable / non-transient
+      # connection exception. None of these are caught by the message- and
+      # error-code-based cases below (which fall through to a plain JDBCError /
+      # StatementInvalid), so AR's with_raw_connection reconnect/retry machinery
+      # never kicks in. See https://dev.mysql.com/doc/connector-j/en/connector-j-reference-error-sqlstates.html
+      CONNECTION_FAILURE_SQL_STATES = %w[
+        08000
+        08001
+        08003
+        08004
+        08006
+        08007
+        08S01
+      ].freeze
+      # CR_SERVER_GONE_ERROR (2006), CR_SERVER_LOST (2013),
+      # ER_SERVER_SHUTDOWN (1053), ER_CONNECTION_KILLED (1927),
+      # ER_CLIENT_INTERACTION_TIMEOUT (4031).
+      CONNECTION_FAILURE_ERROR_CODES = [2006, 2013, 1053, 1927, 4031].freeze
+      CONNECTION_FAILURE_MESSAGES = /
+        Communications?\ link\ failure |
+        No\ operations\ allowed\ after\ connection\ closed |
+        Connection\.*\ refused |
+        Could\ not\ connect\ to |
+        Server\ shutdown\ in\ progress |
+        Connection\ is\ closed
+      /x.freeze
+      private_constant :CONNECTION_FAILURE_SQL_STATES, :CONNECTION_FAILURE_ERROR_CODES, :CONNECTION_FAILURE_MESSAGES
+
       def translate_exception(exception, message:, sql:, binds:)
+        if exception.is_a?(::ActiveRecord::JDBCError) && connection_lost?(exception)
+          return ::ActiveRecord::ConnectionFailed.new(message, sql: sql, binds: binds, connection_pool: @pool)
+        end
+
         case message
         when /Table .* doesn't exist/i
           StatementInvalid.new(message, sql: sql, binds: binds, connection_pool: @pool)
@@ -261,6 +296,25 @@ module ActiveRecord
         else
           super
         end
+      end
+
+      # Detects a lost server connection from a JDBC error so it can be
+      # translated to ActiveRecord::ConnectionFailed (retryable). Mirrors the
+      # PostgreSQL adapter's handling of backend disconnects (e.g. a proxy such
+      # as ProxySQL dropping an idle connection).
+      def connection_lost?(exception)
+        state = exception.sql_state if exception.respond_to?(:sql_state)
+        return true if state && CONNECTION_FAILURE_SQL_STATES.include?(state)
+
+        code = exception.error_code if exception.respond_to?(:error_code)
+        return true if code && CONNECTION_FAILURE_ERROR_CODES.include?(code)
+
+        message = exception.message
+        return true if message && CONNECTION_FAILURE_MESSAGES.match?(message)
+
+        cause = exception.cause if exception.respond_to?(:cause)
+        cause.is_a?(Java::JavaSql::SQLRecoverableException) ||
+          cause.is_a?(Java::JavaSql::SQLNonTransientConnectionException)
       end
 
       # defined in MySQL::DatabaseStatements which is not included

--- a/test/db/mysql/commit_no_retry_test.rb
+++ b/test/db/mysql/commit_no_retry_test.rb
@@ -1,0 +1,42 @@
+require 'db/mysql'
+
+# Regression tests for the COMMIT-retry data-loss footgun (#1) on MySQL.
+#
+# commit_db_transaction / exec_rollback_db_transaction must go through
+# with_raw_connection(allow_retry: false), matching ActiveRecord's native
+# MySQL adapter. With allow_retry: true, a connection drop at COMMIT time can
+# make AR reconnect, replay an *empty* transaction (the original writes died
+# with the dropped backend), COMMIT it successfully, and report success -
+# silently losing the transaction's writes.
+#
+# Note on MySQL vs PostgreSQL: PostgreSQL translates backend drops (e.g.
+# pgbouncer reaping a connection) into a retryable ActiveRecord::ConnectionFailed,
+# which directly exposes this footgun. MySQL currently translates connection
+# loss to a plain ActiveRecord::JDBCError, which is NOT a retryable connection
+# error, so AR will not retry a failed COMMIT today regardless of the flag.
+# These tests therefore pin the safe contract directly (allow_retry: false) so
+# the footgun cannot be silently reintroduced if MySQL later gains
+# ConnectionFailed translation.
+class MySQLCommitNoRetryTest < Test::Unit::TestCase
+
+  def setup
+    @adapter = ActiveRecord::Base.connection
+  end
+
+  def test_commit_db_transaction_does_not_allow_retry
+    @adapter.expects(:with_raw_connection)
+            .with(allow_retry: false, materialize_transactions: true)
+            .returns(nil)
+
+    @adapter.commit_db_transaction
+  end
+
+  def test_exec_rollback_db_transaction_does_not_allow_retry
+    @adapter.expects(:with_raw_connection)
+            .with(allow_retry: false, materialize_transactions: true)
+            .returns(nil)
+
+    @adapter.exec_rollback_db_transaction
+  end
+
+end

--- a/test/db/mysql/connection_lost_test.rb
+++ b/test/db/mysql/connection_lost_test.rb
@@ -1,0 +1,108 @@
+require 'db/mysql'
+
+# Regression tests for the MySQL/MariaDB connection-lost translation, the
+# MySQL analog of the PostgreSQL backend-disconnect patch.
+#
+# A JDBCError whose SQLState (class 08), vendor error code, message, or wrapped
+# Java exception indicates the server connection is gone must translate to
+# ActiveRecord::ConnectionFailed so AR's with_raw_connection(allow_retry:)
+# machinery will reconnect and retry. Without this, a proxy (e.g. ProxySQL) or
+# the server dropping an idle connection surfaces as a raw JDBCError /
+# StatementInvalid and the safe retry never triggers.
+class MySQLConnectionLostTest < Test::Unit::TestCase
+
+  def setup
+    @adapter = ActiveRecord::Base.connection
+  end
+
+  # https://dev.mysql.com/doc/connector-j/en/connector-j-reference-error-sqlstates.html
+  # Class 08 - Connection Exception (08S01 = "Communications link failure").
+  CONNECTION_FAILURE_SQL_STATES = %w[
+    08000
+    08001
+    08003
+    08004
+    08006
+    08007
+    08S01
+  ]
+
+  # CR_SERVER_GONE_ERROR, CR_SERVER_LOST, ER_SERVER_SHUTDOWN,
+  # ER_CONNECTION_KILLED, ER_CLIENT_INTERACTION_TIMEOUT.
+  CONNECTION_FAILURE_ERROR_CODES = [2006, 2013, 1053, 1927, 4031]
+
+  CONNECTION_FAILURE_MESSAGES = [
+    'Communications link failure',
+    'No operations allowed after connection closed',
+    'Connection refused',
+    'Could not connect to address=(host=localhost)(port=3306)',
+    'Server shutdown in progress',
+    'Connection is closed',
+  ]
+
+  CONNECTION_FAILURE_SQL_STATES.each do |state|
+    define_method("test_translates_sqlstate_#{state}_to_connection_failed") do
+      err = jdbc_error('boom', sql_state: state)
+      result = translate(err)
+      assert_kind_of ActiveRecord::ConnectionFailed, result,
+        "expected SQLState #{state} to translate to ConnectionFailed, got #{result.class}"
+    end
+  end
+
+  CONNECTION_FAILURE_ERROR_CODES.each do |code|
+    define_method("test_translates_error_code_#{code}_to_connection_failed") do
+      err = jdbc_error('boom', error_code: code)
+      result = translate(err)
+      assert_kind_of ActiveRecord::ConnectionFailed, result,
+        "expected error code #{code} to translate to ConnectionFailed, got #{result.class}"
+    end
+  end
+
+  CONNECTION_FAILURE_MESSAGES.each_with_index do |msg, i|
+    define_method("test_translates_message_#{i}_to_connection_failed") do
+      err = jdbc_error(msg)
+      result = translate(err)
+      assert_kind_of ActiveRecord::ConnectionFailed, result,
+        "expected message #{msg.inspect} to translate to ConnectionFailed, got #{result.class}"
+    end
+  end
+
+  def test_recoverable_jdbc_exception_translates_to_connection_failed
+    cause = Java::JavaSql::SQLRecoverableException.new('socket gone')
+    err = ActiveRecord::JDBCError.new('socket gone', cause)
+    assert_kind_of ActiveRecord::ConnectionFailed, translate(err)
+  end
+
+  def test_non_transient_connection_exception_translates_to_connection_failed
+    cause = Java::JavaSql::SQLNonTransientConnectionException.new('link down')
+    err = ActiveRecord::JDBCError.new('link down', cause)
+    assert_kind_of ActiveRecord::ConnectionFailed, translate(err)
+  end
+
+  def test_does_not_translate_duplicate_entry_to_connection_failed
+    # ER_DUP_ENTRY (1062) is a data error, not a connection failure.
+    err = jdbc_error("Duplicate entry 'x' for key 'PRIMARY'", sql_state: '23000', error_code: 1062)
+    result = translate(err)
+    assert_kind_of ActiveRecord::RecordNotUnique, result
+    assert !result.is_a?(ActiveRecord::ConnectionFailed)
+  end
+
+  def test_does_not_translate_syntax_error_to_connection_failed
+    # ER_PARSE_ERROR (1064) must not be mistaken for a connection failure.
+    err = jdbc_error('You have an error in your SQL syntax', sql_state: '42000', error_code: 1064)
+    result = translate(err)
+    assert !result.is_a?(ActiveRecord::ConnectionFailed),
+      "syntax error should not translate to ConnectionFailed, got #{result.class}"
+  end
+
+  private
+
+  def translate(jdbc_error)
+    @adapter.send(:translate_exception_class, jdbc_error, 'SELECT 1', [])
+  end
+
+  def jdbc_error(message, sql_state: nil, error_code: 0)
+    cause = Java::JavaSql::SQLException.new(message, sql_state, error_code)
+    ActiveRecord::JDBCError.new(message, cause)
+  end
+end

--- a/test/db/postgresql/connection_lost_test.rb
+++ b/test/db/postgresql/connection_lost_test.rb
@@ -114,15 +114,133 @@ class PostgresConnectionLostTest < Test::Unit::TestCase
       @adapter.begin_db_transaction
     end
 
-    # We should be on a different underlying connection now, and the
-    # new one should actually be inside a transaction. pg_current_xact_id()
-    # only returns a value while a transaction is open.
+    # We should be on a different underlying connection now, and the new one
+    # should actually be inside a transaction. txid_current() forces/returns a
+    # transaction id (pg_current_xact_id() would be cleaner but only exists on
+    # PostgreSQL >= 13, and we support older servers).
     new_jdbc = @adapter.instance_variable_get(:@raw_connection).jdbc_connection
     assert !new_jdbc.equal?(original), 'expected a fresh jdbc connection after reconnect'
-    xact_id = @adapter.select_value('SELECT pg_current_xact_id()')
+    xact_id = @adapter.select_value('SELECT txid_current()')
     assert_not_nil xact_id, 'expected BEGIN to have established a live transaction on the new connection'
 
     @adapter.rollback_db_transaction
+  end
+
+  # Regression test for the COMMIT-retry data-loss footgun (#1).
+  #
+  # commit_db_transaction must go through with_raw_connection(allow_retry:
+  # false), matching ActiveRecord's native PostgreSQL adapter. If COMMIT were
+  # retryable, a backend drop at commit time would make AR reconnect, replay
+  # an *empty* transaction (the original writes died with the dropped
+  # backend), COMMIT it successfully, and report success - silently losing
+  # the transaction's writes. With retry disabled the failure must surface to
+  # the caller instead.
+  #
+  # Note: unlike the begin test above we do NOT call #clean!. At commit time a
+  # transaction is in progress, so the connection is "verified" / recently
+  # active - the realistic state in which allow_retry must not reconnect.
+  def test_commit_after_dropped_socket_does_not_silently_retry
+    @adapter.execute('SELECT 1')
+    @adapter.begin_db_transaction
+    # non-empty transaction; also keeps the connection verified/active.
+    @adapter.execute('SELECT 1')
+
+    original = @adapter.instance_variable_get(:@raw_connection).jdbc_connection
+
+    # pgbouncer reaps the backend right before COMMIT.
+    original.close
+    assert original.isClosed, 'precondition: jdbc connection should be closed'
+
+    # With allow_retry: false the dropped COMMIT must raise rather than
+    # reconnecting and committing an empty transaction.
+    assert_raise(ActiveRecord::ConnectionFailed) do
+      @adapter.commit_db_transaction
+    end
+
+    # And it must NOT have silently swapped onto a fresh connection and
+    # committed there.
+    current = @adapter.instance_variable_get(:@raw_connection)
+    assert(current.nil? || current.jdbc_connection.equal?(original),
+           'commit must not reconnect-and-retry on a fresh connection')
+  ensure
+    @adapter.send(:reconnect!) rescue nil
+  end
+
+  # End-to-end regression for the COMMIT-retry data-loss footgun (#1).
+  #
+  # Demonstrates the real-world consequence on actual data: a row written
+  # inside a transaction whose backend is reaped at COMMIT time must not be
+  # reported as successfully committed. With the buggy `allow_retry: true`, AR
+  # would reconnect, replay an *empty* transaction on the fresh connection,
+  # COMMIT it, and return success - the INSERT silently vanishes while the
+  # caller believes it persisted. With `allow_retry: false` the COMMIT raises,
+  # so the caller is correctly told the write did not persist.
+  def test_commit_failure_after_dropped_backend_is_not_reported_as_success
+    @adapter.execute('DROP TABLE IF EXISTS commit_retry_loss')
+    @adapter.execute('CREATE TABLE commit_retry_loss (id serial primary key, name varchar(255))')
+
+    @adapter.begin_db_transaction
+    @adapter.execute("INSERT INTO commit_retry_loss (name) VALUES ('vanishing-write')")
+
+    # pgbouncer reaps the backend after the write but before COMMIT.
+    original = @adapter.instance_variable_get(:@raw_connection).jdbc_connection
+    original.close
+    assert original.isClosed, 'precondition: jdbc connection should be closed'
+
+    # The caller MUST be told the commit failed - no false success.
+    assert_raise(ActiveRecord::ConnectionFailed) do
+      @adapter.commit_db_transaction
+    end
+
+    # After a clean reconnect the row is absent (the write died with the
+    # backend). The point of the fix is that the caller learned this via the
+    # raised error above rather than a silent empty-commit "success".
+    @adapter.send(:reconnect!)
+    count = @adapter.select_value(
+      "SELECT COUNT(*) FROM commit_retry_loss WHERE name = 'vanishing-write'"
+    ).to_i
+    assert_equal 0, count, 'uncommitted write must not be present after a failed commit'
+  ensure
+    @adapter.send(:reconnect!) rescue nil
+    @adapter.execute('DROP TABLE IF EXISTS commit_retry_loss') rescue nil
+  end
+
+  # Regression test for the savepoint-retry data-loss footgun (#1, sibling of
+  # the COMMIT case above).
+  #
+  # create_savepoint / exec_rollback_to_savepoint / release_savepoint must go
+  # through with_raw_connection(allow_retry: false), matching ActiveRecord's
+  # native adapters (which route save-points through internal_execute, whose
+  # default is allow_retry: false). Save-points only ever run inside an open
+  # transaction, so a backend drop means the transaction's prior writes are
+  # gone. If the save-point op were retryable, AR would reconnect, replay an
+  # *empty* transaction, run the SAVEPOINT against it, and report success -
+  # silently losing the transaction's writes. With retry disabled the failure
+  # surfaces to the caller instead.
+  def test_create_savepoint_after_dropped_socket_does_not_silently_retry
+    @adapter.execute('SELECT 1')
+    @adapter.begin_db_transaction
+    # non-empty transaction; also keeps the connection verified/active.
+    @adapter.execute('SELECT 1')
+
+    original = @adapter.instance_variable_get(:@raw_connection).jdbc_connection
+
+    # pgbouncer reaps the backend right before the SAVEPOINT.
+    original.close
+    assert original.isClosed, 'precondition: jdbc connection should be closed'
+
+    # With allow_retry: false the dropped SAVEPOINT must raise rather than
+    # reconnecting and running against a fresh, empty transaction.
+    assert_raise(ActiveRecord::ConnectionFailed) do
+      @adapter.create_savepoint('sp_retry_loss')
+    end
+
+    # And it must NOT have silently swapped onto a fresh connection.
+    current = @adapter.instance_variable_get(:@raw_connection)
+    assert(current.nil? || current.jdbc_connection.equal?(original),
+           'savepoint must not reconnect-and-retry on a fresh connection')
+  ensure
+    @adapter.send(:reconnect!) rescue nil
   end
 
   private

--- a/test/db/sqlite3/transaction_no_retry_test.rb
+++ b/test/db/sqlite3/transaction_no_retry_test.rb
@@ -1,0 +1,64 @@
+require 'db/sqlite3'
+
+# Contract tests for the shared ArJdbc::Abstract::TransactionSupport mixin,
+# exercised through the SQLite3 adapter (which has no external server, so these
+# always run).
+#
+# COMMIT / ROLLBACK / SAVEPOINT operations must go through
+# with_raw_connection(allow_retry: false), matching ActiveRecord's native
+# adapters. With allow_retry: true, a connection drop at COMMIT time can make AR
+# reconnect, replay an *empty* transaction (the original writes died with the
+# dropped backend), COMMIT it successfully, and report success - silently losing
+# the transaction's writes.
+#
+# BEGIN intentionally stays allow_retry: true: it is idempotent, so replaying it
+# on a fresh connection after a drop is safe. The negative test below pins that
+# distinction so the no-retry fix is not over-applied to BEGIN.
+class SQLite3TransactionNoRetryTest < Test::Unit::TestCase
+
+  def setup
+    @adapter = ActiveRecord::Base.connection
+  end
+
+  def test_commit_db_transaction_does_not_allow_retry
+    assert_no_retry { @adapter.commit_db_transaction }
+  end
+
+  def test_exec_rollback_db_transaction_does_not_allow_retry
+    assert_no_retry { @adapter.exec_rollback_db_transaction }
+  end
+
+  def test_create_savepoint_does_not_allow_retry
+    assert_no_retry { @adapter.create_savepoint('sp_no_retry') }
+  end
+
+  def test_exec_rollback_to_savepoint_does_not_allow_retry
+    assert_no_retry { @adapter.exec_rollback_to_savepoint('sp_no_retry') }
+  end
+
+  def test_release_savepoint_does_not_allow_retry
+    assert_no_retry { @adapter.release_savepoint('sp_no_retry') }
+  end
+
+  # Negative: BEGIN must remain retryable (idempotent), so the no-retry fix must
+  # NOT have leaked onto it.
+  def test_begin_db_transaction_still_allows_retry
+    @adapter.expects(:with_raw_connection)
+            .with(allow_retry: true, materialize_transactions: false)
+            .returns(nil)
+
+    @adapter.begin_db_transaction
+  end
+
+  private
+
+  # Asserts the yielded transaction-control call routes through the safe
+  # with_raw_connection contract (no reconnect/retry on a dropped backend).
+  def assert_no_retry
+    @adapter.expects(:with_raw_connection)
+            .with(allow_retry: false, materialize_transactions: true)
+            .returns(nil)
+    yield
+  end
+
+end


### PR DESCRIPTION
## Summary

Splits the connection-retry correctness fix out of #1216 into a focused PR.

Transaction terminators must **not** be retried on a dropped backend. On a
networked database, retrying a `COMMIT` / `ROLLBACK` / savepoint statement
through `with_raw_connection(allow_retry: true)` would reconnect, replay an
*empty* transaction (the original writes died with the old backend), commit it
successfully, and report success — **silently losing the transaction's writes**.

This routes those statements through
`with_raw_connection(allow_retry: false, materialize_transactions: true)`,
matching ActiveRecord's native adapters, and forwards the retry kwargs through
`exec_query` so ordinary statements stay retryable.

It also hardens **MySQL/MariaDB** connection-loss detection: a dropped server
connection (SQLState class `08`, vendor "server gone" codes like
`CR_SERVER_GONE_ERROR`/`CR_SERVER_LOST`, or a recoverable/non-transient cause)
is now translated to `ActiveRecord::ConnectionFailed` so the reconnect/retry
machinery engages — mirroring the PostgreSQL adapter's handling of proxy-dropped
connections (e.g. ProxySQL / pgbouncer).

## Changes

- `abstract/transaction_support.rb` — `allow_retry: false, materialize_transactions: true` for COMMIT/ROLLBACK + all savepoint ops
- `abstract/database_statements.rb` — forward `allow_retry`/`materialize_transactions` through `exec_query`
- `mysql/adapter.rb` — `connection_lost?` detection (SQLStates, vendor error codes, message patterns, recoverable/non-transient causes) + `translate_exception` hook
- Tests: `mysql/commit_no_retry_test.rb`, `sqlite3/transaction_no_retry_test.rb`, `mysql/connection_lost_test.rb`, `postgresql/connection_lost_test.rb`

## Notes

Part of a larger split of #1216 into reviewable, topic-scoped PRs. Targets `72-stable`. No conflicts with the other carved branches.

🤖 Used Claude Opus 4.8

## Justification

Existing functionality today:

`#commit_db_transaction` 

https://github.com/rails/rails/blob/7-2-stable/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb#L111-L113

`#exec_rollback_db_transaction`

https://github.com/rails/rails/blob/7-2-stable/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb#L116-L119


## `create_savepoint` changes



The change in this PR
```ruby
  # BEFORE  (72-stable base — and still on arjdbc master today)
  def create_savepoint(name = current_savepoint_name)
    log("SAVEPOINT #{name}", 'TRANSACTION') do
      with_raw_connection(allow_retry: true, materialize_transactions: false) do |conn|
        conn.create_savepoint(name)
      end
    end
  end
```

```ruby
  # AFTER  (pr/retry-correctness)
  def create_savepoint(name = current_savepoint_name)
    log("SAVEPOINT #{name}", 'TRANSACTION') do
      with_raw_connection(allow_retry: false, materialize_transactions: true) do |conn|
        conn.create_savepoint(name)
      end
    end
  end
```

Native AR defines the savepoint methods in Savepoints, routing through internal_execute with no explicit flags — so it takes internal_execute's defaults, which
  are `allow_retry: false, materialize_transactions: true:`

```ruby
  # active_record/connection_adapters/abstract/savepoints.rb
  def create_savepoint(name = current_savepoint_name)
    internal_execute("SAVEPOINT #{name}", "TRANSACTION")   # defaults: allow_retry: false, materialize_transactions: true
  end
```

  - Savepoint methods: https://github.com/rails/rails/blob/7-2-stable/activerecord/lib/active_record/connection_adapters/abstract/savepoints.rb#L11-L21
  - internal_execute defaults (allow_retry: false, materialize_transactions: true):
  https://github.com/rails/rails/blob/7-2-stable/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb

  So the PR brings ArJdbc's savepoint handling from the unsafe allow_retry: true, materialize_transactions: false into exact parity with native AR's allow_retry:
  false, materialize_transactions: true — the same fix and reasoning as the COMMIT/ROLLBACK methods, and master still needs this change applied separately.


## Why shouldn't MySQL be broken into it's own PR?

The changes to bring `transaction_support.rb` logic in line with what is on AR 7.2, would expose Mysql to these situations where the connection could be dropped, an error is raised (currently a non-retryable JDBCError, not handling situations where the connection is need to be retried. And shipping these two separately could open MySQL to data loss. 

Having them be both in this MR allows for the proper connection retry logic to bubble up to ActiveRecord, and prevents data loss from occuring.

## The sqlite test

SQLITE is just a testing change without any actual logic needed. And will run if PG/MYSQL is not present but ensure the code works as expected.
