### PR TITLE
PostgreSQL: force wire-level BEGIN when starting a transaction

### DIFF
--- a/src/java/arjdbc/postgresql/PostgreSQLRubyJdbcConnection.java
+++ b/src/java/arjdbc/postgresql/PostgreSQLRubyJdbcConnection.java
@@ -173,6 +173,21 @@ public class PostgreSQLRubyJdbcConnection extends arjdbc.jdbc.RubyJdbcConnection
         // NOTE: only reversed order - just to ~ match how Rails does it :
         /* if ( connection.getAutoCommit() ) */ connection.setAutoCommit(false);
         if ( isolation != null ) setTransactionIsolation(context, connection, isolation);
+        // pgjdbc's setAutoCommit(false) only flips a client-side flag; the
+        // wire-level BEGIN is deferred until the next statement is sent
+        // (QueryExecutorImpl#sendQueryPreamble). Rails 7.1+ lazy transactions
+        // assume begin_db_transaction opens a server-side transaction once
+        // materialized, so flush the deferred BEGIN now with a no-op statement
+        // - pgjdbc prepends BEGIN to it in the same round-trip, matching the
+        // cost of pg's exec("BEGIN").
+        Statement statement = null;
+        try {
+            statement = connection.createStatement();
+            statement.execute("SELECT 1");
+        }
+        finally {
+            close(statement);
+        }
         return context.nil;
     }
 

--- a/test/db/postgresql/transaction_test.rb
+++ b/test/db/postgresql/transaction_test.rb
@@ -8,6 +8,20 @@ class PostgresTransactionTest < Test::Unit::TestCase
     assert_true ActiveRecord::Base.connection.supports_savepoints?
   end
 
+  # pgjdbc defers the wire-level BEGIN until the next statement is sent, but
+  # AR 7.1+ lazy transactions expect begin_db_transaction to actually open a
+  # server-side transaction (e.g. materialize_transactions), so it must flush
+  # the deferred BEGIN right away.
+  def test_begin_db_transaction_opens_transaction_on_the_server
+    connection = ActiveRecord::Base.connection
+    assert_equal 'IDLE', connection.jdbc_connection(true).transaction_state.to_s
+
+    connection.begin_db_transaction
+    assert_equal 'OPEN', connection.jdbc_connection(true).transaction_state.to_s
+  ensure
+    connection.rollback_db_transaction
+  end
+
   # @override
   def test_releasing_named_savepoints
     omit 'savepoins not supported' unless @supports_savepoints


### PR DESCRIPTION
### Problem

On PostgreSQL, `begin_db_transaction` ends up calling `Connection#setAutoCommit(false)` — but in pgjdbc that only flips a client-side flag. The actual `BEGIN` is deferred and piggybacked onto the *next* statement sent (see pgjdbc's `QueryExecutorImpl#sendQueryPreamble`).

Rails 7.1+ transactions are lazy on their side too: `materialize_transactions` calls `begin_db_transaction` and expects a transaction to *actually* be open on the server afterwards. Under AR-JDBC that materialization was a wire-level no-op — the server session stays `IDLE` until the next query, so anything that inspects the raw transaction state right after materialization (e.g. Rails' own `adapter_test.rb` via `raw_transaction_open?`) sees no transaction.

### Fix

After `setAutoCommit(false)` (and setting isolation, when given), issue a no-op `SELECT 1`. pgjdbc prepends its deferred `BEGIN` to it in the same round-trip, so the cost matches the pg gem's `exec("BEGIN")` — one round-trip, just moved from the first in-transaction query to `begin_db_transaction` where AR expects it.

Includes a test that asserts the server-side transaction state is `OPEN` right after `begin_db_transaction` (it reports `IDLE` without the fix).

### Verification

Environment: JRuby 9.4.14.0, PostgreSQL 18.4, pgjdbc 42.7.11, macOS.

* `rake test_postgresql`: 306 tests, 0 failures, 0 errors (includes the new test; fails without the patch)
* Rails suite (`rails:test_postgresql`, AR `7-2-stable`), on top of `72-stable` + #1220:
  * `test/cases/adapter_test.rb`: 69 runs, **0 failures, 0 errors** — the 4 remaining failures there (`assert raw_transaction_open?` right after `materialize_transactions`, lines 533/543/553/577) are exactly what this patch fixes
  * same with `PREPARED_STATEMENTS=false`: 67 runs, 0 failures, 0 errors
  * `test/cases/transactions_test.rb`: 105 runs, 0 failures, 0 errors

Related: #1173, #1218, #1220.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
