### PR TITLE
Expose PG-compatible status/transaction_status/async_exec on the JDBC connection (+ CI Postgres 14)

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -84,7 +84,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:11
+        image: postgres:14
         env:
           POSTGRES_PASSWORD: postgres
           POSTGRES_HOST_AUTH_METHOD: trust
@@ -211,7 +211,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:11
+        image: postgres:14
         env:
           POSTGRES_PASSWORD: postgres
           POSTGRES_HOST_AUTH_METHOD: trust

--- a/lib/arjdbc/postgresql/adapter.rb
+++ b/lib/arjdbc/postgresql/adapter.rb
@@ -22,6 +22,7 @@ require 'arjdbc/abstract/transaction_support'
 require 'arjdbc/postgresql/base/array_decoder'
 require 'arjdbc/postgresql/base/array_encoder'
 require 'arjdbc/postgresql/name'
+require 'arjdbc/postgresql/pg_compat'
 require 'arjdbc/postgresql/database_statements'
 require 'arjdbc/postgresql/schema_statements'
 require "arjdbc/postgresql/adapter_hash_config"

--- a/lib/arjdbc/postgresql/pg_compat.rb
+++ b/lib/arjdbc/postgresql/pg_compat.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+# Minimal subset of the libpq constants that ActiveRecord's native PostgreSQL
+# code paths reference as ::PG::* (e.g. #retryable_query_error? checks
+# transaction_status against PQTRANS_INERROR, and the Rails test-suite helper
+# +remote_disconnect+ uses CONNECTION_BAD / PQTRANS_INTRANS).
+#
+# The matching #status / #transaction_status / #async_exec methods are defined
+# on the JDBC connection (PostgreSQLRubyJdbcConnection) in the Java extension.
+#
+# Only defined when the real pg gem is absent (i.e. under JRuby).
+unless defined?(PG)
+  module PG
+    # PQtransactionStatus
+    PQTRANS_IDLE    = 0 # connection idle, no transaction open
+    PQTRANS_ACTIVE  = 1 # command in progress
+    PQTRANS_INTRANS = 2 # idle, within a transaction block
+    PQTRANS_INERROR = 3 # idle, within a failed transaction block
+    PQTRANS_UNKNOWN = 4 # connection is bad / state cannot be determined
+
+    # PQstatus (subset that AR uses)
+    CONNECTION_OK  = 0
+    CONNECTION_BAD = 1
+  end
+end

--- a/src/java/arjdbc/postgresql/PostgreSQLRubyJdbcConnection.java
+++ b/src/java/arjdbc/postgresql/PostgreSQLRubyJdbcConnection.java
@@ -214,6 +214,68 @@ public class PostgreSQLRubyJdbcConnection extends arjdbc.jdbc.RubyJdbcConnection
         });
     }
 
+    // libpq PQtransactionStatus codes (see PG::PQTRANS_* / pg_compat.rb).
+    private static final int PQTRANS_IDLE    = 0;
+    private static final int PQTRANS_INTRANS = 2;
+    private static final int PQTRANS_INERROR = 3;
+    private static final int PQTRANS_UNKNOWN = 4;
+    // libpq PQstatus codes (see PG::CONNECTION_* / pg_compat.rb).
+    private static final int CONNECTION_OK  = 0;
+    private static final int CONNECTION_BAD = 1;
+
+    /**
+     * Mirrors <code>PG::Connection#transaction_status</code>. ActiveRecord's
+     * #retryable_query_error? distinguishes PQTRANS_INERROR from other states,
+     * so we read the JDBC driver's protocol-level transaction state (exposed
+     * only on the internal BaseConnection; PGConnection has no equivalent).
+     */
+    @JRubyMethod(name = "transaction_status")
+    public IRubyObject transaction_status(final ThreadContext context) {
+        // getTransactionState() is a local protocol-state read (no server
+        // round-trip), so use the plain accessor rather than withConnection's
+        // retry/reconnect machinery; a missing/closed connection or any error
+        // falls through to PQTRANS_UNKNOWN (matching libpq).
+        final Connection connection = getConnection(false);
+        try {
+            if (connection != null) {
+                final org.postgresql.core.BaseConnection base =
+                    connection.unwrap(org.postgresql.core.BaseConnection.class);
+                switch (base.getTransactionState()) {
+                    case IDLE:   return context.runtime.newFixnum(PQTRANS_IDLE);
+                    case OPEN:   return context.runtime.newFixnum(PQTRANS_INTRANS);
+                    case FAILED: return context.runtime.newFixnum(PQTRANS_INERROR);
+                }
+            }
+        }
+        catch (SQLException e) { /* fall through to unknown */ }
+        return context.runtime.newFixnum(PQTRANS_UNKNOWN);
+    }
+
+    /**
+     * Mirrors <code>PG::Connection#status</code> (CONNECTION_OK / CONNECTION_BAD).
+     * A closed connection reports CONNECTION_BAD so AR / test helpers reconnect.
+     */
+    @JRubyMethod(name = "status")
+    public IRubyObject status(final ThreadContext context) {
+        final Connection connection = getConnection(false);
+        try {
+            if (connection != null && !connection.isClosed()) {
+                return context.runtime.newFixnum(CONNECTION_OK);
+            }
+        }
+        catch (SQLException e) { /* treat as bad below */ }
+        return context.runtime.newFixnum(CONNECTION_BAD);
+    }
+
+    /**
+     * Mirrors <code>PG::Connection#async_exec</code>; under JDBC the statement
+     * runs synchronously. Used by Rails' +remote_disconnect+ test helper.
+     */
+    @JRubyMethod(name = "async_exec", required = 1)
+    public IRubyObject async_exec(final ThreadContext context, final IRubyObject sql) {
+        return execute(context, sql);
+    }
+
     @JRubyMethod
     public IRubyObject exec_params(ThreadContext context, IRubyObject sql, IRubyObject binds) {
         return execute_prepared_query(context, sql, binds, null);


### PR DESCRIPTION
## Summary

Under JRuby the PostgreSQL raw connection is a `PostgreSQLJdbcConnection`, not a `PG::Connection`. ActiveRecord 7.2's PostgreSQL reconnection test suite calls `PG::Connection` methods and `::PG::*` constants directly on that raw connection, so they blew up with `NoMethodError` / `uninitialized constant PG` and aborted those tests.

This PR makes the JDBC connection answer the small libpq-compatible API those paths invoke, and bumps the CI Postgres image to a supported release.

## Changes

- **`status`, `transaction_status`, `async_exec`** on `PostgreSQLRubyJdbcConnection` (Java).
- **`::PG::PQTRANS_*` / `::PG::CONNECTION_*` constants** (`lib/arjdbc/postgresql/pg_compat.rb`), defined only when the real `pg` gem is absent.
- **CI: PostgreSQL `11` → `14`** (separate commit) — PG 11 is EOL and lacks `pg_current_xact_id()` (PG 13+), which the AR 7.2 suite uses.

## Why the `PG` module shim is necessary

The real `pg` gem is a C extension and is unavailable under JRuby — the entire reason AR-JDBC exists — so the top-level `::PG` namespace and its libpq constants are simply not defined.

**AR-JDBC's own production code never references `::PG`.** Verified by runtime method resolution:

```ruby
ActiveRecord::Base.connection.method(:retryable_query_error?).owner
#=> ActiveRecord::ConnectionAdapters::AbstractAdapter   # abstract_adapter.rb:1079
```

It is AR's **native** PostgreSQL adapter that compares `transaction_status` to `::PG::PQTRANS_INERROR`, but AR-JDBC is `class PostgreSQLAdapter < AbstractAdapter` (it does **not** subclass AR's native PG adapter), so that method is never in the ancestry. The other native `::PG` sites are bypassed the same way:

- `#retryable_query_error?` resolves to `AbstractAdapter` (no `::PG`), not [`postgresql_adapter.rb#L826-L831`](https://github.com/rails/rails/blob/7-2-stable/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb#L826-L831).
- `#reset!` is overridden by AR-JDBC, so [`postgresql_adapter.rb#L367-L372`](https://github.com/rails/rails/blob/7-2-stable/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb#L367-L372) is never reached.
- `#cancel_any_running_query` / `IDLE_TRANSACTION_STATUSES` live in AR's native `postgresql/database_statements.rb`, which AR-JDBC never loads (it ships its own): [`database_statements.rb#L162-L166`](https://github.com/rails/rails/blob/7-2-stable/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb#L162-L166).

**So the shim's only consumer is the Rails test suite.** Rails' `remote_disconnect` helper hard-codes `::PG::*` on the raw connection, in files this gem cannot edit:

- [`test/cases/adapter_test.rb#L913-L921`](https://github.com/rails/rails/blob/7-2-stable/activerecord/test/cases/adapter_test.rb#L913-L921) — `.status == ::PG::CONNECTION_BAD` (L917), `.transaction_status == ::PG::PQTRANS_INTRANS` (L918), `.async_exec("begin")` (L919)
- [`test/cases/adapter_test.rb#L885-L893`](https://github.com/rails/rails/blob/7-2-stable/activerecord/test/cases/adapter_test.rb#L885-L893) — `.transaction_status == ::PG::PQTRANS_INTRANS` (L891)

Because those constants are resolved on the **caller's** side (`== ::PG::PQTRANS_INTRANS`), nothing our methods return can satisfy them — a top-level `::PG` must exist or the tests raise `uninitialized constant PG`.

**Why shim rather than exclude these tests?** They exercise behavior AR-JDBC genuinely supports and cares about — reconnect/retry after a dropped backend, the same scenario as the connection-loss work in the sibling PRs. The `::PG` references are only test *scaffolding* used to induce the disconnect, not the behavior under test. With the shim in place these tests run and drop from **26 errors → 3 errors / 4 failures**; the remaining 7 are *real* reconnect-recovery and transaction-state gaps. Excluding the tests would throw away that coverage **and mask those genuine gaps**. Exclusions are for things that cannot work under JRuby; these can. Hence the shim — an ~8-line, version-stable libpq constants module guarded by `unless defined?(PG)` — is the correct minimal solution.

## Why the constant values / state mapping are correct

- libpq `ConnStatusType` (`CONNECTION_OK = 0`, `CONNECTION_BAD = 1`) and `PGTransactionStatusType` (`PQTRANS_IDLE = 0`, `ACTIVE = 1`, `INTRANS = 2`, `INERROR = 3`, `UNKNOWN = 4`) — PostgreSQL source:
  [`libpq-fe.h#L56-L59`](https://github.com/postgres/postgres/blob/REL_14_STABLE/src/interfaces/libpq/libpq-fe.h#L56-L59) and [`libpq-fe.h#L114-L120`](https://github.com/postgres/postgres/blob/REL_14_STABLE/src/interfaces/libpq/libpq-fe.h#L114-L120)
- `transaction_status` reads the driver's protocol-level state via `BaseConnection#getTransactionState()` and maps `IDLE/OPEN/FAILED` → `PQTRANS_IDLE/INTRANS/INERROR`. Driver enum:
  [`pgjdbc TransactionState.java#L8-L11`](https://github.com/pgjdbc/pgjdbc/blob/master/pgjdbc/src/main/java/org/postgresql/core/TransactionState.java#L8-L11)
  (`PGConnection` exposes no transaction state, hence the unwrap to `BaseConnection`.)

## Verification

Local run of `test/cases/adapter_test.rb` (jruby-9.4.14.0, AR 7-2-stable, `--seed=12345`):

| | runs | failures | errors |
|---|---|---|---|
| before | 67 | 1 | **26** (33× `transaction_status`, 13× `status` `NoMethodError`) |
| after  | 67 | 4 | **3** |

The remaining 3 errors / 4 failures are deeper reconnect-recovery and transaction-state-tracking gaps, tracked separately. This PR does **not** target the `too many clients` connection-leak cascade — that is a distinct issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
