### PR TITLE
Changed File.exists? to File.exist? in Rakefile

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -284,7 +284,7 @@ if defined? JRUBY_VERSION
           if match = requirement.match(/^jar\s+([\w\-\.]+):([\w\-]+),\s+?([\w\.\-]+)?/)
             matched_jar = Jars.send :to_jar, match[1], match[2], match[3], nil
             matched_jar = File.join( Jars.home, matched_jar )
-            matched_jars << matched_jar if File.exists?( matched_jar )
+            matched_jars << matched_jar if File.exist?( matched_jar )
           end
         end
         matched_jars


### PR DESCRIPTION
The File.exists? method no longer exists in Ruby 4 and JRuby 10. Changed the only leftover of File.exists? to File.exist? in order to ensure compatibility.